### PR TITLE
fix: staticcheck QF1005

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -61,9 +61,6 @@ linters:
           - staticcheck
         text: SA1019
       - linters:
-          - staticcheck
-        text: QF1005
-      - linters:
           - unused
         text: is unused
     paths:

--- a/vsphere/internal/helper/structure/structure_helper.go
+++ b/vsphere/internal/helper/structure/structure_helper.go
@@ -271,7 +271,7 @@ func ByteToMB(n interface{}) interface{} {
 func ByteToGiB(n interface{}) int {
 	switch n.(type) {
 	case int, int32, int64:
-		return int(math.Ceil(float64(n.(int64)) / math.Pow(1024, 3)))
+		return int(math.Ceil(float64(n.(int64)) / float64(1024*1024*1024)))
 	}
 	panic(fmt.Errorf("non-integer type %T for value", n))
 }
@@ -283,11 +283,11 @@ func ByteToGiB(n interface{}) int {
 func GiBToByte(n interface{}) int64 {
 	switch v := n.(type) {
 	case int:
-		return int64(v * int(math.Pow(1024, 3)))
+		return int64(v * int(float64(1024*1024*1024)))
 	case int32:
-		return int64(v * int32(math.Pow(1024, 3)))
+		return int64(v * int32(float64(1024*1024*1024)))
 	case int64:
-		return v * int64(math.Pow(1024, 3))
+		return v * int64(float64(1024*1024*1024))
 	}
 	panic(fmt.Errorf("non-integer type %T for value", n))
 }


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 no-inline-html -->

<!--
    NOTE: Do NOT enter content between the comment markers <!- and ->.

    In order to have the best experience with our community, we recommend that you read the code of
    conduct and contributing guidelines before submitting a pull request.

    By submitting this pull request, you confirm that you have read, understood, and agreed to the
    project's code of conduct and contributing guidelines.

    Please use conventional commits to format the title of the pull request and the commit messages.

    For more information, please refer to https://www.conventionalcommits.org and the contributing
    guidelines for this project.
-->

### Summary

Resolves `golangci-lint` identified issues for QF1005: `could expand call to math.Pow `.

Ref: [QF1005](https://staticcheck.dev/docs/checks#QF1005)

Before:

```shell
terraform-provider-vsphere on  fix/staticcheck-QF1005 [$] via 🐹 v1.24.3  
➜ golangci-lint run
vsphere/internal/helper/structure/structure_helper.go:274:45: QF1005: could expand call to math.Pow (staticcheck)
                return int(math.Ceil(float64(n.(int64)) / math.Pow(1024, 3)))
                                                          ^
vsphere/internal/helper/structure/structure_helper.go:286:24: QF1005: could expand call to math.Pow (staticcheck)
                return int64(v * int(math.Pow(1024, 3)))
                                     ^
vsphere/internal/helper/structure/structure_helper.go:288:26: QF1005: could expand call to math.Pow (staticcheck)
                return int64(v * int32(math.Pow(1024, 3)))
                                       ^
vsphere/internal/helper/structure/structure_helper.go:290:20: QF1005: could expand call to math.Pow (staticcheck)
                return v * int64(math.Pow(1024, 3))
                                 ^
4 issues:
* staticcheck: 4
```

After:

```shell
terraform-provider-vsphere on  fix/staticcheck-QF1005 [$] via 🐹 v1.24.3 
➜ golangci-lint run --fix
0 issues.

terraform-provider-vsphere on  fix/staticcheck-QF1005 [$] via 🐹 v1.24.3 
➜ golangci-lint run      
0 issues.
```

### Type

<!--
    Please check the one(s) that applies to this pull request using "x".
-->

- [ ] `fix`: Bug Fix
- [ ] `feat`: Feature or Enhancement
- [ ] `docs`: Documentation
- [x] `refactor`: Refactoring
- [ ] `chore`: Build, Dependencies, Workflows, etc.
- [ ] `other`: Other (Please describe.)

### Breaking Changes?

<!--
    Please check the one that applies to this pull request using "x".
    If this pull request contains a breaking change, please describe the impact and mitigation path.
-->

- [ ] Yes, there are breaking changes.
- [x] No, there are no breaking changes.

### Tests

<!--
    Please check the one(s) that applies to this pull request using "x".
    For bug fixes and enhancements/features, please ensure that tests and documentation have been completed and provide details.
-->

- [ ] Tests have been added or updated.
- [ ] Tests have been completed.

Output:

<!--
    Please provide the output of the acceptance tests as applicable.
-->

### Documentation

<!--
    Please check the one(s) that applies to this pull request using "x".
    For enhancements/features, please ensure that documentation has been updated.
-->

- [ ] Documentation has been added or updated.

### Issue References

<!--
    Is this related to any GitHub issue(s)? If so, please provide the issue number(s) that are closed or resolved by this pull request.

    For bug fixes and enhancements/features, please ensure that a GitHub issue has been created and provide the issue number(s) here.

    Please use the 'Closes', 'Resolves', or 'Fixes' keywords followed by the a hash and issue number.
    This will link the pull request to the issue(s) and automatically close them when the pull request is merged.

    Example:

    Closes #000
    Resolves #001
    Fixes #002
-->

### Release Note

<!--
    Please provide context for the release notes.

    For example:

    ```
    - `r/foo` - Added support for foo. (#xxx)
    ```
-->

### Additional Information

<!--
    Please provide any additional information that may be helpful.
-->
