### PR TITLE
fix: revive var-naming

### DIFF
--- a/vsphere/data_source_vsphere_dynamic.go
+++ b/vsphere/data_source_vsphere_dynamic.go
@@ -46,8 +46,8 @@ func dataSourceVSphereDynamicRead(d *schema.ResourceData, meta interface{}) erro
 	if err != nil {
 		return err
 	}
-	tagIds := d.Get("filter").(*schema.Set).List()
-	matches, err := filterObjectsByTag(tm, tagIds)
+	tagIDs := d.Get("filter").(*schema.Set).List()
+	matches, err := filterObjectsByTag(tm, tagIDs)
 	if err != nil {
 		return err
 	}
@@ -95,11 +95,11 @@ func filterObjectsByName(d *schema.ResourceData, meta interface{}, matches []tag
 
 func filterObjectsByTag(tm *tags.Manager, t []interface{}) ([]tags.AttachedObjects, error) {
 	log.Printf("[DEBUG] dataSourceDynamic: Filtering objects by tags.")
-	var tagIds []string
+	var tagIDs []string
 	for _, ti := range t {
-		tagIds = append(tagIds, ti.(string))
+		tagIDs = append(tagIDs, ti.(string))
 	}
-	matches, err := tm.GetAttachedObjectsOnTags(context.TODO(), tagIds)
+	matches, err := tm.GetAttachedObjectsOnTags(context.TODO(), tagIDs)
 	if err != nil {
 		return nil, err
 	}

--- a/vsphere/data_source_vsphere_dynamic_test.go
+++ b/vsphere/data_source_vsphere_dynamic_test.go
@@ -25,7 +25,7 @@ func TestAccDataSourceVSphereDynamic_regexAndTag(t *testing.T) {
 			{
 				Config: testAccDataSourceVSphereConfigRegexAndTag(),
 				Check: resource.ComposeTestCheckFunc(
-					testMatchDatacenterIds("vsphere_datacenter.dc2", "data.vsphere_dynamic.dyn1"),
+					testMatchDatacenterIDs("vsphere_datacenter.dc2", "data.vsphere_dynamic.dyn1"),
 				),
 			},
 			{
@@ -46,7 +46,7 @@ func TestAccDataSourceVSphereDynamic_multiTag(t *testing.T) {
 			{
 				Config: testAccDataSourceVSphereConfigMultiTag(),
 				Check: resource.ComposeTestCheckFunc(
-					testMatchDatacenterIds("vsphere_datacenter.dc1", "data.vsphere_dynamic.dyn2"),
+					testMatchDatacenterIDs("vsphere_datacenter.dc1", "data.vsphere_dynamic.dyn2"),
 				),
 			},
 			{
@@ -83,7 +83,7 @@ func TestAccDataSourceVSphereDynamic_typeFilter(t *testing.T) {
 			{
 				Config: testAccDataSourceVSphereConfigType(),
 				Check: resource.ComposeTestCheckFunc(
-					testMatchDatacenterIds("vsphere_datacenter.dc1", "data.vsphere_dynamic.dyn4"),
+					testMatchDatacenterIDs("vsphere_datacenter.dc1", "data.vsphere_dynamic.dyn4"),
 				),
 			},
 			{
@@ -93,7 +93,7 @@ func TestAccDataSourceVSphereDynamic_typeFilter(t *testing.T) {
 	})
 }
 
-func testMatchDatacenterIds(a, b string) resource.TestCheckFunc {
+func testMatchDatacenterIDs(a, b string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		ida := s.RootModule().Resources[a].Primary.Attributes["moid"]
 		idb := s.RootModule().Resources[b].Primary.ID

--- a/vsphere/data_source_vsphere_role_test.go
+++ b/vsphere/data_source_vsphere_role_test.go
@@ -13,7 +13,7 @@ import (
 
 const NoAccessRoleDescription = "No access"
 const NoAccessRoleName = "NoAccess"
-const NoAccessRoleId = "-5"
+const NoAccessRoleID = "-5"
 
 func TestAccDataSourceVSphereRole_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
@@ -66,7 +66,7 @@ func TestAccDataSourceVSphereRole_systemRoleData(t *testing.T) {
 				Config: testAccDataSourceVSphereRoleSystemRoleConfig(),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("data.vsphere_role.role1", "name", NoAccessRoleName),
-					resource.TestCheckResourceAttr("data.vsphere_role.role1", "id", NoAccessRoleId),
+					resource.TestCheckResourceAttr("data.vsphere_role.role1", "id", NoAccessRoleID),
 					resource.TestCheckResourceAttr("data.vsphere_role.role1", "role_privileges.#", "0")),
 			},
 		},

--- a/vsphere/internal/helper/guestoscustomizations/customizations_helper.go
+++ b/vsphere/internal/helper/guestoscustomizations/customizations_helper.go
@@ -380,7 +380,7 @@ func FlattenGuestOsCustomizationSpec(d *schema.ResourceData, specItem *types.Cus
 	return nil
 }
 
-func IsSpecOsApplicableToVmOs(vmOsFamily types.VirtualMachineGuestOsFamily, specType string) bool {
+func IsSpecOsApplicableToVMOs(vmOsFamily types.VirtualMachineGuestOsFamily, specType string) bool {
 	if specType == GuestOsCustomizationTypeWindows && vmOsFamily == types.VirtualMachineGuestOsFamilyWindowsGuest {
 		return true
 	}

--- a/vsphere/internal/helper/ovfdeploy/ovf_helper.go
+++ b/vsphere/internal/helper/ovfdeploy/ovf_helper.go
@@ -126,8 +126,8 @@ func DeployOvfAndGetResult(client *govmomi.Client, ovfCreateImportSpecResult *ty
 	return nfcLease.Complete(context.Background())
 }
 
-func upload(ctx context.Context, client *govmomi.Client, item types.OvfFileItem, f io.Reader, rawUrl string, size int64, totalBytesRead *int64) error {
-	u, err := client.ParseURL(rawUrl)
+func upload(ctx context.Context, client *govmomi.Client, item types.OvfFileItem, f io.Reader, rawURL string, size int64, totalBytesRead *int64) error {
+	u, err := client.ParseURL(rawURL)
 	if err != nil {
 		return err
 	}

--- a/vsphere/internal/virtualdevice/virtual_machine_device_subresource.go
+++ b/vsphere/internal/virtualdevice/virtual_machine_device_subresource.go
@@ -1078,11 +1078,11 @@ func (c *pciApplyConfig) modifyVirtualPciDevices(devList *schema.Set, op types.V
 // virtual machine.
 func PciPassthroughApplyOperation(d *schema.ResourceData, c *govmomi.Client, l object.VirtualDeviceList) (object.VirtualDeviceList, []types.BaseVirtualDeviceConfigSpec, error) {
 	old, newValue := d.GetChange("pci_device_id")
-	oldDevIds := old.(*schema.Set)
-	newDevIds := newValue.(*schema.Set)
+	oldDevIDs := old.(*schema.Set)
+	newDevIDs := newValue.(*schema.Set)
 
-	delDevs := oldDevIds.Difference(newDevIds)
-	addDevs := newDevIds.Difference(oldDevIds)
+	delDevs := oldDevIDs.Difference(newDevIDs)
+	addDevs := newDevIDs.Difference(oldDevIDs)
 	applyConfig := &pciApplyConfig{
 		Client:        c,
 		ResourceData:  d,
@@ -1118,11 +1118,11 @@ func PciPassthroughApplyOperation(d *schema.ResourceData, c *govmomi.Client, l o
 // operations. It also sets the state in advance of the post-create read.
 func PciPassthroughPostCloneOperation(d *schema.ResourceData, c *govmomi.Client, l object.VirtualDeviceList) (object.VirtualDeviceList, []types.BaseVirtualDeviceConfigSpec, error) {
 	old, newValue := d.GetChange("pci_device_id")
-	oldDevIds := old.(*schema.Set)
-	newDevIds := newValue.(*schema.Set)
+	oldDevIDs := old.(*schema.Set)
+	newDevIDs := newValue.(*schema.Set)
 
-	delDevs := oldDevIds.Difference(newDevIds)
-	addDevs := newDevIds.Difference(oldDevIds)
+	delDevs := oldDevIDs.Difference(newDevIDs)
+	addDevs := newDevIDs.Difference(oldDevIDs)
 	applyConfig := &pciApplyConfig{
 		Client:        c,
 		ResourceData:  d,

--- a/vsphere/internal/virtualdevice/virtual_machine_disk_subresource.go
+++ b/vsphere/internal/virtualdevice/virtual_machine_disk_subresource.go
@@ -977,10 +977,10 @@ func DiskCloneRelocateOperation(resourceData *schema.ResourceData, client *govmo
 Sets the value of the VM datastore
 */
 func addDiskDatastore(r *DiskSubresource, d *schema.ResourceData) *DiskSubresource {
-	diskDsId := r.Get("datastore_id")
-	dataDsId := d.Get("datastore_id")
-	if (diskDsId == "" || diskDsId == diskDatastoreComputedName) && dataDsId != "" {
-		r.Set("datastore_id", dataDsId)
+	diskDsID := r.Get("datastore_id")
+	dataDsID := d.Get("datastore_id")
+	if (diskDsID == "" || diskDsID == diskDatastoreComputedName) && dataDsID != "" {
+		r.Set("datastore_id", dataDsID)
 	}
 
 	return r
@@ -1000,8 +1000,8 @@ func shouldAddRelocateSpec(d *schema.ResourceData, disk *types.VirtualDisk, sche
 
 	// If the VM is cloned to a datastore cluster and no datastore is specified for the disk
 	// it should not be added to the relocate spec
-	diskDataStoreId, _ := dataProps["datastore_id"].(string)
-	diskDsIsEmpty := diskDataStoreId == "" || diskDataStoreId == diskDatastoreComputedName
+	diskDataStoreID, _ := dataProps["datastore_id"].(string)
+	diskDsIsEmpty := diskDataStoreID == "" || diskDataStoreID == diskDatastoreComputedName
 	if d.Get("datastore_id") == "" && d.Get("datastore_cluster_id") != "" && diskDsIsEmpty {
 		return false
 	}
@@ -1059,8 +1059,8 @@ func virtualDiskToSchemaPropsMap(disk *types.VirtualDisk) map[string]interface{}
 func diskDataToSchemaProps(d *schema.ResourceData, deviceIndex int) map[string]interface{} {
 	m := make(map[string]interface{})
 	datastoreKey := fmt.Sprintf("disk.%d.datastore_id", deviceIndex)
-	if datastoreId, ok := d.GetOk(datastoreKey); ok {
-		m["datastore_id"] = datastoreId
+	if datastoreID, ok := d.GetOk(datastoreKey); ok {
+		m["datastore_id"] = datastoreID
 	}
 
 	diskModeKey := fmt.Sprintf("disk.%d.disk_mode", deviceIndex)

--- a/vsphere/internal/virtualdevice/virtual_machine_network_interface_subresource.go
+++ b/vsphere/internal/virtualdevice/virtual_machine_network_interface_subresource.go
@@ -834,25 +834,25 @@ func (r *NetworkInterfaceSubresource) Create(l object.VirtualDeviceList) ([]type
 
 	// Minimum Supported Version: 6.0.0
 	if (version.Newer(viapi.VSphereVersion{Product: version.Product, Major: 6}) && r.Get("adapter_type") != networkInterfaceSubresourceTypeSriov) {
-		bandwidth_limit := structure.Int64Ptr(-1)
-		bandwidth_reservation := structure.Int64Ptr(0)
-		bandwidth_share_level := types.SharesLevelNormal
+		bandwidthLimit := structure.Int64Ptr(-1)
+		bandwidthReservation := structure.Int64Ptr(0)
+		bandwidthShareLevel := types.SharesLevelNormal
 		if r.Get("bandwidth_limit") != nil {
-			bandwidth_limit = structure.Int64Ptr(int64(r.Get("bandwidth_limit").(int)))
+			bandwidthLimit = structure.Int64Ptr(int64(r.Get("bandwidth_limit").(int)))
 		}
 		if r.Get("bandwidth_reservation") != nil {
-			bandwidth_reservation = structure.Int64Ptr(int64(r.Get("bandwidth_reservation").(int)))
+			bandwidthReservation = structure.Int64Ptr(int64(r.Get("bandwidth_reservation").(int)))
 		}
 		if r.Get("bandwidth_share_level") != nil {
-			bandwidth_share_level = types.SharesLevel(r.Get("bandwidth_share_level").(string))
+			bandwidthShareLevel = types.SharesLevel(r.Get("bandwidth_share_level").(string))
 		}
 
 		alloc := &types.VirtualEthernetCardResourceAllocation{
-			Limit:       bandwidth_limit,
-			Reservation: bandwidth_reservation,
+			Limit:       bandwidthLimit,
+			Reservation: bandwidthReservation,
 			Share: types.SharesInfo{
 				Shares: int32(r.Get("bandwidth_share_count").(int)),
-				Level:  bandwidth_share_level,
+				Level:  bandwidthShareLevel,
 			},
 		}
 		card.ResourceAllocation = alloc
@@ -1081,25 +1081,25 @@ func (r *NetworkInterfaceSubresource) Update(l object.VirtualDeviceList) ([]type
 
 	// Minimum Supported Version: 6.0.0
 	if (version.Newer(viapi.VSphereVersion{Product: version.Product, Major: 6}) && r.Get("adapter_type") != networkInterfaceSubresourceTypeSriov) {
-		bandwidth_limit := structure.Int64Ptr(-1)
-		bandwidth_reservation := structure.Int64Ptr(0)
-		bandwidth_share_level := types.SharesLevelNormal
+		bandwidthLimit := structure.Int64Ptr(-1)
+		bandwidthReservation := structure.Int64Ptr(0)
+		bandwidthShareLevel := types.SharesLevelNormal
 		if r.Get("bandwidth_limit") != nil {
-			bandwidth_limit = structure.Int64Ptr(int64(r.Get("bandwidth_limit").(int)))
+			bandwidthLimit = structure.Int64Ptr(int64(r.Get("bandwidth_limit").(int)))
 		}
 		if r.Get("bandwidth_reservation") != nil {
-			bandwidth_reservation = structure.Int64Ptr(int64(r.Get("bandwidth_reservation").(int)))
+			bandwidthReservation = structure.Int64Ptr(int64(r.Get("bandwidth_reservation").(int)))
 		}
 		if r.Get("bandwidth_share_level") != nil {
-			bandwidth_share_level = types.SharesLevel(r.Get("bandwidth_share_level").(string))
+			bandwidthShareLevel = types.SharesLevel(r.Get("bandwidth_share_level").(string))
 		}
 
 		alloc := &types.VirtualEthernetCardResourceAllocation{
-			Limit:       bandwidth_limit,
-			Reservation: bandwidth_reservation,
+			Limit:       bandwidthLimit,
+			Reservation: bandwidthReservation,
 			Share: types.SharesInfo{
 				Shares: int32(r.Get("bandwidth_share_count").(int)),
-				Level:  bandwidth_share_level,
+				Level:  bandwidthShareLevel,
 			},
 		}
 		card.ResourceAllocation = alloc
@@ -1132,19 +1132,19 @@ func (r *NetworkInterfaceSubresource) addPhysicalFunction(device types.BaseVirtu
 
 	// These seem to be the correct DeviceId, SystemId and VendorId settings if you
 	// investigate a manually created vSphere SRIOV network interface
-	physical_function_conf := &types.VirtualPCIPassthroughDeviceBackingInfo{
+	physicalFunctionConf := &types.VirtualPCIPassthroughDeviceBackingInfo{
 		Id:       r.Get("physical_function").(string),
 		DeviceId: "0",
 		SystemId: "BYPASS",
 		VendorId: 0,
 	}
-	sriov_conf := &types.VirtualSriovEthernetCardSriovBackingInfo{
-		PhysicalFunctionBacking: physical_function_conf,
+	sriovConf := &types.VirtualSriovEthernetCardSriovBackingInfo{
+		PhysicalFunctionBacking: physicalFunctionConf,
 	}
 
 	device = &types.VirtualSriovEthernetCard{
 		VirtualEthernetCard: *d2.(types.BaseVirtualEthernetCard).GetVirtualEthernetCard(),
-		SriovBacking:        sriov_conf,
+		SriovBacking:        sriovConf,
 	}
 
 	return device, nil

--- a/vsphere/provider.go
+++ b/vsphere/provider.go
@@ -133,7 +133,7 @@ func Provider() *schema.Provider {
 			"vsphere_tag_category":                             resourceVSphereTagCategory(),
 			"vsphere_virtual_disk":                             resourceVSphereVirtualDisk(),
 			"vsphere_virtual_machine":                          resourceVSphereVirtualMachine(),
-			"vsphere_virtual_machine_class":                    resourceVsphereVmClass(),
+			"vsphere_virtual_machine_class":                    resourceVsphereVMClass(),
 			"vsphere_virtual_machine_snapshot":                 resourceVSphereVirtualMachineSnapshot(),
 			"vsphere_nas_datastore":                            resourceVSphereNasDatastore(),
 			"vsphere_storage_drs_vm_override":                  resourceVSphereStorageDrsVMOverride(),

--- a/vsphere/resource_vsphere_compute_cluster.go
+++ b/vsphere/resource_vsphere_compute_cluster.go
@@ -1165,12 +1165,12 @@ func resourceVSphereComputeClusterApplyHostImage(
 		}
 	}
 
-	draftId, err := m.CreateSoftwareDraft(d.Id())
+	draftID, err := m.CreateSoftwareDraft(d.Id())
 	if err != nil {
 		return err
 	}
 
-	if err := m.SetSoftwareDraftBaseImage(d.Id(), draftId, d.Get("host_image.0.esx_version").(string)); err != nil {
+	if err := m.SetSoftwareDraftBaseImage(d.Id(), draftID, d.Get("host_image.0.esx_version").(string)); err != nil {
 		return err
 	}
 
@@ -1182,19 +1182,19 @@ func resourceVSphereComputeClusterApplyHostImage(
 	spec.ComponentsToSet = getComponentsToAdd(oldComponentsMap, newComponentsMap)
 	componentsToRemove := getComponentsToRemove(oldComponentsMap, newComponentsMap)
 
-	if err = m.UpdateSoftwareDraftComponents(d.Id(), draftId, spec); err != nil {
+	if err = m.UpdateSoftwareDraftComponents(d.Id(), draftID, spec); err != nil {
 		return err
 	}
 
 	if len(componentsToRemove) > 0 {
 		for _, componentId := range componentsToRemove {
-			if err := m.RemoveSoftwareDraftComponents(d.Id(), draftId, componentId); err != nil {
+			if err := m.RemoveSoftwareDraftComponents(d.Id(), draftID, componentId); err != nil {
 				return err
 			}
 		}
 	}
 
-	taskId, err := m.CommitSoftwareDraft(d.Id(), draftId, clusters.SettingsClustersSoftwareDraftsCommitSpec{})
+	taskId, err := m.CommitSoftwareDraft(d.Id(), draftID, clusters.SettingsClustersSoftwareDraftsCommitSpec{})
 	if err != nil {
 		return err
 	}

--- a/vsphere/resource_vsphere_compute_cluster_vm_group.go
+++ b/vsphere/resource_vsphere_compute_cluster_vm_group.go
@@ -170,7 +170,7 @@ func resourceVSphereComputeClusterVMGroupUpdate(d *schema.ResourceData, meta int
 		return err
 	}
 
-	// Convert existing and new virtual machines to string slices for diffVmGroup.
+	// Convert existing and new virtual machines to string slices for diffVMGroup.
 	existingVMs := make([]string, len(existingGroup.Vm))
 	for i, vm := range existingGroup.Vm {
 		existingVMs[i] = vm.Value
@@ -181,8 +181,8 @@ func resourceVSphereComputeClusterVMGroupUpdate(d *schema.ResourceData, meta int
 		newVMs[i] = vm.Value
 	}
 
-	// Use diffVmGroup to find added and removed virtual machines from virtual machine group.
-	addedVMs, removedVMs := diffVmGroup(existingVMs, newVMs)
+	// Use diffVMGroup to find added and removed virtual machines from virtual machine group.
+	addedVMs, removedVMs := diffVMGroup(existingVMs, newVMs)
 
 	// Convert addedVMs and removedVMs back to ManagedObjectReference slices.
 	addedVMRefs := make([]types.ManagedObjectReference, len(addedVMs))
@@ -476,7 +476,7 @@ func resourceVSphereComputeClusterVMGroupClient(meta interface{}) (*govmomi.Clie
 	return client, nil
 }
 
-func diffVmGroup(oldVMs, newVMs []string) ([]string, []string) {
+func diffVMGroup(oldVMs, newVMs []string) ([]string, []string) {
 	oldVMMap := make(map[string]bool)
 	for _, vm := range oldVMs {
 		oldVMMap[vm] = true

--- a/vsphere/resource_vsphere_distributed_virtual_switch_pvlan_mapping_test.go
+++ b/vsphere/resource_vsphere_distributed_virtual_switch_pvlan_mapping_test.go
@@ -81,18 +81,18 @@ func testAccResourceVSphereDistributedVirtualSwitchPvlanMappingExists(expected b
 			return fmt.Errorf("could not find pvlan mapping resource: %s", err)
 		}
 
-		primary_vlan_id, err := strconv.Atoi(mappingToSearchFor.resourceAttributes["primary_vlan_id"])
+		primaryVlanID, err := strconv.Atoi(mappingToSearchFor.resourceAttributes["primaryVlanID"])
 		if err != nil {
 			return err
 		}
-		secondary_vlan_id, err := strconv.Atoi(mappingToSearchFor.resourceAttributes["secondary_vlan_id"])
+		secondaryVlanID, err := strconv.Atoi(mappingToSearchFor.resourceAttributes["secondaryVlanID"])
 		if err != nil {
 			return err
 		}
-		pvlan_type := mappingToSearchFor.resourceAttributes["pvlan_type"]
+		pvlanType := mappingToSearchFor.resourceAttributes["pvlanType"]
 
 		for _, mapping := range props.Config.(*types.VMwareDVSConfigInfo).PvlanConfig {
-			if mapping.PrimaryVlanId == int32(primary_vlan_id) && mapping.SecondaryVlanId == int32(secondary_vlan_id) && mapping.PvlanType == pvlan_type {
+			if mapping.PrimaryVlanId == int32(primaryVlanID) && mapping.SecondaryVlanId == int32(secondaryVlanID) && mapping.PvlanType == pvlanType {
 				if !expected {
 					return fmt.Errorf("found PVLAN mapping when not expecting to")
 				}

--- a/vsphere/resource_vsphere_offline_software_depot.go
+++ b/vsphere/resource_vsphere_offline_software_depot.go
@@ -113,9 +113,9 @@ func resourceVsphereOfflineSoftwareDepotDelete(d *schema.ResourceData, meta inte
 	client := meta.(*Client).restClient
 	m := depots.NewManager(client)
 
-	if taskId, err := m.DeleteOfflineDepot(d.Id()); err != nil {
+	if taskID, err := m.DeleteOfflineDepot(d.Id()); err != nil {
 		return err
-	} else if _, err = tasks.NewManager(client).WaitForCompletion(context.Background(), taskId); err != nil {
+	} else if _, err = tasks.NewManager(client).WaitForCompletion(context.Background(), taskID); err != nil {
 		return err
 	}
 	return nil

--- a/vsphere/resource_vsphere_role.go
+++ b/vsphere/resource_vsphere_role.go
@@ -71,11 +71,11 @@ func resourceRoleCreate(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceRoleRead(d *schema.ResourceData, meta interface{}) error {
-	return roleById(d, false, meta)
+	return getRoleByID(d, false, meta)
 }
 
 func resourceRoleImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
-	err := roleById(d, true, meta)
+	err := getRoleByID(d, true, meta)
 	if err != nil {
 		return nil, err
 	}
@@ -83,7 +83,7 @@ func resourceRoleImport(d *schema.ResourceData, meta interface{}) ([]*schema.Res
 	return []*schema.ResourceData{d}, nil
 }
 
-func roleById(d *schema.ResourceData, excludeSystem bool, meta interface{}) error {
+func getRoleByID(d *schema.ResourceData, excludeSystem bool, meta interface{}) error {
 	log.Printf("[DEBUG] Reading vm role with id %s", d.Id())
 	client := meta.(*Client).vimClient
 	authorizationManager := object.NewAuthorizationManager(client.Client)

--- a/vsphere/resource_vsphere_role_test.go
+++ b/vsphere/resource_vsphere_role_test.go
@@ -127,8 +127,8 @@ func TestAccResourceVsphereRole_importSystemRoleShouldError(t *testing.T) {
 				ResourceName:      "vsphere_role." + RoleResource,
 				ImportState:       true,
 				ImportStateVerify: true,
-				ImportStateId:     NoAccessRoleId,
-				ExpectError:       regexp.MustCompile(fmt.Sprintf("error specified role with id %s is a system role. System roles are not supported for this operation", NoAccessRoleId)),
+				ImportStateId:     NoAccessRoleID,
+				ExpectError:       regexp.MustCompile(fmt.Sprintf("error specified role with id %s is a system role. System roles are not supported for this operation", NoAccessRoleID)),
 			},
 		},
 	})

--- a/vsphere/resource_vsphere_supervisor.go
+++ b/vsphere/resource_vsphere_supervisor.go
@@ -232,15 +232,15 @@ func resourceVsphereSupervisorCreate(d *schema.ResourceData, meta interface{}) e
 	c := meta.(*Client).restClient
 	m := namespace.NewManager(c)
 
-	clusterId := d.Get("cluster").(string)
+	clusterID := d.Get("cluster").(string)
 
 	spec := buildClusterEnableSpec(d)
 
-	if err := m.EnableCluster(context.Background(), clusterId, spec); err != nil {
+	if err := m.EnableCluster(context.Background(), clusterID, spec); err != nil {
 		return err
 	}
 
-	d.SetId(clusterId)
+	d.SetId(clusterID)
 
 	if err := waitForSupervisorEnable(m, d); err != nil {
 		return err
@@ -263,7 +263,7 @@ func resourceVsphereSupervisorRead(d *schema.ResourceData, meta interface{}) err
 	c := meta.(*Client).restClient
 	m := namespace.NewManager(c)
 
-	cluster := getClusterById(m, d.Id())
+	cluster := getClusterByID(m, d.Id())
 
 	if cluster == nil {
 		return fmt.Errorf("could not find cluster %s", cluster.ID)
@@ -342,8 +342,8 @@ func buildClusterEnableSpec(d *schema.ResourceData) *namespace.EnableClusterSpec
 	}
 
 	contentLib := d.Get("content_library").(string)
-	mainDns := d.Get("main_dns").([]interface{})
-	workerDns := d.Get("worker_dns").([]interface{})
+	mainDNS := d.Get("main_dns").([]interface{})
+	workerDNS := d.Get("worker_dns").([]interface{})
 	mainNtp := d.Get("main_ntp").([]interface{})
 	workerNtp := d.Get("worker_ntp").([]interface{})
 	dnsSearchDomains := d.Get("search_domains").([]interface{})
@@ -360,8 +360,8 @@ func buildClusterEnableSpec(d *schema.ResourceData) *namespace.EnableClusterSpec
 		MasterManagementNetwork:                getMgmtNetwork(d),
 		ImageStorage:                           namespace.ImageStorageSpec{StoragePolicy: storagePolicy},
 		NcpClusterNetworkSpec:                  &ncpNetworkSpec,
-		MasterDNS:                              structure.SliceInterfacesToStrings(mainDns),
-		WorkerDNS:                              structure.SliceInterfacesToStrings(workerDns),
+		MasterDNS:                              structure.SliceInterfacesToStrings(mainDNS),
+		WorkerDNS:                              structure.SliceInterfacesToStrings(workerDNS),
 		MasterNTPServers:                       structure.SliceInterfacesToStrings(mainNtp),
 		WorkloadNTPServers:                     structure.SliceInterfacesToStrings(workerNtp),
 		DefaultKubernetesServiceContentLibrary: contentLib,
@@ -420,7 +420,7 @@ func waitForSupervisorEnable(m *namespace.Manager, d *schema.ResourceData) error
 		select {
 		case <-context.Background().Done():
 		case <-ticker.C:
-			cluster := getClusterById(m, d.Id())
+			cluster := getClusterByID(m, d.Id())
 
 			if cluster == nil {
 				return fmt.Errorf("could not find cluster %s", cluster.ID)
@@ -452,7 +452,7 @@ func waitForSupervisorDisable(m *namespace.Manager, d *schema.ResourceData) erro
 		select {
 		case <-context.Background().Done():
 		case <-ticker.C:
-			cluster := getClusterById(m, d.Id())
+			cluster := getClusterByID(m, d.Id())
 
 			if cluster == nil {
 				return nil
@@ -465,7 +465,7 @@ func waitForSupervisorDisable(m *namespace.Manager, d *schema.ResourceData) erro
 	}
 }
 
-func getClusterById(m *namespace.Manager, id string) *namespace.ClusterSummary {
+func getClusterByID(m *namespace.Manager, id string) *namespace.ClusterSummary {
 	clusters, err := m.ListClusters(context.Background())
 
 	if err != nil {

--- a/vsphere/resource_vsphere_supervisor_test.go
+++ b/vsphere/resource_vsphere_supervisor_test.go
@@ -54,7 +54,7 @@ func TestAccResourceVSphereSupervisor_full(t *testing.T) {
 			{
 				// You can change the network settings in the configuration
 				// so that they fit your environment
-				Config: testAccVSphereSupervisorConfig_withVmClasses(),
+				Config: testAccVSphereSupervisorConfigWithVMClasses(),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("vsphere_supervisor.supervisor", "id"),
 				),
@@ -139,7 +139,7 @@ resource "vsphere_supervisor" "supervisor" {
 		os.Getenv("TF_VAR_EDGE_CLUSTER"))
 }
 
-func testAccVSphereSupervisorConfig_withVmClasses() string {
+func testAccVSphereSupervisorConfigWithVMClasses() string {
 	return fmt.Sprintf(`
 %s
 

--- a/vsphere/resource_vsphere_vapp_container_test.go
+++ b/vsphere/resource_vsphere_vapp_container_test.go
@@ -19,7 +19,7 @@ import (
 )
 
 const (
-	testAccResourceVSphereVappContainerClonedVmDiskSize = "20"
+	testAccResourceVSphereVappContainerClonedVMDiskSize = "20"
 )
 
 func TestAccResourceVSphereVAppContainer_basic(t *testing.T) {
@@ -772,7 +772,7 @@ resource "vsphere_virtual_machine" "vm" {
 			testhelper.ConfigResResourcePool1(),
 			testhelper.ConfigDataRootPortGroup1()),
 		os.Getenv("TF_VAR_VSPHERE_TEMPLATE"),
-		testAccResourceVSphereVappContainerClonedVmDiskSize,
+		testAccResourceVSphereVappContainerClonedVMDiskSize,
 	)
 }
 

--- a/vsphere/resource_vsphere_virtual_machine.go
+++ b/vsphere/resource_vsphere_virtual_machine.go
@@ -560,8 +560,8 @@ func resourceVSphereVirtualMachineRead(d *schema.ResourceData, meta interface{})
 	for _, dev := range vprops.Config.Hardware.Device {
 		if pci, ok := dev.(*types.VirtualPCIPassthrough); ok {
 			if pciBacking, ok := pci.Backing.(*types.VirtualPCIPassthroughDeviceBackingInfo); ok {
-				devId := pciBacking.Id
-				pciDevs = append(pciDevs, devId)
+				devID := pciBacking.Id
+				pciDevs = append(pciDevs, devID)
 			} else {
 				log.Printf("[DEBUG] %s: PCI passthrough device %q has no backing ID", resourceVSphereVirtualMachineIDString(d), pci.GetVirtualDevice().DeviceInfo.GetDescription())
 			}
@@ -1819,7 +1819,7 @@ func resourceVSphereVirtualMachinePostDeployChanges(d *schema.ResourceData, meta
 				return err
 			}
 
-			if !guestoscustomizations.IsSpecOsApplicableToVmOs(types.VirtualMachineGuestOsFamily(family), specItem.Info.Type) {
+			if !guestoscustomizations.IsSpecOsApplicableToVMOs(types.VirtualMachineGuestOsFamily(family), specItem.Info.Type) {
 				return fmt.Errorf("customization specification type %s is not applicable to OS family %s", specItem.Info.Type, family)
 			}
 

--- a/vsphere/resource_vsphere_virtual_machine_class.go
+++ b/vsphere/resource_vsphere_virtual_machine_class.go
@@ -11,12 +11,12 @@ import (
 	"github.com/vmware/govmomi/vapi/namespace"
 )
 
-func resourceVsphereVmClass() *schema.Resource {
+func resourceVsphereVMClass() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceVsphereVmClassCreate,
-		Read:   resourceVsphereVmClassRead,
-		Update: resourceVsphereVmClassUpdate,
-		Delete: resourceVsphereVmClassDelete,
+		Create: resourceVsphereVMClassCreate,
+		Read:   resourceVsphereVMClassRead,
+		Update: resourceVsphereVMClassUpdate,
+		Delete: resourceVsphereVMClassDelete,
 		Schema: map[string]*schema.Schema{
 			"name": {
 				Type:        schema.TypeString,
@@ -55,7 +55,7 @@ func resourceVsphereVmClass() *schema.Resource {
 	}
 }
 
-func resourceVsphereVmClassCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceVsphereVMClassCreate(d *schema.ResourceData, meta interface{}) error {
 	c := meta.(*Client).restClient
 	m := namespace.NewManager(c)
 
@@ -85,7 +85,7 @@ func resourceVsphereVmClassCreate(d *schema.ResourceData, meta interface{}) erro
 	return nil
 }
 
-func resourceVsphereVmClassRead(d *schema.ResourceData, meta interface{}) error {
+func resourceVsphereVMClassRead(d *schema.ResourceData, meta interface{}) error {
 	c := meta.(*Client).restClient
 	m := namespace.NewManager(c)
 
@@ -94,7 +94,7 @@ func resourceVsphereVmClassRead(d *schema.ResourceData, meta interface{}) error 
 	return err
 }
 
-func resourceVsphereVmClassUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceVsphereVMClassUpdate(d *schema.ResourceData, meta interface{}) error {
 	c := meta.(*Client).restClient
 	m := namespace.NewManager(c)
 
@@ -118,7 +118,7 @@ func resourceVsphereVmClassUpdate(d *schema.ResourceData, meta interface{}) erro
 	return m.UpdateVmClass(context.Background(), d.Id(), vmClassSpec)
 }
 
-func resourceVsphereVmClassDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceVsphereVMClassDelete(d *schema.ResourceData, meta interface{}) error {
 	c := meta.(*Client).restClient
 	m := namespace.NewManager(c)
 

--- a/vsphere/resource_vsphere_virtual_machine_class_test.go
+++ b/vsphere/resource_vsphere_virtual_machine_class_test.go
@@ -15,7 +15,7 @@ func TestAccResourceVSphereVmClass_basic(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccVSphereVmClassConfig(),
+				Config: testAccVSphereVMClassConfig(),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("vsphere_virtual_machine_class.vm_class_1", "id"),
 				),
@@ -29,7 +29,7 @@ func TestAccResourceVSphereVmClass_vgpu(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccVSphereVmClassConfig_vgpu(),
+				Config: testAccVSphereVMClassConfigVgpu(),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("vsphere_virtual_machine_class.vm_class_1", "id"),
 				),
@@ -38,7 +38,7 @@ func TestAccResourceVSphereVmClass_vgpu(t *testing.T) {
 	})
 }
 
-func testAccVSphereVmClassConfig() string {
+func testAccVSphereVMClassConfig() string {
 	return `
 		resource "vsphere_virtual_machine_class" "vm_class_1" {
 			name = "test-class-11"
@@ -49,7 +49,7 @@ func testAccVSphereVmClassConfig() string {
 `
 }
 
-func testAccVSphereVmClassConfig_vgpu() string {
+func testAccVSphereVMClassConfigVgpu() string {
 	return `
 		resource "vsphere_virtual_machine_class" "vm_class_1" {
 			name = "test-class-11"

--- a/vsphere/resource_vsphere_virtual_machine_test.go
+++ b/vsphere/resource_vsphere_virtual_machine_test.go
@@ -3479,8 +3479,8 @@ func testAccResourceVSphereVirtualMachineCheckVmdkDatastore(diskIndex int, expec
 		for _, dev := range props.Config.Hardware.Device {
 			if disk, ok := dev.(*types.VirtualDisk); ok {
 				if info, ok := disk.Backing.(*types.VirtualDiskFlatVer2BackingInfo); ok {
-					currentDiskUuid := info.Uuid
-					if currentDiskUuid == uuidToLookFor {
+					currentDiskUUID := info.Uuid
+					if currentDiskUUID == uuidToLookFor {
 						var dsPath object.DatastorePath
 						if ok := dsPath.FromString(info.FileName); !ok {
 							return fmt.Errorf("could not parse datastore path %q", info.FileName)

--- a/vsphere/resource_vsphere_vm_storage_policy.go
+++ b/vsphere/resource_vsphere_vm_storage_policy.go
@@ -133,9 +133,9 @@ func resourceVMStoragePolicyRead(d *schema.ResourceData, meta interface{}) error
 	profileID := types2.PbmProfileId{
 		UniqueId: d.Id(),
 	}
-	pbmProfileIds := []types2.PbmProfileId{profileID}
+	pbmProfileIDs := []types2.PbmProfileId{profileID}
 
-	vmStoragePolicies, err := pbmClient.RetrieveContent(context.Background(), pbmProfileIds)
+	vmStoragePolicies, err := pbmClient.RetrieveContent(context.Background(), pbmProfileIDs)
 	if err != nil {
 		if strings.Contains(err.Error(), "Profile not found") {
 			log.Printf("[DEBUG] storage policy profile %s: Resource has been deleted", d.Id())
@@ -282,13 +282,13 @@ func resourceVMStoragePolicyDelete(d *schema.ResourceData, meta interface{}) err
 	if err != nil {
 		return fmt.Errorf("error while creating pbm client %s", err)
 	}
-	var policyIdsToDelete []types2.PbmProfileId
-	policyIdsToDelete = append(policyIdsToDelete, types2.PbmProfileId{
+	var policyIDsToDelete []types2.PbmProfileId
+	policyIDsToDelete = append(policyIDsToDelete, types2.PbmProfileId{
 		UniqueId: d.Id(),
 	})
 
 	var deleteProfileOutcome []types2.PbmProfileOperationOutcome
-	deleteProfileOutcome, err = pbmClient.DeleteProfile(context.Background(), policyIdsToDelete)
+	deleteProfileOutcome, err = pbmClient.DeleteProfile(context.Background(), policyIDsToDelete)
 	if err != nil {
 		return fmt.Errorf("error while deleting policy with ID %s %s", d.Id(), err)
 	}

--- a/vsphere/resource_vsphere_vnic.go
+++ b/vsphere/resource_vsphere_vnic.go
@@ -153,7 +153,7 @@ func resourceVsphereNicRead(d *schema.ResourceData, meta interface{}) error {
 	var services []string
 	for _, netConfig := range hostVnicMgrInfo.NetConfig {
 		for _, vnic := range netConfig.SelectedVnic {
-			if isNicIdContained := strings.Contains(vnic, nicID); isNicIdContained {
+			if isNicIDContained := strings.Contains(vnic, nicID); isNicIDContained {
 				services = append(services, netConfig.NicType)
 			}
 		}


### PR DESCRIPTION
### Description

Rename variables based on idiomatic principles, per `revive` and `golangci-lint`.

```shell
~/Downloads/terraform-provider-vsphere git:[fix/revive-var-naming]
golangci-lint run
0 issues.
```
