### PR TITLE
[wip] fix: scsi unit number flips

### DIFF
--- a/vsphere/internal/virtualdevice/virtual_machine_disk_subresource.go
+++ b/vsphere/internal/virtualdevice/virtual_machine_disk_subresource.go
@@ -2158,9 +2158,6 @@ func (r *Subresource) findControllerInfo(l object.VirtualDeviceList, disk *types
 	switch sc := ctlr.(type) {
 	case types.BaseVirtualSCSIController:
 		unit := *disk.UnitNumber
-		if unit > sc.GetVirtualSCSIController().ScsiCtlrUnitNumber {
-			unit--
-		}
 		unit += 15 * sc.GetVirtualSCSIController().BusNumber
 		return int(unit), ctlr.(types.BaseVirtualController), nil
 	case types.BaseVirtualSATAController:

--- a/vsphere/internal/virtualdevice/virtual_machine_disk_subresource_test.go
+++ b/vsphere/internal/virtualdevice/virtual_machine_disk_subresource_test.go
@@ -7,6 +7,7 @@ package virtualdevice
 import (
 	"testing"
 
+	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/vim25/types"
 )
 
@@ -55,4 +56,289 @@ func TestDiskCapacityInGiB(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestFindControllerInfo(t *testing.T) {
+	cases := []struct {
+		name           string
+		deviceList     object.VirtualDeviceList
+		disk           *types.VirtualDisk
+		expectedUnit   int
+		expectedCtlrID int32
+		expectError    bool
+	}{
+		{
+			name: "SCSI controller - standard unit",
+			deviceList: object.VirtualDeviceList{
+				&types.VirtualLsiLogicController{
+					VirtualSCSIController: types.VirtualSCSIController{
+						VirtualController: types.VirtualController{
+							VirtualDevice: types.VirtualDevice{
+								Key: 1000,
+							},
+							BusNumber: 0,
+						},
+					},
+				},
+			},
+			disk: &types.VirtualDisk{
+				VirtualDevice: types.VirtualDevice{
+					ControllerKey: 1000,
+					UnitNumber:    intPtr(5),
+				},
+			},
+			expectedUnit:   5,
+			expectedCtlrID: 1000,
+			expectError:    false,
+		},
+		{
+			name: "SCSI controller - second bus",
+			deviceList: object.VirtualDeviceList{
+				&types.VirtualLsiLogicController{
+					VirtualSCSIController: types.VirtualSCSIController{
+						VirtualController: types.VirtualController{
+							VirtualDevice: types.VirtualDevice{
+								Key: 1001,
+							},
+							BusNumber: 1,
+						},
+					},
+				},
+			},
+			disk: &types.VirtualDisk{
+				VirtualDevice: types.VirtualDevice{
+					ControllerKey: 1001,
+					UnitNumber:    intPtr(3),
+				},
+			},
+			expectedUnit:   18, // 15 * 1 + 3
+			expectedCtlrID: 1001,
+			expectError:    false,
+		},
+		{
+			name: "SATA controller - standard unit",
+			deviceList: object.VirtualDeviceList{
+				&types.VirtualAHCIController{
+					VirtualSATAController: types.VirtualSATAController{
+						VirtualController: types.VirtualController{
+							VirtualDevice: types.VirtualDevice{
+								Key: 15000,
+							},
+							BusNumber: 0,
+						},
+					},
+				},
+			},
+			disk: &types.VirtualDisk{
+				VirtualDevice: types.VirtualDevice{
+					ControllerKey: 15000,
+					UnitNumber:    intPtr(10),
+				},
+			},
+			expectedUnit:   10,
+			expectedCtlrID: 15000,
+			expectError:    false,
+		},
+		{
+			name: "SATA controller - second bus",
+			deviceList: object.VirtualDeviceList{
+				&types.VirtualAHCIController{
+					VirtualSATAController: types.VirtualSATAController{
+						VirtualController: types.VirtualController{
+							VirtualDevice: types.VirtualDevice{
+								Key: 15001,
+							},
+							BusNumber: 1,
+						},
+					},
+				},
+			},
+			disk: &types.VirtualDisk{
+				VirtualDevice: types.VirtualDevice{
+					ControllerKey: 15001,
+					UnitNumber:    intPtr(5),
+				},
+			},
+			expectedUnit:   35, // 30 * 1 + 5
+			expectedCtlrID: 15001,
+			expectError:    false,
+		},
+		{
+			name: "IDE controller - standard unit",
+			deviceList: object.VirtualDeviceList{
+				&types.VirtualIDEController{
+					VirtualController: types.VirtualController{
+						VirtualDevice: types.VirtualDevice{
+							Key: 200,
+						},
+						BusNumber: 0,
+					},
+				},
+			},
+			disk: &types.VirtualDisk{
+				VirtualDevice: types.VirtualDevice{
+					ControllerKey: 200,
+					UnitNumber:    intPtr(1),
+				},
+			},
+			expectedUnit:   1,
+			expectedCtlrID: 200,
+			expectError:    false,
+		},
+		{
+			name: "IDE controller - second bus",
+			deviceList: object.VirtualDeviceList{
+				&types.VirtualIDEController{
+					VirtualController: types.VirtualController{
+						VirtualDevice: types.VirtualDevice{
+							Key: 201,
+						},
+						BusNumber: 1,
+					},
+				},
+			},
+			disk: &types.VirtualDisk{
+				VirtualDevice: types.VirtualDevice{
+					ControllerKey: 201,
+					UnitNumber:    intPtr(0),
+				},
+			},
+			expectedUnit:   2, // 2 * 1 + 0
+			expectedCtlrID: 201,
+			expectError:    false,
+		},
+		{
+			name: "NVMe controller - standard unit",
+			deviceList: object.VirtualDeviceList{
+				&types.VirtualNVMEController{
+					VirtualController: types.VirtualController{
+						VirtualDevice: types.VirtualDevice{
+							Key: 31000,
+						},
+						BusNumber: 0,
+					},
+				},
+			},
+			disk: &types.VirtualDisk{
+				VirtualDevice: types.VirtualDevice{
+					ControllerKey: 31000,
+					UnitNumber:    intPtr(34),
+				},
+			},
+			expectedUnit:   34,
+			expectedCtlrID: 31000,
+			expectError:    false,
+		},
+		{
+			name: "NVMe controller - second bus",
+			deviceList: object.VirtualDeviceList{
+				&types.VirtualNVMEController{
+					VirtualController: types.VirtualController{
+						VirtualDevice: types.VirtualDevice{
+							Key: 31001,
+						},
+						BusNumber: 1,
+					},
+				},
+			},
+			disk: &types.VirtualDisk{
+				VirtualDevice: types.VirtualDevice{
+					ControllerKey: 31001,
+					UnitNumber:    intPtr(5),
+				},
+			},
+			expectedUnit:   69, // 64 * 1 + 5
+			expectedCtlrID: 31001,
+			expectError:    false,
+		},
+		{
+			name:       "controller not found",
+			deviceList: object.VirtualDeviceList{},
+			disk: &types.VirtualDisk{
+				VirtualDevice: types.VirtualDevice{
+					ControllerKey: 1000,
+					UnitNumber:    intPtr(5),
+				},
+			},
+			expectedUnit:   0,
+			expectedCtlrID: 0,
+			expectError:    true,
+		},
+		{
+			name: "unit number not set",
+			deviceList: object.VirtualDeviceList{
+				&types.VirtualLsiLogicController{
+					VirtualSCSIController: types.VirtualSCSIController{
+						VirtualController: types.VirtualController{
+							VirtualDevice: types.VirtualDevice{
+								Key: 1000,
+							},
+							BusNumber: 0,
+						},
+					},
+				},
+			},
+			disk: &types.VirtualDisk{
+				VirtualDevice: types.VirtualDevice{
+					ControllerKey: 1000,
+				},
+			},
+			expectedUnit:   0,
+			expectedCtlrID: 0,
+			expectError:    true,
+		},
+		{
+			name: "unsupported controller type",
+			deviceList: object.VirtualDeviceList{
+				&types.VirtualPCIController{
+					VirtualController: types.VirtualController{
+						VirtualDevice: types.VirtualDevice{
+							Key: 100,
+						},
+						BusNumber: 0,
+					},
+				},
+			},
+			disk: &types.VirtualDisk{
+				VirtualDevice: types.VirtualDevice{
+					ControllerKey: 100,
+					UnitNumber:    intPtr(0),
+				},
+			},
+			expectedUnit:   0,
+			expectedCtlrID: 0,
+			expectError:    true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			sr := &Subresource{}
+			unit, ctlr, err := sr.findControllerInfo(tc.deviceList, tc.disk)
+
+			if tc.expectError {
+				if err == nil {
+					t.Fatal("expected error but got none")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+
+			if unit != tc.expectedUnit {
+				t.Errorf("expected unit number %d, got %d", tc.expectedUnit, unit)
+			}
+
+			if ctlr.GetVirtualController().Key != tc.expectedCtlrID {
+				t.Errorf("expected controller ID %d, got %d", tc.expectedCtlrID, ctlr.GetVirtualController().Key)
+			}
+		})
+	}
+}
+
+// Helper function to create int pointers
+func intPtr(i int32) *int32 {
+	return &i
 }


### PR DESCRIPTION
### Description
These changes fix a bug where unit numbers on disk subresources where changed by the provider causing changes to be planned.

This bug affected all vms with disks where SCSI ID's ranged from 8 to 15. While unit numbers where correct in Vsphere tthe provider decremented them by one while reading the disk thus creating changes that where not requested. 
<!--- Please leave a helpful description of the pull request here. --->

### Acceptance tests

- [ ] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:
```
make test 
?       github.com/hashicorp/terraform-provider-vsphere [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/administrationroles    [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/clustercomputeresource  [no test files]
ok      github.com/hashicorp/terraform-provider-vsphere/vsphere (cached)
go test -timeout=30s -parallel=4 github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/computeresource github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/contentlibrary github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/customattribute github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/datacenter
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/computeresource [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/contentlibrary  [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/datacenter      [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/customattribute [no test files]
go test -timeout=30s -parallel=4 github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/datastore github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/dvportgroup github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/envbrowse github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/folder
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/datastore       [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/dvportgroup     [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/envbrowse       [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/folder  [no test files]
go test -timeout=30s -parallel=4 github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/guestoscustomizations github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/hostsystem github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/network github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/nsx
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/guestoscustomizations   [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/hostsystem      [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/network [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/nsx     [no test files]
go test -timeout=30s -parallel=4 github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/ovfdeploy github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/provider github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/resourcepool github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/spbm
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/ovfdeploy       [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/provider        [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/resourcepool    [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/spbm    [no test files]
go test -timeout=30s -parallel=4 github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/storagepod github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/structure github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/testhelper github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/utils
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/storagepod      [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/structure       [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/testhelper      [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/utils   [no test files]
go test -timeout=30s -parallel=4 github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/vappcontainer github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/viapi github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/virtualdisk github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/virtualmachine
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/vappcontainer   [no test files]
ok      github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/viapi   (cached)
ok      github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/virtualdisk     (cached)
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/virtualmachine  [no test files]
go test -timeout=30s -parallel=4 github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/vsanclient github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/vsansystem github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/virtualdevice github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/vmworkflow
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/vsanclient      [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/vsansystem      [no test files]
?       github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/vmworkflow     [no test files]
ok      github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/virtualdevice  (cached)
```
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

### Release Note

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vsphere/blob/main/CHANGELOG.md):

<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Fixes a bug where disk unit numbers > 7 where shuffled. 
```

### References
Closes https://github.com/hashicorp/terraform-provider-vsphere/issues/1309
Closes https://github.com/hashicorp/terraform-provider-vsphere/issues/2348
<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
