### PR TITLE
[wip] fix: DiskDiffOperation

### DIFF
--- a/vsphere/internal/virtualdevice/virtual_machine_disk_subresource.go
+++ b/vsphere/internal/virtualdevice/virtual_machine_disk_subresource.go
@@ -683,7 +683,7 @@ nextNew:
 				delete(nm, "size")
 			}
 		}
-		if dsID, ok := nm["datastore_id"]; !ok {
+		if ok := nm["datastore_id"]; !ok {
 			nm["datastore_id"] = diskDatastoreComputedName
 		}
 		normalized = append(normalized, nm)

--- a/vsphere/internal/virtualdevice/virtual_machine_disk_subresource.go
+++ b/vsphere/internal/virtualdevice/virtual_machine_disk_subresource.go
@@ -683,7 +683,7 @@ nextNew:
 				delete(nm, "size")
 			}
 		}
-		if ok := nm["datastore_id"]; !ok {
+		if _, ok := nm["datastore_id"]; !ok {
 			nm["datastore_id"] = diskDatastoreComputedName
 		}
 		normalized = append(normalized, nm)

--- a/vsphere/internal/virtualdevice/virtual_machine_disk_subresource.go
+++ b/vsphere/internal/virtualdevice/virtual_machine_disk_subresource.go
@@ -683,7 +683,7 @@ nextNew:
 				delete(nm, "size")
 			}
 		}
-		if dsID, ok := nm["datastore_id"]; !ok || dsID == "" {
+		if dsID, ok := nm["datastore_id"]; !ok {
 			nm["datastore_id"] = diskDatastoreComputedName
 		}
 		normalized = append(normalized, nm)


### PR DESCRIPTION
### Description

Fixes https://github.com/hashicorp/terraform-provider-vsphere/issues/2363: Creating a new VM using datastores created as part of the same apply would give an error as the following:

```
╷
│ Error: Provider produced inconsistent final plan
│ 
│ When expanding the plan for module.solution["solution"].module.product["product"].vsphere_virtual_machine.db_vm["vm_uuid"] to
│ include new values learned so far during apply, provider "registry.terraform.io/hashicorp/vsphere"
│ produced an invalid new value for .disk[4].datastore_id: was cty.StringVal("<computed>"), but now
│ cty.StringVal("datastore-176385").
│ 
│ This is a bug in the provider, which should be reported in the provider's own issue tracker.
╵

```
Apologies for not creating an acceptance test but I am a n00b to Go and this provider. I am also pretty sure that my "fix" might not be the ultimate solution

- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```

### Release Note

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vsphere/blob/main/CHANGELOG.md):

<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
...
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
