### PR TITLE
docs: clarify `disk_provisioning` options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ DOCUMENTATION:
 
 - `d/folder`/`r/folder`: Updated documentation. (#2459)
 - `d/license`/`r/flicense`: Updated documentation. (#2435)
+- `r/virtual_machine`: Updated documentation. (#2480)
+- `d/ovf_vm_template`: Updated documentation. (#2480)
 
 CHORE:
 

--- a/docs/data-sources/ovf_vm_template.md
+++ b/docs/data-sources/ovf_vm_template.md
@@ -205,8 +205,13 @@ The following arguments are supported:
 * `ip_allocation_policy` - (Optional) The IP allocation policy.
 * `ip_protocol` - (Optional) The IP protocol.
 * `disk_provisioning` - (Optional) The disk provisioning type. If set, all the
-  disks in the deployed OVA/OVF will have the same specified disk type. Can be
-  one of `thin`, `flat`, `thick` or `sameAsSource`.
+  disks included in the OVF/OVA will have the same specified policy. Can be
+  one of `thin`, `thick`, `eagerZeroedThick`, or `sameAsSource`.
+  * `thin`: Each disk is allocated and zeroed on demand as the space is used.
+  * `thick`: Each disk is allocated at creation time and the space is zeroed
+     on demand as the space is used.
+  * `eagerZeroedThick`: Each disk is allocated and zeroed at creation time.
+  * `sameAsSource`: Each disk will have the same disk type as the source.
 * `deployment_option` - (Optional) The key of the chosen deployment option. If
   empty, the default option is chosen.
 * `ovf_network_map` - (Optional) The mapping of name of network identifiers

--- a/docs/resources/virtual_machine.md
+++ b/docs/resources/virtual_machine.md
@@ -1409,7 +1409,11 @@ The options available in the `ovf_deploy` block are:
 
 * `ip_protocol` - (Optional) The IP protocol.
 
-* `disk_provisioning` - (Optional) The disk provisioning policy. If set, all the disks included in the OVF/OVA will have the same specified policy. One of `thin`, `flat`, `thick`, or `sameAsSource`.
+* `disk_provisioning` - (Optional) The disk provisioning type. If set, all the disks included in the OVF/OVA will have the same specified policy. One of `thin`, `thick`, `eagerZeroedThick`, or `sameAsSource`.
+  * `thin`: Each disk is allocated and zeroed on demand as the space is used.
+  * `thick`: Each disk is allocated at creation time and the space is zeroed on demand as the space is used.
+  * `eagerZeroedThick`: Each disk is allocated and zeroed at creation time.
+  * `sameAsSource`: Each disk will have the same disk type as the source.
 
 * `deployment_option` - (Optional) The key for the deployment option. If empty, the default option is selected.
 


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 no-inline-html -->

<!--
    NOTE: Do NOT enter content between the comment markers <!- and ->.

    In order to have the best experience with our community, we recommend that you read the code of
    conduct and contributing guidelines before submitting a pull request.

    By submitting this pull request, you confirm that you have read, understood, and agreed to the
    project's code of conduct and contributing guidelines.

    Please use conventional commits to format the title of the pull request and the commit messages.

    For more information, please refer to https://www.conventionalcommits.org and the contributing
    guidelines for this project.
-->

### Summary

Clarifies the `disk_provisioning` argument options.

[Reference](https://github.com/vmware/govmomi/blob/d2fecb683891ca1ffeaea8fd18912c3b87938977/vim25/types/enum.go#L9323-L9367).

Updating to:

```markdown
* `disk_provisioning` - (Optional) The disk provisioning type.
  If set, all the disks included in the OVF/OVA will have the same specified policy.
  One of `thin`, `thick`, `eagerZeroedThick`, or `sameAsSource`.
  * `thin`: Each disk is allocated and zeroed on demand as the space is used.
  * `thick`: Each disk is allocated at creation time and the space is zeroed on demand as the space is used.
  * `eagerZeroedThick`: Each disk is allocated and zeroed at creation time.
  * `sameAsSource`: Each disk will have the same disk type as the source.
```

### Type

<!--
    Please check the one(s) that applies to this pull request using "x".
-->

- [ ] `fix`: Bug Fix
- [ ] `feat`: Feature or Enhancement
- [x] `docs`: Documentation
- [ ] `refactor`: Refactoring
- [ ] `chore`: Build, Dependencies, Workflows, etc.
- [ ] `other`: Other (Please describe.)

### Breaking Changes?

<!--
    Please check the one that applies to this pull request using "x".
    If this pull request contains a breaking change, please describe the impact and mitigation path.
-->

- [ ] Yes, there are breaking changes.
- [x] No, there are no breaking changes.

### Tests

<!--
    Please check the one(s) that applies to this pull request using "x".
    For bug fixes and enhancements/features, please ensure that tests and documentation have been completed and provide details.
-->

- [ ] Tests have been added or updated.
- [ ] Tests have been completed.
- [x] Not applicable.

Output:

<!--
    Please provide the output of the acceptance tests as applicable.
-->

### Documentation

<!--
    Please check the one(s) that applies to this pull request using "x".
    For enhancements/features, please ensure that documentation has been updated.
-->

- [x] Documentation has been added or updated.

### Issue References

<!--
    Is this related to any GitHub issue(s)? If so, please provide the issue number(s) that are closed or resolved by this pull request.

    For bug fixes and enhancements/features, please ensure that a GitHub issue has been created and provide the issue number(s) here.

    Please use the 'Closes', 'Resolves', or 'Fixes' keywords followed by the a hash and issue number.
    This will link the pull request to the issue(s) and automatically close them when the pull request is merged.

    Example:

    Closes #000
    Resolves #001
    Fixes #002
-->

Resolves #2479 

### Release Note

<!--
    Please provide context for the release notes.

    For example:

    ```
    - `r/foo` - Added support for foo. (#xxx)
    ```
-->

### Additional Information

<!--
    Please provide any additional information that may be helpful.
-->
