### PR TITLE
fix: staticcheck S1040

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -87,9 +87,6 @@ linters:
       - linters:
           - staticcheck
         text: S1017
-      - linters:
-          - staticcheck
-        text: S1040
     paths:
       - third_party$
       - builtin$

--- a/vsphere/internal/virtualdevice/virtual_machine_device_subresource.go
+++ b/vsphere/internal/virtualdevice/virtual_machine_device_subresource.go
@@ -768,9 +768,9 @@ func ReadSCSIBusSharing(l object.VirtualDeviceList, count int) string {
 	if len(ctlrs) == 0 || ctlrs[0] == nil {
 		return subresourceControllerSharingUnknown
 	}
-	last := ctlrs[0].(types.BaseVirtualSCSIController).GetVirtualSCSIController().SharedBus
+	last := ctlrs[0].GetVirtualSCSIController().SharedBus
 	for _, ctlr := range ctlrs[1:] {
-		if ctlr == nil || ctlr.(types.BaseVirtualSCSIController).GetVirtualSCSIController().SharedBus != last {
+		if ctlr == nil || ctlr.GetVirtualSCSIController().SharedBus != last {
 			return subresourceControllerSharingMixed
 		}
 	}


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 no-inline-html -->

<!--
    NOTE: Do NOT enter content between the comment markers <!- and ->.

    In order to have the best experience with our community, we recommend that you read the code of
    conduct and contributing guidelines before submitting a pull request.

    By submitting this pull request, you confirm that you have read, understood, and agreed to the
    project's code of conduct and contributing guidelines.

    Please use conventional commits to format the title of the pull request and the commit messages.

    For more information, please refer to https://www.conventionalcommits.org and the contributing
    guidelines for this project.
-->

### Summary

Resolves `golangci-lint` identified issues for S1040: type assertion to the same type.

Before:

```shell
terraform-provider-vsphere on  chore/fix-staticcheck-S1040 via 🐹 v1.24.3 took 7.4s 
➜ golangci-lint run
vsphere/internal/virtualdevice/virtual_machine_device_subresource.go:771:10: S1040: type assertion to the same type: ctlrs[0] already has type types.BaseVirtualSCSIController (staticcheck)
        last := ctlrs[0].(types.BaseVirtualSCSIController).GetVirtualSCSIController().SharedBus
                ^
vsphere/internal/virtualdevice/virtual_machine_device_subresource.go:773:21: S1040: type assertion to the same type: ctlr already has type types.BaseVirtualSCSIController (staticcheck)
                if ctlr == nil || ctlr.(types.BaseVirtualSCSIController).GetVirtualSCSIController().SharedBus != last {
                                  ^
2 issues:
* staticcheck: 2
```

After:

```shell
terraform-provider-vsphere on  chore/fix-staticcheck-S1040 via 🐹 v1.24.3 took 7.4s 
➜ golangci-lint run
0 issues.
```

### Type

<!--
    Please check the one(s) that applies to this pull request using "x".
-->

- [ ] `fix`: Bug Fix
- [ ] `feat`: Feature or Enhancement
- [ ] `docs`: Documentation
- [ ] `refactor`: Refactoring
- [x] `chore`: Build, Dependencies, Workflows, etc.
- [ ] `other`: Other (Please describe.)

### Breaking Changes?

<!--
    Please check the one that applies to this pull request using "x".
    If this pull request contains a breaking change, please describe the impact and mitigation path.
-->

- [ ] Yes, there are breaking changes.
- [x] No, there are no breaking changes.

### Tests

<!--
    Please check the one(s) that applies to this pull request using "x".
    For bug fixes and enhancements/features, please ensure that tests and documentation have been completed and provide details.
-->

- [ ] Tests have been added or updated.
- [x] Tests have been completed.

Output:

<!--
    Please provide the output of the acceptance tests as applicable.
-->

### Documentation

<!--
    Please check the one(s) that applies to this pull request using "x".
    For enhancements/features, please ensure that documentation has been updated.
-->

- [ ] Documentation has been added or updated.

### Issue References

<!--
    Is this related to any GitHub issue(s)? If so, please provide the issue number(s) that are closed or resolved by this pull request.

    For bug fixes and enhancements/features, please ensure that a GitHub issue has been created and provide the issue number(s) here.

    Please use the 'Closes', 'Resolves', or 'Fixes' keywords followed by the a hash and issue number.
    This will link the pull request to the issue(s) and automatically close them when the pull request is merged.

    Example:

    Closes #000
    Resolves #001
    Fixes #002
-->

### Release Note

<!--
    Please provide context for the release notes.

    For example:

    ```
    - `r/foo` - Added support for foo. (#xxx)
    ```
-->

### Additional Information

<!--
    Please provide any additional information that may be helpful.
-->
