### PR TITLE
fix: staticcheck S1017

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -84,9 +84,6 @@ linters:
       - linters:
           - staticcheck
         text: S1009
-      - linters:
-          - staticcheck
-        text: S1017
     paths:
       - third_party$
       - builtin$

--- a/vsphere/resource_vsphere_virtual_machine.go
+++ b/vsphere/resource_vsphere_virtual_machine.go
@@ -43,13 +43,13 @@ import (
 // rollback fails on a post-clone virtual machine operation.
 const formatVirtualMachinePostCloneRollbackError = `warning:
 
-There was an error performing post-clone changes to virtual machine %q: %s. 
+There was an error performing post-clone changes to virtual machine %q: %s.
 
-Additionally, there was an error removing the cloned virtual machine: %s. 
+Additionally, there was an error removing the cloned virtual machine: %s.
 
-The virtual machine may still exist in state. 
+The virtual machine may still exist in state.
 
-If it does, the resource will need to be tainted before trying again. 
+If it does, the resource will need to be tainted before trying again.
 
 If the virtual machine does not exist in state, manually delete it to try again
 
@@ -1088,9 +1088,8 @@ func resourceVSphereVirtualMachineCustomizeDiff(_ context.Context, d *schema.Res
 			// For most cases (all non-imported workflows), any changed attribute in
 			// the clone configuration namespace is a ForceNew. Flag those now.
 			for _, k := range d.GetChangedKeysPrefix("clone.0") {
-				if strings.HasSuffix(k, ".#") {
-					k = strings.TrimSuffix(k, ".#")
-				}
+				k = strings.TrimSuffix(k, ".#")
+
 				// To maintain consistency with other timeout options, timeout does not
 				// need to ForceNew
 				if k == "clone.0.timeout" {


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 no-inline-html -->

<!--
    NOTE: Do NOT enter content between the comment markers <!- and ->.

    In order to have the best experience with our community, we recommend that you read the code of
    conduct and contributing guidelines before submitting a pull request.

    By submitting this pull request, you confirm that you have read, understood, and agreed to the
    project's code of conduct and contributing guidelines.

    Please use conventional commits to format the title of the pull request and the commit messages.

    For more information, please refer to https://www.conventionalcommits.org and the contributing
    guidelines for this project.
-->

### Summary

Resolves `golangci-lint` identified issues for S1017: `replace this if statement with an unconditional strings.TrimSuffix`.

Before:

```shell
terraform-provider-vsphere on  chore/fix-staticcheck-S1017 via 🐹 v1.24.3 took 14.3s 
➜ golangci-lint run
vsphere/resource_vsphere_virtual_machine.go:1091:5: S1017: should replace this if statement with an unconditional strings.TrimSuffix (staticcheck)
                                if strings.HasSuffix(k, ".#") {
                                ^
1 issues:
* staticcheck: 1
```

After:

```shell
terraform-provider-vsphere on  chore/fix-staticcheck-S1017 via 🐹 v1.24.3 took 14.3s 
➜ golangci-lint run
0 issues.
```

### Type

<!--
    Please check the one(s) that applies to this pull request using "x".
-->

- [ ] `fix`: Bug Fix
- [ ] `feat`: Feature or Enhancement
- [ ] `docs`: Documentation
- [ ] `refactor`: Refactoring
- [x] `chore`: Build, Dependencies, Workflows, etc.
- [ ] `other`: Other (Please describe.)

### Breaking Changes?

<!--
    Please check the one that applies to this pull request using "x".
    If this pull request contains a breaking change, please describe the impact and mitigation path.
-->

- [ ] Yes, there are breaking changes.
- [x] No, there are no breaking changes.

### Tests

<!--
    Please check the one(s) that applies to this pull request using "x".
    For bug fixes and enhancements/features, please ensure that tests and documentation have been completed and provide details.
-->

- [ ] Tests have been added or updated.
- [x] Tests have been completed.

Output:

<!--
    Please provide the output of the acceptance tests as applicable.
-->

### Documentation

<!--
    Please check the one(s) that applies to this pull request using "x".
    For enhancements/features, please ensure that documentation has been updated.
-->

- [ ] Documentation has been added or updated.

### Issue References

<!--
    Is this related to any GitHub issue(s)? If so, please provide the issue number(s) that are closed or resolved by this pull request.

    For bug fixes and enhancements/features, please ensure that a GitHub issue has been created and provide the issue number(s) here.

    Please use the 'Closes', 'Resolves', or 'Fixes' keywords followed by the a hash and issue number.
    This will link the pull request to the issue(s) and automatically close them when the pull request is merged.

    Example:

    Closes #000
    Resolves #001
    Fixes #002
-->

### Release Note

<!--
    Please provide context for the release notes.

    For example:

    ```
    - `r/foo` - Added support for foo. (#xxx)
    ```
-->

### Additional Information

<!--
    Please provide any additional information that may be helpful.
-->
