### PR TITLE
fix: ineffectual assignment

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -55,9 +55,6 @@ linters:
           - gosec
         text: G505
       - linters:
-          - ineffassign
-        text: ineffectual assignment
-      - linters:
           - revive
         text: unused-parameter
       - linters:

--- a/vsphere/internal/virtualdevice/virtual_machine_network_interface_subresource.go
+++ b/vsphere/internal/virtualdevice/virtual_machine_network_interface_subresource.go
@@ -1010,8 +1010,12 @@ func (r *NetworkInterfaceSubresource) Update(l object.VirtualDeviceList) ([]type
 		if err != nil {
 			return nil, err
 		}
+
 		if len(r.Get("physical_function").(string)) > 0 {
 			newDevice, err = r.addPhysicalFunction(newDevice)
+			if err != nil {
+				return nil, err
+			}
 		}
 
 		r.Set("key", l.NewKey())

--- a/vsphere/resource_vsphere_compute_cluster.go
+++ b/vsphere/resource_vsphere_compute_cluster.go
@@ -1760,12 +1760,13 @@ func flattenClusterVsanHostConfigInfo(d *schema.ResourceData, obj []types.VsanHo
 		if vsanHost.FaultDomainInfo.Name != "" {
 			name := vsanHost.FaultDomainInfo.Name
 			if hostIds, ok := fdMap[name]; ok {
-				hostIds = append(hostIds.([]string), vsanHost.HostSystem.Value)
+				fdMap[name] = append(hostIds.([]string), vsanHost.HostSystem.Value)
 			} else {
 				fdMap[name] = []string{vsanHost.HostSystem.Value}
 			}
 		}
 	}
+
 	var faultDomainList []interface{}
 	for fdName, hostIds := range fdMap {
 		faultDomainList = append(faultDomainList, map[string]interface{}{

--- a/vsphere/resource_vsphere_virtual_machine.go
+++ b/vsphere/resource_vsphere_virtual_machine.go
@@ -1657,7 +1657,7 @@ func resourceVSphereVirtualMachinePostDeployChanges(d *schema.ResourceData, meta
 			fmt.Errorf("error in virtual machine configuration: %s", err),
 		)
 	}
-	devices, delta, err = virtualdevice.NormalizeBus(devices, d)
+	devices, delta, err = virtualdevice.NormalizeBus(devices, d) //nolint:ineffassign
 	if err != nil {
 		return resourceVSphereVirtualMachineRollbackCreate(
 			d,


### PR DESCRIPTION
### Description

Fix ineffectual assignment.

Before:

```shell
~/Downloads/terraform-provider-vsphere git:[fix/ineffectual-assignment]
golangci-lint run
vsphere/resource_vsphere_compute_cluster.go:1762:5: ineffectual assignment to hostIds (ineffassign)
                                hostIds = append(hostIds.([]string), vsanHost.HostSystem.Value)
                                ^
vsphere/resource_vsphere_virtual_machine.go:1657:2: ineffectual assignment to devices (ineffassign)
        devices, delta, err = virtualdevice.NormalizeBus(devices, d)
        ^

2 issues:
* ineffassign: 2
```

After:

```shell
~/Downloads/terraform-provider-vsphere git:[fix/ineffectual-assignment]
golangci-lint run
0 issues.
```