### PR TITLE
fix: gosec g402

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -29,7 +29,7 @@ linters:
       # Exclude specific rules to suppress false positives or acceptable issues.
       - linters:
           - gosec
-        text: G115|G401|G402
+        text: G115|G401
       - linters:
           - staticcheck
         text: SA1019

--- a/vsphere/data_source_vsphere_host_thumbprint.go
+++ b/vsphere/data_source_vsphere_host_thumbprint.go
@@ -40,7 +40,9 @@ func dataSourceVSphereHostThumbprint() *schema.Resource {
 }
 
 func dataSourceVSphereHostThumbprintRead(d *schema.ResourceData, _ interface{}) error {
-	config := &tls.Config{}
+	config := &tls.Config{
+		MinVersion: tls.VersionTLS12, // Enforce TLS 1.2 or higher.
+	}
 	config.InsecureSkipVerify = d.Get("insecure").(bool)
 	conn, err := tls.Dial("tcp", d.Get("address").(string)+":"+d.Get("port").(string), config)
 	if err != nil {

--- a/vsphere/internal/helper/ovfdeploy/ovf_helper.go
+++ b/vsphere/internal/helper/ovfdeploy/ovf_helper.go
@@ -387,7 +387,7 @@ func GetNetworkMapping(client *govmomi.Client, m map[string]interface{}) ([]type
 func getClient(allowUnverifiedSSL bool) *http.Client {
 	if allowUnverifiedSSL {
 		tr := &http.Transport{
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint (gosec G402)
 		}
 		return &http.Client{Transport: tr}
 	}

--- a/vsphere/resource_vsphere_host.go
+++ b/vsphere/resource_vsphere_host.go
@@ -871,7 +871,9 @@ func buildHostConnectSpec(d *schema.ResourceData) (types.HostConnectSpec, error)
 }
 
 func getHostThumbprint(d *schema.ResourceData) (string, error) {
-	config := &tls.Config{}
+	config := &tls.Config{
+		MinVersion: tls.VersionTLS12, // Enforce TLS 1.2 or higher.
+	}
 
 	// Check the hostname.
 	address, ok := d.Get("hostname").(string)


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 no-inline-html -->

<!--
    NOTE: Do NOT enter content between the comment markers <!- and ->.

    In order to have the best experience with our community, we recommend that you read the code of
    conduct and contributing guidelines before submitting a pull request.

    By submitting this pull request, you confirm that you have read, understood, and agreed to the
    project's code of conduct and contributing guidelines.

    Please use conventional commits to format the title of the pull request and the commit messages.

    For more information, please refer to https://www.conventionalcommits.org and the contributing
    guidelines for this project.
-->

### Summary

- Enforce TLS 1.2 or higher.
- Ignored the use of `InsecureSkipVerify` as this is for the non-default `allow_unverified_ssl` provider configuration option.

> [!IMPORTANT]
>
> VMware vSphere 7.0:
> - TLS 1.2 is enabled by default.
> - TLS 1.0 and TLS 1.1 are disabled by default. 
> - You can use the TLS Configurator utility to enable older versions of the protocol temporarily. You can then disable the older less secure versions after all connections use TLS 1.2.  
>
> VMware vSphere 8.0:
> - TLS 1.2 is enabled by default.
> - Cannot be downgraded to support TLS 1.0 or 1.1.


### Type

<!--
    Please check the one(s) that applies to this pull request using "x".
-->

- [x] `fix`: Bug Fix
- [ ] `feat`: Feature or Enhancement
- [ ] `docs`: Documentation
- [ ] `refactor`: Refactoring
- [ ] `chore`: Build, Dependencies, Workflows, etc.
- [ ] `other`: Other (Please describe.)

### Breaking Changes?

<!--
    Please check the one that applies to this pull request using "x".
    If this pull request contains a breaking change, please describe the impact and mitigation path.
-->

- [ ] Yes, there are breaking changes.
- [x] No, there are no breaking changes.

### Tests

<!--
    Please check the one(s) that applies to this pull request using "x".
    For bug fixes and enhancements/features, please ensure that tests and documentation have been completed and provide details.
-->

- [ ] Tests have been added or updated.
- [x] Tests have been completed.

```shell
PS F:\Code\test\host> terraform plan
╷
│ Warning: Provider development overrides are in effect
│
│ The following provider development overrides are set in the CLI configuration:
│  - hashicorp/vsphere in C:\Users\Administrator\go\bin
│
│ The behavior may therefore not match any released version of the provider and applying changes may cause the state to become incompatible with published releases.
╵
data.vsphere_host_thumbprint.thumbprint: Reading...
data.vsphere_host_thumbprint.thumbprint: Read complete after 0s [id=C1:DC:8D:42:31:35:D1:DA:5C:C7:27:14:C3:B8:0F:11:A3:77:CD:86]

Changes to Outputs:
  + name = {
      + address  = "sfo01-w01-r01-esx02.sfo.rainpole.io"
      + id       = "C1:DC:8D:42:31:35:D1:DA:5C:C7:27:14:C3:B8:0F:11:A3:77:CD:86"
      + insecure = false
      + port     = "443"
    }

You can apply this plan to save these new output values to the Terraform state, without changing any real infrastructure.

─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── 

Note: You didn't use the -out option to save this plan, so Terraform can't guarantee to take exactly these actions if you run "terraform apply" now.
PS F:\Code\test\host> terraform apply --auto-approve  
╷
│ Warning: Provider development overrides are in effect
│
│ The following provider development overrides are set in the CLI configuration:
│  - hashicorp/vsphere in C:\Users\Administrator\go\bin
│
│ The behavior may therefore not match any released version of the provider and applying changes may cause the state to become incompatible with published releases.
╵
data.vsphere_host_thumbprint.thumbprint: Reading...
data.vsphere_host_thumbprint.thumbprint: Read complete after 0s [id=C1:DC:8D:42:31:35:D1:DA:5C:C7:27:14:C3:B8:0F:11:A3:77:CD:86]

Changes to Outputs:
  + name = {
      + address  = "sfo01-w01-r01-esx02.sfo.rainpole.io"
      + id       = "C1:DC:8D:42:31:35:D1:DA:5C:C7:27:14:C3:B8:0F:11:A3:77:CD:86"
      + insecure = false
      + port     = "443"
    }

You can apply this plan to save these new output values to the Terraform state, without changing any real infrastructure.

Apply complete! Resources: 0 added, 0 changed, 0 destroyed.

Outputs:

name = {
  "address" = "sfo01-w01-r01-esx02.sfo.rainpole.io"
  "id" = "C1:DC:8D:42:31:35:D1:DA:5C:C7:27:14:C3:B8:0F:11:A3:77:CD:86"
  "insecure" = false
  "port     = "443"
}

<!--
    Please provide the output of the acceptance tests as applicable.
-->

### Documentation

<!--
    Please check the one(s) that applies to this pull request using "x".
    For enhancements/features, please ensure that documentation has been updated.
-->

- [ ] Documentation has been added or updated.

### Issue References

<!--
    Is this related to any GitHub issue(s)? If so, please provide the issue number(s) that are closed or resolved by this pull request.

    For bug fixes and enhancements/features, please ensure that a GitHub issue has been created and provide the issue number(s) here.

    Please use the 'Closes', 'Resolves', or 'Fixes' keywords followed by the a hash and issue number.
    This will link the pull request to the issue(s) and automatically close them when the pull request is merged.

    Example:

    Closes #000
    Resolves #001
    Fixes #002
-->

### Release Note

<!--
    Please provide context for the release notes.

    For example:

    ```
    - `r/foo` - Added support for foo. (#xxx)
    ```
-->

### Additional Information

<!--
    Please provide any additional information that may be helpful.
-->
