### PR TITLE
[wip] feat: extend `d/host_pci_device` support

### DIFF
--- a/docs/data-sources/host_pci_device.md
+++ b/docs/data-sources/host_pci_device.md
@@ -3,14 +3,20 @@ subcategory: "Host and Cluster Management"
 page_title: "VMware vSphere: vsphere_host_pci_device"
 sidebar_current: "docs-vsphere-data-source-host_pci_device"
 description: |-
-  A data source that can be used to get information for a PCI passthrough
-  device on an ESXi host.
+  A data source that can be used to get information for PCI passthrough
+  device(s) on an ESXi host. The returned attribute `pci_devices` will
+  be a list of matching PCI Passthrough devices, based on the criteria:
+    - name_regex
+    - class_id
+    - vendor_id
+
+  **NOTE** - The matching criteria above are evaluated in that order.
 ---
 
 # vsphere_host_pci_device
 
-The `vsphere_host_pci_device` data source can be used to discover the device ID
-of a vSphere host's PCI device. This can then be used with
+The `vsphere_host_pci_device` data source can be used to discover the device ID(s)
+of a vSphere host's PCI device(s). This can then be used with
 `vsphere_virtual_machine`'s `pci_device_id`.
 
 ## Example Usage with Vendor ID and Class ID
@@ -58,14 +64,34 @@ The following arguments are supported:
   a host.
 * `name_regex` - (Optional) A regular expression that will be used to match the
   host PCI device name.
+* `class_id` - (Optional) The hexadecimal PCI device class ID.
 * `vendor_id` - (Optional) The hexadecimal PCI device vendor ID.
-* `class_id` - (Optional) The hexadecimal PCI device class ID
 
 [docs-about-morefs]: /docs/providers/vsphere/index.html#use-of-managed-object-references-by-the-vsphere-provider
 
-~> **NOTE:** `name_regex`, `vendor_id`, and `class_id` can all be used together.
+~> **NOTE:** `name_regex`, `class_id`, and `vendor_id` can all be used together.
+The above arguments are evaluated and filter PCI Device results in the above order.
 
 ## Attribute Reference
 
-* `id` - The device ID of the PCI device.
-* `name` - The name of the PCI device.
+The following attributes are exported:
+
+* `host_id` - The [managed objectID][docs-about-morefs] of the ESXi host.
+* `id` - Unique (SHA256) id based on the host_id if the ESXi host.
+* `name_regex` - (Optional) A regular expression that will be used to match the
+  host vGPU profile name.
+* `class_id` - (Optional) The hexadecimal PCI device class ID.
+* `vendor_id` - (Optional) The hexadecimal PCI device vendor ID.
+* `pci_devices` - The list of matching PCI Devices available on the host.
+  * `id` - The name ID of this PCI, composed of "bus:slot.function"
+  * `name` - The name of the PCI device.
+  * `bus` - The bus ID of the PCI device.
+  * `class_id` - The hexadecimal value of the PCI device's class ID.
+  * `device_id` - The hexadecimal value of the PCI device's device ID.
+  * `function` - The function ID of the PCI device.
+  * `parent_bridge` - The parent bridge of the PCI device.
+  * `slot` - The slot ID of the PCI device.
+  * `sub_device_id` - The hexadecimal value of the PCI device's sub device ID.
+  * `sub_vendor_id` - The hexadecimal value of the PCI device's sub vendor ID.
+  * `vendor_id` - The hexadecimal value of the PCI device's vendor ID.
+  * `vendor_name` - The vendor name of the PCI device.

--- a/vsphere/data_source_vsphere_host_pci_device.go
+++ b/vsphere/data_source_vsphere_host_pci_device.go
@@ -5,6 +5,8 @@
 package vsphere
 
 import (
+	"crypto/sha256"
+	"fmt"
 	"log"
 	"regexp"
 	"strconv"
@@ -39,10 +41,74 @@ func dataSourceVSphereHostPciDevice() *schema.Resource {
 				Optional:    true,
 				Description: "The hexadecimal value of the PCI device's vendor ID.",
 			},
-			"name": {
-				Type:        schema.TypeString,
+			"pci_devices": {
+				Type:        schema.TypeList,
 				Computed:    true,
-				Description: "The name of the PCI device.",
+				Description: "The list of matching PCI Devices available on the host.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The name ID of this PCI, composed of 'bus:slot.function'",
+						},
+						"name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The name of the PCI device.",
+						},
+						"bus": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The bus ID of the PCI device.",
+						},
+						"slot": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The slot ID of the PCI device.",
+						},
+						"function": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The function ID of the PCI device.",
+						},
+						"class_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The hexadecimal value of the PCI device's class ID.",
+						},
+						"vendor_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The hexadecimal value of the PCI device's vendor ID.",
+						},
+						"sub_vendor_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The hexadecimal value of the PCI device's sub vendor ID.",
+						},
+						"vendor_name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The vendor name of the PCI device.",
+						},
+						"device_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The hexadecimal value of the PCI device's device ID.",
+						},
+						"sub_device_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The hexadecimal value of the PCI device's sub device ID.",
+						},
+						"parent_bridge": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The parent bridge of the PCI device.",
+						},
+					},
+				},
 			},
 		},
 	}
@@ -50,20 +116,39 @@ func dataSourceVSphereHostPciDevice() *schema.Resource {
 
 func dataSourceVSphereHostPciDeviceRead(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] DataHostPCIDev: Beginning PCI device lookup on %s", d.Get("host_id").(string))
+
 	client := meta.(*Client).vimClient
+
 	host, err := hostsystem.FromID(client, d.Get("host_id").(string))
 	if err != nil {
 		return err
 	}
+
 	hprops, err := hostsystem.Properties(host)
 	if err != nil {
 		return err
 	}
+
+	// Create unique ID based on the host_id
+	idsum := sha256.New()
+	if _, err := fmt.Fprintf(idsum, "%#v", d.Get("host_id").(string)); err != nil {
+		return err
+	}
+
+	d.SetId(fmt.Sprintf("%x", idsum.Sum(nil)))
+
+	// Identify PCI devices matching name_regex (if any)
 	devices, err := matchName(d, hprops.Hardware.PciDevice)
 	if err != nil {
 		return err
 	}
+
+	// Output slice
+	pciDevices := make([]interface{}, 0, len(devices))
+
 	log.Printf("[DEBUG] DataHostPCIDev: Looking for a device with matching class_id and vendor_id")
+
+	// Loop through devices
 	for _, device := range devices {
 		// Match the class_id if it is set.
 		if class, exists := d.GetOk("class_id"); exists {
@@ -75,6 +160,7 @@ func dataSourceVSphereHostPciDeviceRead(d *schema.ResourceData, meta interface{}
 				continue
 			}
 		}
+
 		// Now match the vendor_id if it is set.
 		if vendor, exists := d.GetOk("vendor_id"); exists {
 			vendorInt, err := strconv.ParseInt(vendor.(string), 16, 16)
@@ -85,15 +171,43 @@ func dataSourceVSphereHostPciDeviceRead(d *schema.ResourceData, meta interface{}
 				continue
 			}
 		}
+
+		// Convertions
 		classHex := strconv.FormatInt(int64(device.ClassId), 16)
 		vendorHex := strconv.FormatInt(int64(device.VendorId), 16)
-		d.SetId(device.Id)
-		_ = d.Set("name", device.DeviceName)
-		_ = d.Set("class_id", classHex)
-		_ = d.Set("vendor_id", vendorHex)
+		subVendorHex := strconv.FormatInt(int64(device.SubVendorId), 16)
+		deviceHex := strconv.FormatInt(int64(device.DeviceId), 16)
+		subDeviceHex := strconv.FormatInt(int64(device.SubDeviceId), 16)
+		busString := fmt.Sprintf("%v", device.Bus)
+		slotString := fmt.Sprintf("%v", device.Slot)
+		functionString := fmt.Sprintf("%v", device.Function)
+
+		dev := map[string]interface{}{
+			"id":            device.Id,
+			"name":          device.DeviceName,
+			"class_id":      classHex,
+			"vendor_id":     vendorHex,
+			"sub_vendor_id": subVendorHex,
+			"device_id":     deviceHex,
+			"sub_device_id": subDeviceHex,
+			"bus":           busString,
+			"slot":          slotString,
+			"function":      functionString,
+			"parent_bridge": device.ParentBridge,
+			"vendor_name":   device.VendorName,
+		}
+
+		// Add PCI device to output slice
+		pciDevices = append(pciDevices, dev)
+
 		log.Printf("[DEBUG] DataHostPCIDev: Matching PCI device found: %s", device.DeviceName)
-		return nil
 	}
+
+	// Set the `pci_devices` output to all PCI devices
+	if err := d.Set("pci_devices", pciDevices); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/vsphere/data_source_vsphere_host_pci_device_test.go
+++ b/vsphere/data_source_vsphere_host_pci_device_test.go
@@ -1,0 +1,68 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package vsphere
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/vmware/terraform-provider-vsphere/vsphere/internal/helper/testhelper"
+)
+
+func TestAccDataSourceVSphereHostPciDevice_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccDataSourceVSphereHostPciDevicePreCheck(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceVSphereHostPciDeviceConfig(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(
+						"data.vsphere_host_pci_device.device",
+						"pci_devices.#",
+					),
+				),
+			},
+			{
+				Config: testAccDataSourceVSphereHostPciDeviceConfig(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(
+						"data.vsphere_host_pci_device.device",
+						"pci_devices.0.name",
+					),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceVSphereHostPciDevicePreCheck(t *testing.T) {
+	if os.Getenv("TF_VAR_VSPHERE_DATACENTER") == "" {
+		t.Skip("set TF_VAR_VSPHERE_DATACENTER to run vsphere_host_pci_device acceptance tests")
+	}
+	if os.Getenv("TF_VAR_VSPHERE_ESXI1") == "" {
+		t.Skip("set TF_VAR_VSPHERE_ESXI1 to run vsphere_host_pci_device acceptance tests")
+	}
+}
+
+func testAccDataSourceVSphereHostPciDeviceConfig() string {
+	return fmt.Sprintf(`
+%s
+
+data "vsphere_host" "host" {
+  name          = "%s"
+  datacenter_id = "${data.vsphere_datacenter.rootdc1.id}"
+}
+
+data "vsphere_host_pci_device" "device" {
+  host_id    = "${data.vsphere_host.host.id}"
+  name_regex = ""
+}
+`, testhelper.CombineConfigs(testhelper.ConfigDataRootDC1(), testhelper.ConfigDataRootPortGroup1()), os.Getenv("TF_VAR_VSPHERE_ESXI1"))
+}


### PR DESCRIPTION
### Description

<!--- Please leave a helpful description of the pull request here. --->

Add support for the `vsphere_host_pci_device` data source to return all PCI devices which share the same details

### Provider tests

#### ESXi Host with ConnectX PCI Device(s)

```
Changes to Outputs:
  + host_devices       = {
      + class_id    = null
      + host_id     = "host-1021"
      + id          = "fdcccc4252c0516e9d54a1ee6e851ba9f336c64502d6e80c5a684072f6e02bdc"
      + name_regex  = "ConnectX"
      + pci_devices = [
          + {
              + bus           = "136"
              + class_id      = "200"
              + device_id     = "1015"
              + function      = "0"
              + id            = "0000:88:00.0"
              + name          = "MT27710 Family [ConnectX-4 Lx]"
              + parent_bridge = ""
              + slot          = "0"
              + sub_device_id = "16"
              + sub_vendor_id = "15b3"
              + vendor_id     = "15b3"
              + vendor_name   = "Mellanox Technologies"
            },
          + {
              + bus           = "136"
              + class_id      = "200"
              + device_id     = "1015"
              + function      = "1"
              + id            = "0000:88:00.1"
              + name          = "MT27710 Family [ConnectX-4 Lx]"
              + parent_bridge = ""
              + slot          = "0"
              + sub_device_id = "16"
              + sub_vendor_id = "15b3"
              + vendor_id     = "15b3"
              + vendor_name   = "Mellanox Technologies"
            },
          + {
              + bus           = "219"
              + class_id      = "200"
              + device_id     = "1015"
              + function      = "0"
              + id            = "0000:db:00.0"
              + name          = "MT27710 Family [ConnectX-4 Lx]"
              + parent_bridge = ""
              + slot          = "0"
              + sub_device_id = "16"
              + sub_vendor_id = "15b3"
              + vendor_id     = "15b3"
              + vendor_name   = "Mellanox Technologies"
            },
          + {
              + bus           = "219"
              + class_id      = "200"
              + device_id     = "1015"
              + function      = "1"
              + id            = "0000:db:00.1"
              + name          = "MT27710 Family [ConnectX-4 Lx]"
              + parent_bridge = ""
              + slot          = "0"
              + sub_device_id = "16"
              + sub_vendor_id = "15b3"
              + vendor_id     = "15b3"
              + vendor_name   = "Mellanox Technologies"
            },
        ]
      + vendor_id   = null
    }
```

#### ESXi host without ConnectX PCI Device(s)

```
Changes to Outputs:
  + host_devices       = {
      + class_id    = null
      + host_id     = "host-11"
      + id          = "4982008974bbce3052719253d1d87e7d07e927d8c88ee0ada5e5fcfcc140c729"
      + name_regex  = "ConnectX"
      + pci_devices = []
      + vendor_id   = null
    }
```

### Acceptance tests
- [x] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS="-run=TestAccDataSourceVSphereHostPciDevice_basic -count=1"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run=TestAccDataSourceVSphereHostPciDevice_basic -count=1 -timeout 360m
?       github.com/hashicorp/terraform-provider-vsphere [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/administrationroles    [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/clustercomputeresource  [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/computeresource [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/contentlibrary  [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/customattribute [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/datacenter      [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/datastore       [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/dvportgroup     [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/envbrowse       [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/folder  [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/hostsystem      [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/structure       [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/testhelper      [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/ovfdeploy       [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/provider        [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/resourcepool    [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/spbm    [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/storagepod      [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/network [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/nsx     [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/utils   [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/vappcontainer   [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/virtualmachine  [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/vsanclient      [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/vsansystem      [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/vmworkflow     [no test files]
=== RUN   TestAccDataSourceVSphereHostPciDevice_basic
--- PASS: TestAccDataSourceVSphereHostPciDevice_basic (8.45s)
PASS
ok      github.com/hashicorp/terraform-provider-vsphere/vsphere 8.475s
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/viapi   0.010s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/virtualdisk     0.079s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/virtualdevice  0.058s [no tests to run]

...
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vsphere/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
...
```
### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->

Closes #1572 