### PR TITLE
feat: add `parent_resource_pool_id` to `d/resource_pool`

### DIFF
--- a/docs/data-sources/resource_pool.md
+++ b/docs/data-sources/resource_pool.md
@@ -18,14 +18,34 @@ that you want to use to create virtual machines in using the
 
 ## Example Usage
 
+### Find a Resource Pool by Path
+
 ```hcl
 data "vsphere_datacenter" "datacenter" {
   name = "dc-01"
 }
 
 data "vsphere_resource_pool" "pool" {
-  name          = "resource-pool-01"
+  name          = "cluster-01/Resources"
   datacenter_id = data.vsphere_datacenter.datacenter.id
+}
+```
+
+### Find a Child Resource Pool Using the Parent ID
+
+```hcl
+data "vsphere_datacenter" "datacenter" {
+  name = "dc-01"
+}
+
+data "vsphere_resource_pool" "parent_pool" {
+  name          = "cluster-01/Resources"
+  datacenter_id = data.vsphere_datacenter.datacenter.id
+}
+
+data "vsphere_resource_pool" "child_pool" {
+  name                    = "example"
+  parent_resource_pool_id = data.vsphere_resource_pool.parent_pool.id
 }
 ```
 
@@ -65,6 +85,9 @@ The following arguments are supported:
   the resource pool is located. This can be omitted if the search path used in
   `name` is an absolute path. For default datacenters, use the id attribute from
   an empty `vsphere_datacenter` data source.
+* `parent_resource_pool_id` - (Optional) The [managed object ID][docs-about-morefs]
+  of the parent resource pool. When specified, the `name` parameter is used to find 
+  a child resource pool with the given name under this parent resource pool.
 
 [docs-about-morefs]: /docs/providers/vsphere/index.html#use-of-managed-object-references-by-the-vsphere-provider
 
@@ -74,5 +97,5 @@ load the ESXi host's root resource pool.
 
 ## Attribute Reference
 
-Currently, the only exported attribute from this data source is `id`, which
-represents the ID of the resource pool.
+The only exported attribute from this data source is `id`, which represents the
+ID of the resource pool.

--- a/vsphere/data_source_vsphere_resource_pool.go
+++ b/vsphere/data_source_vsphere_resource_pool.go
@@ -5,14 +5,17 @@
 package vsphere
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/vmware/govmomi/find"
 	"github.com/vmware/govmomi/object"
 	"github.com/vmware/terraform-provider-vsphere/vsphere/internal/helper/resourcepool"
 	"github.com/vmware/terraform-provider-vsphere/vsphere/internal/helper/viapi"
 )
 
+// dataSourceVSphereResourcePool defines a data source for retrieving information about a vSphere resource pool.
 func dataSourceVSphereResourcePool() *schema.Resource {
 	return &schema.Resource{
 		Read: dataSourceVSphereResourcePoolRead,
@@ -20,7 +23,7 @@ func dataSourceVSphereResourcePool() *schema.Resource {
 		Schema: map[string]*schema.Schema{
 			"name": {
 				Type:        schema.TypeString,
-				Description: "The name or path of the resource pool.",
+				Description: "The name or path of the resource pool. When used with parent_resource_pool_id, this must be a simple name of a child resource pool, not a path.",
 				Optional:    true,
 			},
 			"datacenter_id": {
@@ -28,33 +31,68 @@ func dataSourceVSphereResourcePool() *schema.Resource {
 				Description: "The managed object ID of the datacenter the resource pool is in. This is not required when using ESXi directly, or if there is only one datacenter in your infrastructure.",
 				Optional:    true,
 			},
+			"parent_resource_pool_id": {
+				Type:        schema.TypeString,
+				Description: "The managed object ID of the parent resource pool.",
+				Optional:    true,
+			},
 		},
 	}
 }
 
+// dataSourceVSphereResourcePoolRead reads details of a vSphere resource pool based on its name and parent identifiers.
 func dataSourceVSphereResourcePoolRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*Client).vimClient
+	finder := find.NewFinder(client.Client, true)
 
-	name := d.Get("name").(string)
-	if err := viapi.ValidateVirtualCenter(client); err == nil {
-		if name == "" {
-			return fmt.Errorf("name cannot be empty when using vCenter")
-		}
-	}
+	name, nameOk := d.Get("name").(string)
+	dcID, dcOk := d.GetOk("datacenter_id")
+	parentID, parentOk := d.GetOk("parent_resource_pool_id")
 
 	var dc *object.Datacenter
-	if dcID, ok := d.GetOk("datacenter_id"); ok {
+	if dcOk {
 		var err error
 		dc, err = datacenterFromID(client, dcID.(string))
 		if err != nil {
-			return fmt.Errorf("cannot locate datacenter: %s", err)
+			return fmt.Errorf("cannot locate datacenter %q: %s", dcID.(string), err)
+		}
+		finder.SetDatacenter(dc)
+	} else {
+		if err := viapi.ValidateVirtualCenter(client); err == nil {
+			defaultDc, err := finder.DefaultDatacenter(context.TODO())
+			if err != nil {
+				return fmt.Errorf("failed to get default datacenter: %w", err)
+			}
+			finder.SetDatacenter(defaultDc)
 		}
 	}
-	rp, err := resourcepool.FromPathOrDefault(client, name, dc)
-	if err != nil {
-		return fmt.Errorf("error fetching resource pool: %s", err)
+
+	var rp *object.ResourcePool
+	var err error
+
+	if parentOk {
+		if !nameOk || name == "" {
+			return fmt.Errorf("argument 'name' is required when 'parent_resource_pool_id' is specified")
+		}
+
+		var err error
+		rp, err = resourcepool.FromParentAndName(client, parentID.(string), name)
+		if err != nil {
+			return err
+		}
+
+	} else {
+		if !nameOk || name == "" {
+			return fmt.Errorf("argument 'name' is required when 'parent_resource_pool_id' is not specified")
+		}
+
+		rp, err = resourcepool.FromPathOrDefault(client, name, dc)
+		if err != nil {
+			return fmt.Errorf("error fetching resource pool by path %q: %s", name, err)
+		}
 	}
 
 	d.SetId(rp.Reference().Value)
+
 	return nil
 }


### PR DESCRIPTION
### Description

> [!NOTE]
> **TESTED AND READY** 

Enhances the functionality of the `d/resource_pool` by introducing support for finding child resource pools using `parent_resource_pool_id`. It also includes updates to the documentation, new helper methods, and additional test cases to validate the changes.

#### Enhancements to `d/resource_pool`:

* Added a new optional argument, `parent_resource_pool_id`, to specify the parent resource pool's ID when searching for a child resource pool. The `name` argument must now be a simple name (not a path) when used with this new parameter. (`vsphere/data_source_vsphere_resource_pool.go`, [vsphere/data_source_vsphere_resource_pool.goR7-R96](diffhunk://#diff-fba432a0d0c3dde38a9688fc432f35ce6b1caef4a4a021d54f9e88afe0642e69R7-R96))

* Updated the `dataSourceVSphereResourcePoolRead` function to handle the new `parent_resource_pool_id` parameter, allowing retrieval of child resource pools based on the parent ID. (`vsphere/data_source_vsphere_resource_pool.go`, [vsphere/data_source_vsphere_resource_pool.goR7-R96](diffhunk://#diff-fba432a0d0c3dde38a9688fc432f35ce6b1caef4a4a021d54f9e88afe0642e69R7-R96))

#### Documentation updates:

* Updated the `docs/data-sources/resource_pool.md` file to include examples and descriptions for using the `parent_resource_pool_id` argument. Added a new example for finding a child resource pool using the parent ID. [[1]](diffhunk://#diff-50a8f4379f03e18dde3a8502c60f3aa31fd97e479b512f0fc251a19bffab1453R21-R51) [[2]](diffhunk://#diff-50a8f4379f03e18dde3a8502c60f3aa31fd97e479b512f0fc251a19bffab1453R88-R90)

* Refined the description of exported attributes and arguments in the documentation for better clarity.

#### Helper methods:

* Introduced a new method, `FromParentAndName`, in `resource_pool_helper.go` to retrieve a child resource pool by its name and parent resource pool ID. This method includes error handling for invalid inputs and missing child resource pools. (`vsphere/internal/helper/resourcepool/resource_pool_helper.go`, [vsphere/internal/helper/resourcepool/resource_pool_helper.goL48-R134](diffhunk://#diff-234202cf07cb9d9fcab8a6b05d04b25ce388c354db1914541fdc5f52443b4cadL48-R134))

* Refactored existing helper methods to improve code readability and maintainability. (`vsphere/internal/helper/resourcepool/resource_pool_helper.go`, [[1]](diffhunk://#diff-234202cf07cb9d9fcab8a6b05d04b25ce388c354db1914541fdc5f52443b4cadL21-R28) [[2]](diffhunk://#diff-234202cf07cb9d9fcab8a6b05d04b25ce388c354db1914541fdc5f52443b4cadL69-R151)

#### Test coverage:

* Added multiple new acceptance tests to validate the functionality of the `parent_resource_pool_id` argument, including tests for valid cases, missing arguments, invalid parent IDs, and non-existent child resource pools. (`vsphere/data_source_vsphere_resource_pool_test.go`, [[1]](diffhunk://#diff-55f201c7f6d50cf8df0f0d79710adf322c01cbdd2a42a8dcb8d45720b4b53af4R57-R155) [[2]](diffhunk://#diff-55f201c7f6d50cf8df0f0d79710adf322c01cbdd2a42a8dcb8d45720b4b53af4L89-R188)

* Updated existing test configurations to align with the new functionality and error messages. (`vsphere/data_source_vsphere_resource_pool_test.go`, [[1]](diffhunk://#diff-55f201c7f6d50cf8df0f0d79710adf322c01cbdd2a42a8dcb8d45720b4b53af4L104-R221) [[2]](diffhunk://#diff-55f201c7f6d50cf8df0f0d79710adf322c01cbdd2a42a8dcb8d45720b4b53af4L131-R344)

### Testing

Before:

```hcl
provider "vsphere" {
  vsphere_server       = var.vsphere_server
  user                 = var.vsphere_username
  password             = var.vsphere_password
  allow_unverified_ssl = var.vsphere_insecure
}

data "vsphere_datacenter" "datacenter" {
  name = "sfo-w01-dc01"
}
data "vsphere_resource_pool" "parent" {
  name          = "parent"
  datacenter_id = data.vsphere_datacenter.datacenter.id
}
data "vsphere_resource_pool" "child" {
  name                    = "child"
  datacenter_id           = data.vsphere_datacenter.datacenter.id
}

output "parent" {
  value = data.vsphere_resource_pool.parent.id
}

output "child" {
  value = data.vsphere_resource_pool.child.id
}
```

```shell
> terraform plan                  
╷
│ Warning: Provider development overrides are in effect
│
│ The following provider development overrides are set in the CLI configuration:
│  - hashicorp/vsphere in C:\Users\Administrator\go\bin
│
│ The behavior may therefore not match any released version of the provider and applying changes may cause the state to become incompatible with published releases.
╵
data.vsphere_datacenter.datacenter: Reading...
data.vsphere_datacenter.datacenter: Read complete after 0s [id=datacenter-3]
data.vsphere_resource_pool.child: Reading...
data.vsphere_resource_pool.parent: Reading...
data.vsphere_resource_pool.parent: Read complete after 0s [id=resgroup-8119]

Changes to Outputs:
  + parent = "resgroup-8119"

You can apply this plan to save these new output values to the Terraform state, without changing any real infrastructure.
╷
│ Error: error fetching resource pool by path "child": path 'child' resolves to multiple resource pools
│
│   with data.vsphere_resource_pool.child,
│   on main.tf line 15, in data "vsphere_resource_pool" "child":
│   15: data "vsphere_resource_pool" "child" {
```

After:

```hcl
provider "vsphere" {
  vsphere_server       = var.vsphere_server
  user                 = var.vsphere_username
  password             = var.vsphere_password
  allow_unverified_ssl = var.vsphere_insecure
}

data "vsphere_datacenter" "datacenter" {
  name = "sfo-w01-dc01"
}
data "vsphere_resource_pool" "parent" {
  name          = "parent"
  datacenter_id = data.vsphere_datacenter.datacenter.id
}
data "vsphere_resource_pool" "child" {
  name                    = "child"
  datacenter_id           = data.vsphere_datacenter.datacenter.id
  parent_resource_pool_id = data.vsphere_resource_pool.parent.id
}

output "parent" {
  value = data.vsphere_resource_pool.parent.id
}

output "child" {
  value = data.vsphere_resource_pool.child.id
}
```

```shell
> terraform plan
╷
│ Warning: Provider development overrides are in effect
│
│ The following provider development overrides are set in the CLI configuration:
│  - hashicorp/vsphere in C:\Users\Administrator\go\bin
│
│ The behavior may therefore not match any released version of the provider and applying changes may cause the state to become incompatible with published releases.
╵
data.vsphere_datacenter.datacenter: Reading...
data.vsphere_datacenter.datacenter: Read complete after 0s [id=datacenter-3]
data.vsphere_resource_pool.parent: Reading...
data.vsphere_resource_pool.parent: Read complete after 1s [id=resgroup-8119]
data.vsphere_resource_pool.child: Reading...
data.vsphere_resource_pool.child: Read complete after 0s [id=resgroup-8120]

Changes to Outputs:
  + child  = "resgroup-8120"
  + parent = "resgroup-8119"

You can apply this plan to save these new output values to the Terraform state, without changing any real infrastructure.
```

### Reference

Closes #1271
