### PR TITLE
fix: address G107 gosec warnings in HTTP requests

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -35,9 +35,6 @@ linters:
       # TODO: Setting temporary exclusions for specific linters.
       - linters:
           - gosec
-        text: G107
-      - linters:
-          - gosec
         text: G115
       - linters:
           - gosec

--- a/vsphere/internal/helper/contentlibrary/content_library_helper.go
+++ b/vsphere/internal/helper/contentlibrary/content_library_helper.go
@@ -370,7 +370,12 @@ func (uploadSession libraryUploadSession) uploadOvaDisksFromLocal(ovaFilePath st
 }
 
 func (uploadSession libraryUploadSession) uploadOvaDisksFromURL(ovfFilePath string, diskName string, size int64) error {
-	resp, err := http.Get(ovfFilePath)
+	client := &http.Client{}
+	req, err := http.NewRequest("GET", ovfFilePath, nil)
+	if err != nil {
+		return fmt.Errorf("error creating request for %s: %w", ovfFilePath, err)
+	}
+	resp, err := client.Do(req)
 	if err != nil {
 		return fmt.Errorf("error performing GET request to %s: %w", ovfFilePath, err)
 	}

--- a/vsphere/resource_vsphere_content_library_item_test.go
+++ b/vsphere/resource_vsphere_content_library_item_test.go
@@ -144,7 +144,12 @@ func testAccResourceVSphereContentLibraryItemGetOva() {
 }
 
 func testAccResourceVSphereContentLibraryItemGetFile(url, file string) error {
-	resp, err := http.Get(url)
+	client := &http.Client{}
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return err
+	}
+	resp, err := client.Do(req)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 no-inline-html -->

<!--
    NOTE: Do NOT enter content between the comment markers <!- and ->.

    In order to have the best experience with our community, we recommend that you read the code of
    conduct and contributing guidelines before submitting a pull request.

    By submitting this pull request, you confirm that you have read, understood, and agreed to the
    project's code of conduct and contributing guidelines.

    Please use conventional commits to format the title of the pull request and the commit messages.

    For more information, please refer to https://www.conventionalcommits.org and the contributing
    guidelines for this project.
-->

### Summary

Replace direct `http.Get()` calls with `http.Client` and explicit `http.NewRequest` to address G107 warnings (Potential HTTP request made with variable URL).

Before:

```shell
terraform-provider-vsphere on  fix/gosec-G107 [$!] via 🐹 v1.24.3 took 3.9s 
➜ golangci-lint run
vsphere/internal/helper/contentlibrary/content_library_helper.go:373:15: G107: Potential HTTP request made with variable url (gosec)
        resp, err := http.Get(ovfFilePath)
                     ^
vsphere/resource_vsphere_content_library_item_test.go:147:15: G107: Potential HTTP request made with variable url (gosec)
        resp, err := http.Get(url)
                     ^
2 issues:
* gosec: 2
```

After:

```shell
terraform-provider-vsphere on  fix/gosec-G107 [$] via 🐹 v1.24.3 took 2.3s 
➜ golangci-lint run
0 issues.
```

### Type

<!--
    Please check the one(s) that applies to this pull request using "x".
-->

- [x] `fix`: Bug Fix
- [ ] `feat`: Feature or Enhancement
- [ ] `docs`: Documentation
- [ ] `refactor`: Refactoring
- [ ] `chore`: Build, Dependencies, Workflows, etc.
- [ ] `other`: Other (Please describe.)

### Breaking Changes?

<!--
    Please check the one that applies to this pull request using "x".
    If this pull request contains a breaking change, please describe the impact and mitigation path.
-->

- [ ] Yes, there are breaking changes.
- [x] No, there are no breaking changes.

### Tests

<!--
    Please check the one(s) that applies to this pull request using "x".
    For bug fixes and enhancements/features, please ensure that tests and documentation have been completed and provide details.
-->

- [ ] Tests have been added or updated.
- [x] Tests have been completed.

Output:

```shell
Running tool: /usr/local/bin/go test -timeout 30s -run ^TestAccResourceVSphereContentLibraryItem_localOva$ github.com/vmware/terraform-provider-vsphere/vsphere

ok  	github.com/vmware/terraform-provider-vsphere/vsphere	0.563s
```

<!--
    Please provide the output of the acceptance tests as applicable.
-->

### Documentation

<!--
    Please check the one(s) that applies to this pull request using "x".
    For enhancements/features, please ensure that documentation has been updated.
-->

- [ ] Documentation has been added or updated.

### Issue References

<!--
    Is this related to any GitHub issue(s)? If so, please provide the issue number(s) that are closed or resolved by this pull request.

    For bug fixes and enhancements/features, please ensure that a GitHub issue has been created and provide the issue number(s) here.

    Please use the 'Closes', 'Resolves', or 'Fixes' keywords followed by the a hash and issue number.
    This will link the pull request to the issue(s) and automatically close them when the pull request is merged.

    Example:

    Closes #000
    Resolves #001
    Fixes #002
-->

### Release Note

<!--
    Please provide context for the release notes.

    For example:

    ```
    - `r/foo` - Added support for foo. (#xxx)
    ```
-->

### Additional Information

<!--
    Please provide any additional information that may be helpful.
-->
