### PR TITLE
refactor: use of deprecated `GetOkExists`

### DIFF
--- a/vsphere/distributed_virtual_port_setting_structure.go
+++ b/vsphere/distributed_virtual_port_setting_structure.go
@@ -313,9 +313,9 @@ func flattenVmwareDistributedVirtualSwitchPvlanSpec(d *schema.ResourceData, obj 
 func expandBaseVmwareDistributedVirtualSwitchVlanSpec(d *schema.ResourceData) types.BaseVmwareDistributedVirtualSwitchVlanSpec {
 	var obj types.BaseVmwareDistributedVirtualSwitchVlanSpec
 
-	_, ide := d.GetOkExists("vlan_id")
-	_, pvid := d.GetOkExists("port_private_secondary_vlan_id")
-	vteList, vteOK := d.GetOkExists("vlan_range")
+	_, ide := d.GetOk("vlan_id")
+	_, pvid := d.GetOk("port_private_secondary_vlan_id")
+	vteList, vteOK := d.GetOk("vlan_range")
 	vte := vteOK && len(vteList.(*schema.Set).List()) > 0
 	switch {
 	case vte:

--- a/vsphere/host_network_policy_structure.go
+++ b/vsphere/host_network_policy_structure.go
@@ -112,7 +112,7 @@ func schemaHostNetworkPolicy() map[string]*schema.Schema {
 func expandHostNicFailureCriteria(d *schema.ResourceData) *types.HostNicFailureCriteria {
 	obj := &types.HostNicFailureCriteria{}
 
-	if v, ok := d.GetOkExists("check_beacon"); ok {
+	if v, ok := d.GetOk("check_beacon"); ok {
 		obj.CheckBeacon = structure.BoolPtr(v.(bool))
 	}
 
@@ -141,8 +141,8 @@ func flattenHostNicFailureCriteria(d *schema.ResourceData, obj *types.HostNicFai
 // HostNicOrderPolicy.
 func expandHostNicOrderPolicy(d *schema.ResourceData) *types.HostNicOrderPolicy {
 	obj := &types.HostNicOrderPolicy{}
-	activeNics, activeOk := d.GetOkExists("active_nics")
-	standbyNics, standbyOk := d.GetOkExists("standby_nics")
+	activeNics, activeOk := d.GetOk("active_nics")
+	standbyNics, standbyOk := d.GetOk("standby_nics")
 	if !activeOk && !standbyOk {
 		return nil
 	}
@@ -168,10 +168,10 @@ func expandHostNicTeamingPolicy(d *schema.ResourceData) *types.HostNicTeamingPol
 	obj := &types.HostNicTeamingPolicy{
 		Policy: d.Get("teaming_policy").(string),
 	}
-	if v, ok := d.GetOkExists("failback"); ok {
+	if v, ok := d.GetOk("failback"); ok {
 		obj.RollingOrder = structure.BoolPtr(!v.(bool))
 	}
-	if v, ok := d.GetOkExists("notify_switches"); ok {
+	if v, ok := d.GetOk("notify_switches"); ok {
 		obj.NotifySwitches = structure.BoolPtr(v.(bool))
 	}
 	obj.FailureCriteria = expandHostNicFailureCriteria(d)
@@ -206,13 +206,13 @@ func flattenHostNicTeamingPolicy(d *schema.ResourceData, obj *types.HostNicTeami
 // a HostNetworkSecurityPolicy.
 func expandHostNetworkSecurityPolicy(d *schema.ResourceData) *types.HostNetworkSecurityPolicy {
 	obj := &types.HostNetworkSecurityPolicy{}
-	if v, ok := d.GetOkExists("allow_promiscuous"); ok {
+	if v, ok := d.GetOk("allow_promiscuous"); ok {
 		obj.AllowPromiscuous = structure.BoolPtr(v.(bool))
 	}
-	if v, ok := d.GetOkExists("allow_forged_transmits"); ok {
+	if v, ok := d.GetOk("allow_forged_transmits"); ok {
 		obj.ForgedTransmits = structure.BoolPtr(v.(bool))
 	}
-	if v, ok := d.GetOkExists("allow_mac_changes"); ok {
+	if v, ok := d.GetOk("allow_mac_changes"); ok {
 		obj.MacChanges = structure.BoolPtr(v.(bool))
 	}
 	return obj
@@ -241,7 +241,7 @@ func expandHostNetworkTrafficShapingPolicy(d *schema.ResourceData) *types.HostNe
 		BurstSize:        int64(d.Get("shaping_burst_size").(int)),
 		PeakBandwidth:    int64(d.Get("shaping_peak_bandwidth").(int)),
 	}
-	if v, ok := d.GetOkExists("shaping_enabled"); ok {
+	if v, ok := d.GetOk("shaping_enabled"); ok {
 		obj.Enabled = structure.BoolPtr(v.(bool))
 	}
 	return obj

--- a/vsphere/internal/helper/structure/structure_helper.go
+++ b/vsphere/internal/helper/structure/structure_helper.go
@@ -108,7 +108,7 @@ func BoolPtr(v bool) *bool {
 // GetBoolPtr reads a ResourceData and returns an appropriate *bool for the
 // state of the definition. nil is returned if it does not exist.
 func GetBoolPtr(d *schema.ResourceData, key string) *bool {
-	v, e := d.GetOkExists(key)
+	v, e := d.GetOk(key)
 	if e {
 		return BoolPtr(v.(bool))
 	}
@@ -222,7 +222,7 @@ func Int32Ptr(v int32) *int32 {
 // GetInt64Ptr reads a ResourceData and returns an appropriate *int64 for the
 // state of the definition. nil is returned if it does not exist.
 func GetInt64Ptr(d *schema.ResourceData, key string) *int64 {
-	v, e := d.GetOkExists(key)
+	v, e := d.GetOk(key)
 	if e {
 		return Int64Ptr(int64(v.(int)))
 	}
@@ -303,7 +303,7 @@ func BoolPolicy(b bool) *types.BoolPolicy {
 // GetBoolPolicy reads a ResourceData and returns an appropriate BoolPolicy for
 // the state of the definition. nil is returned if it does not exist.
 func GetBoolPolicy(d *schema.ResourceData, key string) *types.BoolPolicy {
-	v, e := d.GetOkExists(key)
+	v, e := d.GetOk(key)
 	if e {
 		return BoolPolicy(v.(bool))
 	}
@@ -322,7 +322,7 @@ func SetBoolPolicy(d *schema.ResourceData, key string, val *types.BoolPolicy) er
 
 // GetBoolPolicyReverse acts like GetBoolPolicy, but the value is inverted.
 func GetBoolPolicyReverse(d *schema.ResourceData, key string) *types.BoolPolicy {
-	v, e := d.GetOkExists(key)
+	v, e := d.GetOk(key)
 	if e {
 		return BoolPolicy(!v.(bool))
 	}
@@ -349,7 +349,7 @@ func StringPolicy(s string) *types.StringPolicy {
 // GetStringPolicy reads a ResourceData and returns an appropriate StringPolicy
 // for the state of the definition. nil is returned if it does not exist.
 func GetStringPolicy(d *schema.ResourceData, key string) *types.StringPolicy {
-	v, e := d.GetOkExists(key)
+	v, e := d.GetOk(key)
 	if e {
 		return StringPolicy(v.(string))
 	}
@@ -398,7 +398,7 @@ func LongPolicy(n interface{}) *types.LongPolicy {
 // GetLongPolicy reads a ResourceData and returns an appropriate LongPolicy
 // for the state of the definition. nil is returned if it does not exist.
 func GetLongPolicy(d *schema.ResourceData, key string) *types.LongPolicy {
-	v, e := d.GetOkExists(key)
+	v, e := d.GetOk(key)
 	if e {
 		return LongPolicy(v)
 	}


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 no-inline-html -->

<!--
    NOTE: Do NOT enter content between the comment markers <!- and ->.

    In order to have the best experience with our community, we recommend that you read the code of
    conduct and contributing guidelines before submitting a pull request.

    By submitting this pull request, you confirm that you have read, understood, and agreed to the
    project's code of conduct and contributing guidelines.

    Please use conventional commits to format the title of the pull request and the commit messages.

    For more information, please refer to https://www.conventionalcommits.org and the contributing
    guidelines for this project.
-->

### Summary

Refactors the use of the deprecated `GetOkExists`.

### Type

<!--
    Please check the one(s) that applies to this pull request using "x".
-->

- [ ] `fix`: Bug Fix
- [ ] `feat`: Feature or Enhancement
- [ ] `docs`: Documentation
- [x] `refactor`: Refactoring
- [ ] `chore`: Build, Dependencies, Workflows, etc.
- [ ] `other`: Other (Please describe.)

### Breaking Changes?

<!--
    Please check the one that applies to this pull request using "x".
    If this pull request contains a breaking change, please describe the impact and mitigation path.
-->

- [ ] Yes, there are breaking changes.
- [x] No, there are no breaking changes.

### Tests

<!--
    Please check the one(s) that applies to this pull request using "x".
    For bug fixes and enhancements/features, please ensure that tests and documentation have been completed and provide details.
-->

- [ ] Tests have been added or updated.
- [x] Tests have been completed.

```shell
PS F:\Code\test\host> terraform apply --auto-approve  
╷
│ Warning: Provider development overrides are in effect
│
│ The following provider development overrides are set in the CLI configuration:
│  - hashicorp/vsphere in C:\Users\Administrator\go\bin
│
│ The behavior may therefore not match any released version of the provider and applying changes may cause the state to become incompatible with published releases.
╵
data.vsphere_datacenter.datacenter: Reading...
data.vsphere_datacenter.datacenter: Read complete after 0s [id=datacenter-3]
data.vsphere_distributed_virtual_switch.vds: Reading...
data.vsphere_distributed_virtual_switch.vds: Read complete after 0s [id=50 1f 6c 23 08 f6 4b 4d-1e 16 86 da 3b 52 42 36]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # vsphere_distributed_port_group.pg will be created
  + resource "vsphere_distributed_port_group" "pg" {
      + active_uplinks                    = (known after apply)
      + allow_forged_transmits            = (known after apply)
      + allow_mac_changes                 = (known after apply)
      + allow_promiscuous                 = (known after apply)
      + auto_expand                       = true
      + block_all_ports                   = (known after apply)
      + check_beacon                      = (known after apply)
      + config_version                    = (known after apply)
      + directpath_gen2_allowed           = (known after apply)
      + distributed_virtual_switch_uuid   = (known after apply)
      + egress_shaping_average_bandwidth  = (known after apply)
      + egress_shaping_burst_size         = (known after apply)
      + egress_shaping_enabled            = (known after apply)
      + egress_shaping_peak_bandwidth     = (known after apply)
      + failback                          = (known after apply)
      + id                                = (known after apply)
      + ingress_shaping_average_bandwidth = (known after apply)
      + ingress_shaping_burst_size        = (known after apply)
      + ingress_shaping_enabled           = (known after apply)
      + ingress_shaping_peak_bandwidth    = (known after apply)
      + key                               = (known after apply)
      + lacp_enabled                      = (known after apply)
      + lacp_mode                         = (known after apply)
      + name                              = "terraform-test-pg"
      + netflow_enabled                   = (known after apply)
      + network_resource_pool_key         = "-1"
      + notify_switches                   = (known after apply)
      + number_of_ports                   = (known after apply)
      + port_private_secondary_vlan_id    = (known after apply)
      + standby_uplinks                   = (known after apply)
      + teaming_policy                    = (known after apply)
      + tx_uplink                         = (known after apply)
      + type                              = "earlyBinding"
      + vlan_id                           = (known after apply)

      + vlan_range (known after apply)
    }

  # vsphere_distributed_virtual_switch.dvs will be created
  + resource "vsphere_distributed_virtual_switch" "dvs" {
      + active_uplinks                    = [
          + "uplink1",
          + "uplink2",
        ]
      + allow_forged_transmits            = true
      + allow_mac_changes                 = true
      + allow_promiscuous                 = true
      + backupnfc_maximum_mbit            = (known after apply)
      + backupnfc_reservation_mbit        = (known after apply)
      + backupnfc_share_count             = (known after apply)
      + backupnfc_share_level             = (known after apply)
      + block_all_ports                   = true
      + check_beacon                      = true
      + config_version                    = (known after apply)
      + datacenter_id                     = "datacenter-3"
      + directpath_gen2_allowed           = (known after apply)
      + egress_shaping_average_bandwidth  = 1000000
      + egress_shaping_burst_size         = 5000000
      + egress_shaping_enabled            = true
      + egress_shaping_peak_bandwidth     = 10000000
      + failback                          = true
      + faulttolerance_maximum_mbit       = (known after apply)
      + faulttolerance_reservation_mbit   = (known after apply)
      + faulttolerance_share_count        = (known after apply)
      + faulttolerance_share_level        = (known after apply)
      + hbr_maximum_mbit                  = (known after apply)
      + hbr_reservation_mbit              = (known after apply)
      + hbr_share_count                   = (known after apply)
      + hbr_share_level                   = (known after apply)
      + id                                = (known after apply)
      + ignore_other_pvlan_mappings       = false
      + ingress_shaping_average_bandwidth = 1000000
      + ingress_shaping_burst_size        = 5000000
      + ingress_shaping_enabled           = true
      + ingress_shaping_peak_bandwidth    = 10000000
      + iscsi_maximum_mbit                = (known after apply)
      + iscsi_reservation_mbit            = (known after apply)
      + iscsi_share_count                 = (known after apply)
      + iscsi_share_level                 = (known after apply)
      + lacp_api_version                  = (known after apply)
      + lacp_enabled                      = true
      + lacp_mode                         = "active"
      + link_discovery_operation          = "listen"
      + link_discovery_protocol           = "cdp"
      + management_maximum_mbit           = (known after apply)
      + management_reservation_mbit       = (known after apply)
      + management_share_count            = (known after apply)
      + management_share_level            = (known after apply)
      + max_mtu                           = (known after apply)
      + multicast_filtering_mode          = (known after apply)
      + name                              = "testacc-dvs"
      + netflow_active_flow_timeout       = 60
      + netflow_enabled                   = true
      + netflow_idle_flow_timeout         = 15
      + network_resource_control_version  = (known after apply)
      + nfs_maximum_mbit                  = (known after apply)
      + nfs_reservation_mbit              = (known after apply)
      + nfs_share_count                   = (known after apply)
      + nfs_share_level                   = (known after apply)
      + notify_switches                   = true
      + port_private_secondary_vlan_id    = (known after apply)
      + standby_uplinks                   = [
          + "uplink3",
          + "uplink4",
        ]
      + teaming_policy                    = "failover_explicit"
      + tx_uplink                         = true
      + uplinks                           = (known after apply)
      + vdp_maximum_mbit                  = (known after apply)
      + vdp_reservation_mbit              = (known after apply)
      + vdp_share_count                   = (known after apply)
      + vdp_share_level                   = (known after apply)
      + version                           = (known after apply)
      + virtualmachine_maximum_mbit       = (known after apply)
      + virtualmachine_reservation_mbit   = (known after apply)
      + virtualmachine_share_count        = (known after apply)
      + virtualmachine_share_level        = (known after apply)
      + vlan_id                           = 1000
      + vmotion_maximum_mbit              = (known after apply)
      + vmotion_reservation_mbit          = (known after apply)
      + vmotion_share_count               = (known after apply)
      + vmotion_share_level               = (known after apply)
      + vsan_maximum_mbit                 = (known after apply)
      + vsan_reservation_mbit             = (known after apply)
      + vsan_share_count                  = (known after apply)
      + vsan_share_level                  = (known after apply)

      + vlan_range (known after apply)
    }

Plan: 2 to add, 0 to change, 0 to destroy.
vsphere_distributed_virtual_switch.dvs: Creating...
vsphere_distributed_virtual_switch.dvs: Creation complete after 1s [id=50 1f 18 9d d6 5a a9 ae-c6 55 0e 73 31 fb 5e a6]
vsphere_distributed_port_group.pg: Creating...
vsphere_distributed_port_group.pg: Creation complete after 1s [id=dvportgroup-8139]

Apply complete! Resources: 2 added, 0 changed, 0 destroyed.
PS F:\Code\test\host> terraform destroy --auto-approve
╷
│ Warning: Provider development overrides are in effect
│
│ The following provider development overrides are set in the CLI configuration:
│  - hashicorp/vsphere in C:\Users\Administrator\go\bin
│
│ The behavior may therefore not match any released version of the provider and applying changes may cause the state to become incompatible with published releases.
╵
data.vsphere_datacenter.datacenter: Reading...
data.vsphere_datacenter.datacenter: Read complete after 0s [id=datacenter-3]
data.vsphere_distributed_virtual_switch.vds: Reading...
vsphere_distributed_virtual_switch.dvs: Refreshing state... [id=50 1f 18 9d d6 5a a9 ae-c6 55 0e 73 31 fb 5e a6]
data.vsphere_distributed_virtual_switch.vds: Read complete after 1s [id=50 1f 6c 23 08 f6 4b 4d-1e 16 86 da 3b 52 42 36]
vsphere_distributed_port_group.pg: Refreshing state... [id=dvportgroup-8139]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  - destroy

Terraform will perform the following actions:

  # vsphere_distributed_port_group.pg will be destroyed
  - resource "vsphere_distributed_port_group" "pg" {
      - active_uplinks                         = [
          - "uplink1",
          - "uplink2",
        ] -> null
      - allow_forged_transmits                 = true -> null
      - allow_mac_changes                      = true -> null
      - allow_promiscuous                      = true -> null
      - auto_expand                            = true -> null
      - block_all_ports                        = true -> null
      - block_override_allowed                 = false -> null
      - check_beacon                           = true -> null
      - config_version                         = "0" -> null
      - custom_attributes                      = {} -> null
      - directpath_gen2_allowed                = false -> null
      - distributed_virtual_switch_uuid        = "50 1f 18 9d d6 5a a9 ae-c6 55 0e 73 31 fb 5e a6" -> null
      - egress_shaping_average_bandwidth       = 1000000 -> null
      - egress_shaping_burst_size              = 5000000 -> null
      - egress_shaping_enabled                 = true -> null
      - egress_shaping_peak_bandwidth          = 10000000 -> null
      - failback                               = true -> null
      - id                                     = "dvportgroup-8139" -> null
      - ingress_shaping_average_bandwidth      = 1000000 -> null
      - ingress_shaping_burst_size             = 5000000 -> null
      - ingress_shaping_enabled                = true -> null
      - ingress_shaping_peak_bandwidth         = 10000000 -> null
      - key                                    = "dvportgroup-8139" -> null
      - lacp_enabled                           = true -> null
      - lacp_mode                              = "active" -> null
      - live_port_moving_allowed               = false -> null
      - name                                   = "terraform-test-pg" -> null
      - netflow_enabled                        = true -> null
      - netflow_override_allowed               = false -> null
      - network_resource_pool_key              = "-1" -> null
      - network_resource_pool_override_allowed = false -> null
      - notify_switches                        = true -> null
      - number_of_ports                        = 0 -> null
      - port_config_reset_at_disconnect        = false -> null
      - security_policy_override_allowed       = false -> null
      - shaping_override_allowed               = false -> null
      - standby_uplinks                        = [
          - "uplink3",
          - "uplink4",
        ] -> null
      - tags                                   = [] -> null
      - teaming_policy                         = "failover_explicit" -> null
      - traffic_filter_override_allowed        = false -> null
      - tx_uplink                              = true -> null
      - type                                   = "earlyBinding" -> null
      - uplink_teaming_override_allowed        = false -> null
      - vlan_id                                = 1000 -> null
      - vlan_override_allowed                  = false -> null
        # (2 unchanged attributes hidden)
    }

  # vsphere_distributed_virtual_switch.dvs will be destroyed
  - resource "vsphere_distributed_virtual_switch" "dvs" {
      - active_uplinks                    = [
          - "uplink1",
          - "uplink2",
        ] -> null
      - allow_forged_transmits            = true -> null
      - allow_mac_changes                 = true -> null
      - allow_promiscuous                 = true -> null
      - backupnfc_maximum_mbit            = -1 -> null
      - backupnfc_reservation_mbit        = 0 -> null
      - backupnfc_share_count             = 50 -> null
      - backupnfc_share_level             = "normal" -> null
      - block_all_ports                   = true -> null
      - check_beacon                      = true -> null
      - config_version                    = "1" -> null
      - custom_attributes                 = {} -> null
      - datacenter_id                     = "datacenter-3" -> null
      - directpath_gen2_allowed           = false -> null
      - egress_shaping_average_bandwidth  = 1000000 -> null
      - egress_shaping_burst_size         = 5000000 -> null
      - egress_shaping_enabled            = true -> null
      - egress_shaping_peak_bandwidth     = 10000000 -> null
      - failback                          = true -> null
      - faulttolerance_maximum_mbit       = -1 -> null
      - faulttolerance_reservation_mbit   = 0 -> null
      - faulttolerance_share_count        = 50 -> null
      - faulttolerance_share_level        = "normal" -> null
      - hbr_maximum_mbit                  = -1 -> null
      - hbr_reservation_mbit              = 0 -> null
      - hbr_share_count                   = 50 -> null
      - hbr_share_level                   = "normal" -> null
      - id                                = "50 1f 18 9d d6 5a a9 ae-c6 55 0e 73 31 fb 5e a6" -> null
      - ignore_other_pvlan_mappings       = false -> null
      - ingress_shaping_average_bandwidth = 1000000 -> null
      - ingress_shaping_burst_size        = 5000000 -> null
      - ingress_shaping_enabled           = true -> null
      - ingress_shaping_peak_bandwidth    = 10000000 -> null
      - iscsi_maximum_mbit                = -1 -> null
      - iscsi_reservation_mbit            = 0 -> null
      - iscsi_share_count                 = 50 -> null
      - iscsi_share_level                 = "normal" -> null
      - lacp_api_version                  = "multipleLag" -> null
      - lacp_enabled                      = true -> null
      - lacp_mode                         = "active" -> null
      - link_discovery_operation          = "listen" -> null
      - link_discovery_protocol           = "cdp" -> null
      - management_maximum_mbit           = -1 -> null
      - management_reservation_mbit       = 0 -> null
      - management_share_count            = 50 -> null
      - management_share_level            = "normal" -> null
      - max_mtu                           = 1500 -> null
      - multicast_filtering_mode          = "snooping" -> null
      - name                              = "testacc-dvs" -> null
      - netflow_active_flow_timeout       = 60 -> null
      - netflow_collector_port            = 0 -> null
      - netflow_enabled                   = true -> null
      - netflow_idle_flow_timeout         = 15 -> null
      - netflow_internal_flows_only       = false -> null
      - netflow_observation_domain_id     = 0 -> null
      - netflow_sampling_rate             = 0 -> null
      - network_resource_control_enabled  = false -> null
      - network_resource_control_version  = "version3" -> null
      - nfs_maximum_mbit                  = -1 -> null
      - nfs_reservation_mbit              = 0 -> null
      - nfs_share_count                   = 50 -> null
      - nfs_share_level                   = "normal" -> null
      - notify_switches                   = true -> null
      - standby_uplinks                   = [
          - "uplink3",
          - "uplink4",
        ] -> null
      - tags                              = [] -> null
      - teaming_policy                    = "failover_explicit" -> null
      - tx_uplink                         = true -> null
      - uplinks                           = [
          - "uplink1",
          - "uplink2",
          - "uplink3",
          - "uplink4",
        ] -> null
      - vdp_maximum_mbit                  = -1 -> null
      - vdp_reservation_mbit              = 0 -> null
      - vdp_share_count                   = 50 -> null
      - vdp_share_level                   = "normal" -> null
      - version                           = "8.0.3" -> null
      - virtualmachine_maximum_mbit       = -1 -> null
      - virtualmachine_reservation_mbit   = 0 -> null
      - virtualmachine_share_count        = 100 -> null
      - virtualmachine_share_level        = "high" -> null
      - vlan_id                           = 1000 -> null
      - vmotion_maximum_mbit              = -1 -> null
      - vmotion_reservation_mbit          = 0 -> null
      - vmotion_share_count               = 50 -> null
      - vmotion_share_level               = "normal" -> null
      - vsan_maximum_mbit                 = -1 -> null
      - vsan_reservation_mbit             = 0 -> null
      - vsan_share_count                  = 50 -> null
      - vsan_share_level                  = "normal" -> null
        # (6 unchanged attributes hidden)
    }

Plan: 0 to add, 0 to change, 2 to destroy.
vsphere_distributed_port_group.pg: Destroying... [id=dvportgroup-8139]
vsphere_distributed_port_group.pg: Destruction complete after 1s
vsphere_distributed_virtual_switch.dvs: Destroying... [id=50 1f 18 9d d6 5a a9 ae-c6 55 0e 73 31 fb 5e a6]
vsphere_distributed_virtual_switch.dvs: Destruction complete after 0s

Destroy complete! Resources: 2 destroyed
```

<!--
    Please provide the output of the acceptance tests as applicable.
-->

### Documentation

<!--
    Please check the one(s) that applies to this pull request using "x".
    For enhancements/features, please ensure that documentation has been updated.
-->

- [ ] Documentation has been added or updated.

### Issue References

<!--
    Is this related to any GitHub issue(s)? If so, please provide the issue number(s) that are closed or resolved by this pull request.

    For bug fixes and enhancements/features, please ensure that a GitHub issue has been created and provide the issue number(s) here.

    Please use the 'Closes', 'Resolves', or 'Fixes' keywords followed by the a hash and issue number.
    This will link the pull request to the issue(s) and automatically close them when the pull request is merged.

    Example:

    Closes #000
    Resolves #001
    Fixes #002
-->

### Release Note

<!--
    Please provide context for the release notes.

    For example:

    ```
    - `r/foo` - Added support for foo. (#xxx)
    ```
-->

### Additional Information

<!--
    Please provide any additional information that may be helpful.
-->
