### PR TITLE
refactor: create a stable suite of tests

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -20,6 +20,6 @@ Run `terraform apply` using the configuration provided in `main.tf` to prepare t
 
 ## Run Acceptance Tests
 
-Set the missing values in `setup_env_vars.sh` and source the file.
+Set the missing values in `setup_env_vars.sh`.
 
 Execute `run_tests.sh` to run the full test suite or add the `-run` parameter to the `go test` command to run a subset of tests.

--- a/tests/main.tf
+++ b/tests/main.tf
@@ -61,6 +61,7 @@ resource "vsphere_compute_cluster" "cluster" {
   name          = "acc-test-cluster"
 
   ha_enabled = true
+  drs_enabled = true
 
   host_system_ids = [
     vsphere_host.host1.id,

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -1,2 +1,3 @@
 #!/usr/bin/env bash
-TF_ACC=1 go test -json -v ../../vsphere -timeout 360m 2>&1 | tee gotest.log | gotestfmt
+. setup_env_vars.sh
+TF_ACC=1 go test -run -json -v ../vsphere -timeout 360m 2>&1 | tee gotest.log | gotestfmt

--- a/tests/setup_env_vars.sh
+++ b/tests/setup_env_vars.sh
@@ -1,19 +1,24 @@
 #!/usr/bin/env bash
 export TF_ACC=1
 export TF_LOG=INFO
-export TF_VAR_STORAGE_POLICY=vSAN Default Storage Policy
+export TF_VAR_STORAGE_POLICY="vSAN Default Storage Policy"
 export TF_VAR_VSPHERE_CLUSTER=acc-test-cluster
 export TF_VAR_VSPHERE_DATACENTER=acc-test-dc
 export TF_VAR_VSPHERE_ESXI1=
+export TF_VAR_VSPHERE_ESXI1_PASSWORD=
 export TF_VAR_VSPHERE_ESXI2=
+export TF_VAR_VSPHERE_ESXI2_PASSWORD=
 export TF_VAR_VSPHERE_ESXI3=
+export TF_VAR_VSPHERE_ESXI3_PASSWORD=
 export TF_VAR_VSPHERE_ESXI4=
+export TF_VAR_VSPHERE_ESXI4_PASSWORD=
 export TF_VAR_VSPHERE_NAS_HOST=
-export TF_VAR_VSPHERE_NFS_DS_NAME="acc-test-nfs"
-export TF_VAR_VSPHERE_PG_NAME='VM Network'
-export TF_VAR_VSPHERE_RESOURCE_POOL=New Resource Pool
+export TF_VAR_VSPHERE_NFS_DS_NAME=acc-test-nfs
+export TF_VAR_VSPHERE_PG_NAME="VM Network"
+export TF_VAR_VSPHERE_RESOURCE_POOL="New Resource Pool"
+export TF_VAR_VSPHERE_DS_VMFS_ESXI1_DISK0="mpx.vmhba0:C0:T1:L0"
+export TF_VAR_VSPHERE_SKIP_UNSTABLE_TESTS=true
 export VSPHERE_ALLOW_UNVERIFIED_SSL=true
 export VSPHERE_PASSWORD=
 export VSPHERE_SERVER=
-export VSPHERE_USER=administrator@vsphere.local
-
+export VSPHERE_USER=

--- a/vsphere/data_source_vsphere_compute_cluster_host_group_test.go
+++ b/vsphere/data_source_vsphere_compute_cluster_host_group_test.go
@@ -14,6 +14,7 @@ import (
 )
 
 func TestAccDataSourceVSphereComputeClusterHostGroup_basic(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()

--- a/vsphere/data_source_vsphere_compute_cluster_test.go
+++ b/vsphere/data_source_vsphere_compute_cluster_test.go
@@ -6,6 +6,7 @@ package vsphere
 
 import (
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -13,11 +14,11 @@ import (
 )
 
 func TestAccDataSourceVSphereComputeCluster_basic(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
 			testAccPreCheck(t)
-			testAccResourceVSphereComputeClusterPreCheck(t)
 		},
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
@@ -39,6 +40,7 @@ func TestAccDataSourceVSphereComputeCluster_basic(t *testing.T) {
 }
 
 func TestAccDataSourceVSphereComputeCluster_absolutePathNoDatacenter(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -68,17 +70,13 @@ func testAccDataSourceVSphereComputeClusterConfigBasic() string {
 	return fmt.Sprintf(`
 %s
 
-resource "vsphere_compute_cluster" "compute_cluster" {
-  name          = "testacc-datastore-cluster"
-  datacenter_id = data.vsphere_datacenter.rootdc1.id
-}
-
 data "vsphere_compute_cluster" "compute_cluster_data" {
-  name          = vsphere_compute_cluster.compute_cluster.name
+  name          = "%s"
   datacenter_id = vsphere_compute_cluster.compute_cluster.datacenter_id
 }
 `,
 		testhelper.CombineConfigs(testhelper.ConfigDataRootDC1(), testhelper.ConfigDataRootPortGroup1()),
+		os.Getenv("TF_VAR_VSPHERE_CLUSTER"),
 	)
 }
 
@@ -92,8 +90,9 @@ resource "vsphere_compute_cluster" "compute_cluster" {
 }
 
 data "vsphere_compute_cluster" "compute_cluster_data" {
-  name = "/${data.vsphere_datacenter.rootdc1.name}/host/${vsphere_compute_cluster.compute_cluster.name}"
+  name          = "/${data.vsphere_datacenter.rootdc1.name}/host/${vsphere_compute_cluster.compute_cluster.name}"
 }
-`, testhelper.CombineConfigs(testhelper.ConfigDataRootDC1(), testhelper.ConfigDataRootPortGroup1()),
+`,
+		testhelper.CombineConfigs(testhelper.ConfigDataRootDC1(), testhelper.ConfigDataRootPortGroup1()),
 	)
 }

--- a/vsphere/data_source_vsphere_content_library_item_test.go
+++ b/vsphere/data_source_vsphere_content_library_item_test.go
@@ -14,6 +14,7 @@ import (
 )
 
 func TestAccDataSourceVSphereContentLibraryItem_basic(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()

--- a/vsphere/data_source_vsphere_content_library_test.go
+++ b/vsphere/data_source_vsphere_content_library_test.go
@@ -39,7 +39,7 @@ func testAccDataSourceVSphereContentLibraryConfig() string {
 
 resource "vsphere_content_library" "library" {
   name            = "ContentLibrary_test"
-  storage_backing = [vsphere_nas_datastore.ds1.id]
+  storage_backing = [ data.vsphere_datastore.rootds1.id ]
   description     = "Library Description"
 }
 
@@ -47,7 +47,7 @@ data "vsphere_content_library" "library" {
   name = vsphere_content_library.library.name
 }
 
-
-`, testhelper.CombineConfigs(testhelper.ConfigDataRootDC1(), testhelper.ConfigDataRootHost1(), testhelper.ConfigResDS1(), testhelper.ConfigDataRootComputeCluster1(), testhelper.ConfigResResourcePool1(), testhelper.ConfigDataRootPortGroup1()),
+`,
+		testhelper.CombineConfigs(testhelper.ConfigDataRootDC1(), testhelper.ConfigDataRootHost1(), testhelper.ConfigDataRootDS1(), testhelper.ConfigDataRootComputeCluster1(), testhelper.ConfigResResourcePool1(), testhelper.ConfigDataRootPortGroup1()),
 	)
 }

--- a/vsphere/data_source_vsphere_datacenter_test.go
+++ b/vsphere/data_source_vsphere_datacenter_test.go
@@ -20,7 +20,6 @@ func TestAccDataSourceVSphereDatacenter_basic(t *testing.T) {
 		PreCheck: func() {
 			RunSweepers()
 			testAccPreCheck(t)
-			testAccDataSourceVSphereDatacenterPreCheck(t)
 		},
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
@@ -39,6 +38,7 @@ func TestAccDataSourceVSphereDatacenter_basic(t *testing.T) {
 }
 
 func TestAccDataSourceVSphereDatacenter_defaultDatacenter(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -68,6 +68,7 @@ func testAccDataSourceVSphereDatacenterPreCheck(t *testing.T) {
 }
 
 func TestAccDataSourceVSphereDatacenter_getVirtualMachines(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()

--- a/vsphere/data_source_vsphere_datastore_cluster_test.go
+++ b/vsphere/data_source_vsphere_datastore_cluster_test.go
@@ -14,6 +14,7 @@ import (
 )
 
 func TestAccDataSourceVSphereDatastoreCluster_basic(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -36,6 +37,7 @@ func TestAccDataSourceVSphereDatastoreCluster_basic(t *testing.T) {
 }
 
 func TestAccDataSourceVSphereDatastoreCluster_absolutePathNoDatacenter(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -57,6 +59,7 @@ func TestAccDataSourceVSphereDatastoreCluster_absolutePathNoDatacenter(t *testin
 	})
 }
 func TestAccDataSourceVSphereDatastoreCluster_getDatastores(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()

--- a/vsphere/data_source_vsphere_datastore_stats_test.go
+++ b/vsphere/data_source_vsphere_datastore_stats_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 func TestAccDataSourceVSphereDatastoreStats_basic(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()

--- a/vsphere/data_source_vsphere_datastore_test.go
+++ b/vsphere/data_source_vsphere_datastore_test.go
@@ -18,7 +18,6 @@ func TestAccDataSourceVSphereDatastore_basic(t *testing.T) {
 		PreCheck: func() {
 			RunSweepers()
 			testAccPreCheck(t)
-			testAccDataSourceVSphereDatastorePreCheck(t)
 		},
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
@@ -27,7 +26,7 @@ func TestAccDataSourceVSphereDatastore_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(
 						"data.vsphere_datastore.datastore_data", "id",
-						"vsphere_nas_datastore.ds1", "id",
+						"data.vsphere_datastore.rootds1", "id",
 					),
 				),
 			},
@@ -36,6 +35,7 @@ func TestAccDataSourceVSphereDatastore_basic(t *testing.T) {
 }
 
 func TestAccDataSourceVSphereDatastore_noDatacenterAndAbsolutePath(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -58,6 +58,7 @@ func TestAccDataSourceVSphereDatastore_noDatacenterAndAbsolutePath(t *testing.T)
 }
 
 func TestAccDataSourceVSphereDatastore_getStats(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -93,11 +94,11 @@ func testAccDataSourceVSphereDatastoreConfig() string {
 %s
 
 data "vsphere_datastore" "datastore_data" {
-  name          = vsphere_nas_datastore.ds1.name
+  name          = data.vsphere_datastore.rootds1.name
   datacenter_id = data.vsphere_datacenter.rootdc1.id
 }
 `,
-		testhelper.CombineConfigs(testhelper.ConfigDataRootDC1(), testhelper.ConfigDataRootHost1(), testhelper.ConfigDataRootHost2(), testhelper.ConfigResDS1(), testhelper.ConfigDataRootComputeCluster1(), testhelper.ConfigResResourcePool1(), testhelper.ConfigDataRootPortGroup1()),
+		testhelper.CombineConfigs(testhelper.ConfigDataRootDC1(), testhelper.ConfigDataRootDS1()),
 	)
 }
 

--- a/vsphere/data_source_vsphere_distributed_virtual_switch_test.go
+++ b/vsphere/data_source_vsphere_distributed_virtual_switch_test.go
@@ -31,12 +31,12 @@ func TestAccDataSourceVSphereDistributedVirtualSwitch_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"data.vsphere_distributed_virtual_switch.dvs-data",
 						"uplinks.0",
-						testhelper.HostNic0,
+						testhelper.HostNic1,
 					),
 					resource.TestCheckResourceAttr(
 						"data.vsphere_distributed_virtual_switch.dvs-data",
 						"uplinks.1",
-						testhelper.HostNic1,
+						testhelper.HostNic2,
 					),
 					resource.TestCheckResourceAttrPair(
 						"data.vsphere_distributed_virtual_switch.dvs-data", "id",
@@ -49,6 +49,7 @@ func TestAccDataSourceVSphereDistributedVirtualSwitch_basic(t *testing.T) {
 }
 
 func TestAccDataSourceVSphereDistributedVirtualSwitch_absolutePathNoDatacenterSpecified(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -85,6 +86,7 @@ func TestAccDataSourceVSphereDistributedVirtualSwitch_absolutePathNoDatacenterSp
 }
 
 func TestAccDataSourceVSphereDistributedVirtualSwitch_CreatePortgroup(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -137,8 +139,8 @@ data "vsphere_distributed_virtual_switch" "dvs-data" {
 }
 `,
 		testhelper.CombineConfigs(testhelper.ConfigDataRootDC1(), testhelper.ConfigDataRootPortGroup1()),
-		testhelper.HostNic0,
 		testhelper.HostNic1,
+		testhelper.HostNic2,
 	)
 }
 

--- a/vsphere/data_source_vsphere_dynamic_test.go
+++ b/vsphere/data_source_vsphere_dynamic_test.go
@@ -17,6 +17,9 @@ import (
 func TestAccDataSourceVSphereDynamic_regexAndTag(t *testing.T) {
 	t.Cleanup(RunSweepers)
 	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
@@ -37,7 +40,11 @@ func TestAccDataSourceVSphereDynamic_regexAndTag(t *testing.T) {
 
 func TestAccDataSourceVSphereDynamic_multiTag(t *testing.T) {
 	t.Cleanup(RunSweepers)
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
@@ -57,8 +64,12 @@ func TestAccDataSourceVSphereDynamic_multiTag(t *testing.T) {
 }
 
 func TestAccDataSourceVSphereDynamic_multiResult(t *testing.T) {
+	testAccSkipUnstable(t)
 	t.Cleanup(RunSweepers)
 	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
@@ -74,7 +85,11 @@ func TestAccDataSourceVSphereDynamic_multiResult(t *testing.T) {
 
 func TestAccDataSourceVSphereDynamic_typeFilter(t *testing.T) {
 	t.Cleanup(RunSweepers)
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{

--- a/vsphere/data_source_vsphere_folder_test.go
+++ b/vsphere/data_source_vsphere_folder_test.go
@@ -20,7 +20,6 @@ func TestAccDataSourceVSphereFolder_basic(t *testing.T) {
 		PreCheck: func() {
 			RunSweepers()
 			testAccPreCheck(t)
-			testAccDataSourceVSphereFolderPreCheck(t)
 		},
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
@@ -36,12 +35,6 @@ func TestAccDataSourceVSphereFolder_basic(t *testing.T) {
 			},
 		},
 	})
-}
-
-func testAccDataSourceVSphereFolderPreCheck(t *testing.T) {
-	if os.Getenv("TF_VAR_VSPHERE_DATACENTER") == "" {
-		t.Skip("set TF_VAR_VSPHERE_DATACENTER to run vsphere_folder acceptance tests")
-	}
 }
 
 func testAccDataSourceVSphereFolderConfig() string {

--- a/vsphere/data_source_vsphere_guest_os_customization_test.go
+++ b/vsphere/data_source_vsphere_guest_os_customization_test.go
@@ -14,6 +14,7 @@ import (
 
 func TestAccDataSourceVSphereGOSC_basic(t *testing.T) {
 	goscName := acctest.RandomWithPrefix("lin")
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()

--- a/vsphere/data_source_vsphere_host_test.go
+++ b/vsphere/data_source_vsphere_host_test.go
@@ -19,7 +19,6 @@ func TestAccDataSourceVSphereHost_basic(t *testing.T) {
 		PreCheck: func() {
 			RunSweepers()
 			testAccPreCheck(t)
-			testAccDataSourceVSphereHostPreCheck(t)
 		},
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
@@ -38,6 +37,7 @@ func TestAccDataSourceVSphereHost_basic(t *testing.T) {
 }
 
 func TestAccDataSourceVSphereHost_defaultHost(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -85,7 +85,7 @@ data "vsphere_host" "host" {
   name          = "%s"
   datacenter_id = data.vsphere_datacenter.rootdc1.id
 }
-`, testhelper.CombineConfigs(testhelper.ConfigDataRootDC1(), testhelper.ConfigDataRootPortGroup1()), os.Getenv("TF_VAR_VSPHERE_ESXI1"))
+`, testhelper.ConfigDataRootDC1(), os.Getenv("TF_VAR_VSPHERE_ESXI1"))
 }
 
 func testAccDataSourceVSphereHostConfigDefault() string {

--- a/vsphere/data_source_vsphere_host_thumbprint_test.go
+++ b/vsphere/data_source_vsphere_host_thumbprint_test.go
@@ -17,7 +17,6 @@ func TestAccDataSourceVSphereHostThumbprint_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
-			testAccDataSourceVSphereHostThumbprintPreCheck(t)
 		},
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
@@ -29,12 +28,6 @@ func TestAccDataSourceVSphereHostThumbprint_basic(t *testing.T) {
 			},
 		},
 	})
-}
-
-func testAccDataSourceVSphereHostThumbprintPreCheck(t *testing.T) {
-	if os.Getenv("TF_VAR_VSPHERE_ESXI1") == "" {
-		t.Skip("set TF_VAR_VSPHERE_ESXI1 to run vsphere_host_thumbprint acceptance tests")
-	}
 }
 
 func testAccDataSourceVSphereHostThumbprintConfig() string {

--- a/vsphere/data_source_vsphere_license_test.go
+++ b/vsphere/data_source_vsphere_license_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 func TestAccDataSourceVSphereLicense_basic(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()

--- a/vsphere/data_source_vsphere_network_test.go
+++ b/vsphere/data_source_vsphere_network_test.go
@@ -38,6 +38,7 @@ func TestAccDataSourceVSphereNetwork_dvsPortgroup(t *testing.T) {
 }
 
 func TestAccDataSourceVSphereNetwork_withTimeout(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -62,6 +63,7 @@ func TestAccDataSourceVSphereNetwork_withTimeout(t *testing.T) {
 }
 
 func TestAccDataSourceVSphereNetwork_absolutePathNoDatacenter(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -86,6 +88,7 @@ func TestAccDataSourceVSphereNetwork_absolutePathNoDatacenter(t *testing.T) {
 }
 
 func TestAccDataSourceVSphereNetwork_hostPortgroups(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()

--- a/vsphere/data_source_vsphere_resource_pool_test.go
+++ b/vsphere/data_source_vsphere_resource_pool_test.go
@@ -19,7 +19,6 @@ func TestAccDataSourceVSphereResourcePool_basic(t *testing.T) {
 		PreCheck: func() {
 			RunSweepers()
 			testAccPreCheck(t)
-			testAccDataSourceVSphereResourcePoolPreCheck(t)
 			testAccSkipIfEsxi(t)
 		},
 		Providers: testAccProviders,
@@ -35,6 +34,7 @@ func TestAccDataSourceVSphereResourcePool_basic(t *testing.T) {
 }
 
 func TestAccDataSourceVSphereResourcePool_noDatacenterAndAbsolutePath(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -55,6 +55,7 @@ func TestAccDataSourceVSphereResourcePool_noDatacenterAndAbsolutePath(t *testing
 }
 
 func TestAccDataSourceVSphereResourcePool_withParentId(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -80,6 +81,7 @@ func TestAccDataSourceVSphereResourcePool_withParentId(t *testing.T) {
 }
 
 func TestAccDataSourceVSphereResourcePool_withParentIdAndNamePathError(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -99,6 +101,7 @@ func TestAccDataSourceVSphereResourcePool_withParentIdAndNamePathError(t *testin
 }
 
 func TestAccDataSourceVSphereResourcePool_withParentIdAndMissingNameError(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -118,6 +121,7 @@ func TestAccDataSourceVSphereResourcePool_withParentIdAndMissingNameError(t *tes
 }
 
 func TestAccDataSourceVSphereResourcePool_withInvalidParentIdError(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -136,6 +140,7 @@ func TestAccDataSourceVSphereResourcePool_withInvalidParentIdError(t *testing.T)
 }
 
 func TestAccDataSourceVSphereResourcePool_withParentIdAndNotFoundNameError(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -154,6 +159,7 @@ func TestAccDataSourceVSphereResourcePool_withParentIdAndNotFoundNameError(t *te
 }
 
 func TestAccDataSourceVSphereResourcePool_defaultResourcePoolForESXi(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -174,6 +180,7 @@ func TestAccDataSourceVSphereResourcePool_defaultResourcePoolForESXi(t *testing.
 }
 
 func TestAccDataSourceVSphereResourcePool_emptyNameOnVCenterShouldError(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -208,18 +215,17 @@ func testAccDataSourceVSphereResourcePoolConfig() string {
 	return fmt.Sprintf(`
 %s
 
-variable "resource_pool_name" {
-  description = "The name of the child resource pool to find (relative to cluster Resources)"
-  default     = "%s"
+resource "vsphere_resource_pool" "resource_pool" {
+  name                    = "terraform-test-resource-pool"
+  parent_resource_pool_id = data.vsphere_compute_cluster.rootcompute_cluster1.resource_pool_id
 }
 
 data "vsphere_resource_pool" "pool" {
-  name          = data.vsphere_compute_cluster.rootcompute_cluster1.name + "/Resources/" + var.resource_pool_name
+  name          = vsphere_resource_pool.resource_pool.name
   datacenter_id = data.vsphere_datacenter.rootdc1.id
 }
 `,
 		testhelper.CombineConfigs(testhelper.ConfigDataRootDC1(), testhelper.ConfigDataRootComputeCluster1()),
-		os.Getenv("TF_VAR_VSPHERE_RESOURCE_POOL"),
 	)
 }
 

--- a/vsphere/data_source_vsphere_role_test.go
+++ b/vsphere/data_source_vsphere_role_test.go
@@ -56,6 +56,7 @@ func TestAccDataSourceVSphereRole_basic(t *testing.T) {
 }
 
 func TestAccDataSourceVSphereRole_systemRoleData(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)

--- a/vsphere/data_source_vsphere_tag_test.go
+++ b/vsphere/data_source_vsphere_tag_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestAccDataSourceVSphereTag_basic(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()

--- a/vsphere/data_source_vsphere_vapp_container_test.go
+++ b/vsphere/data_source_vsphere_vapp_container_test.go
@@ -15,6 +15,7 @@ import (
 )
 
 func TestAccDataSourceVSphereVAppContainer_basic(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -36,6 +37,7 @@ func TestAccDataSourceVSphereVAppContainer_basic(t *testing.T) {
 }
 
 func TestAccDataSourceVSphereVAppContainer_path(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()

--- a/vsphere/data_source_vsphere_virtual_machine_test.go
+++ b/vsphere/data_source_vsphere_virtual_machine_test.go
@@ -15,6 +15,7 @@ import (
 )
 
 func TestAccDataSourceVSphereVirtualMachine_basic(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -61,6 +62,7 @@ func TestAccDataSourceVSphereVirtualMachine_basic(t *testing.T) {
 }
 
 func TestAccDataSourceVSphereVirtualMachine_noDatacenterAndAbsolutePath(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -106,6 +108,7 @@ func TestAccDataSourceVSphereVirtualMachine_noDatacenterAndAbsolutePath(t *testi
 }
 
 func TestAccDataSourceVSphereVirtualMachine_uuid(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -152,6 +155,7 @@ func TestAccDataSourceVSphereVirtualMachine_uuid(t *testing.T) {
 }
 
 func TestAccDataSourceVSphereVirtualMachine_moid(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -198,6 +202,7 @@ func TestAccDataSourceVSphereVirtualMachine_moid(t *testing.T) {
 }
 
 func TestAccDataSourceVSphereVirtualMachine_nameAndFolder(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()

--- a/vsphere/data_source_vsphere_vmfs_disks_test.go
+++ b/vsphere/data_source_vsphere_vmfs_disks_test.go
@@ -15,6 +15,7 @@ import (
 )
 
 func TestAccDataSourceVSphereVmfsDisks_basic(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()

--- a/vsphere/internal/helper/testhelper/constants.go
+++ b/vsphere/internal/helper/testhelper/constants.go
@@ -12,4 +12,5 @@ const (
 	ContentLibraryFiles = "http://storage.googleapis.com/vsphere-acctest/TinyVM/TinyVM.ovf"
 	HostNic0            = "vmnic0"
 	HostNic1            = "vmnic1"
+	HostNic2            = "vmnic2"
 )

--- a/vsphere/provider_test.go
+++ b/vsphere/provider_test.go
@@ -6,6 +6,7 @@ package vsphere
 
 import (
 	"os"
+	"strconv"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -38,6 +39,12 @@ func testAccPreCheck(t *testing.T) {
 
 	if v := os.Getenv("VSPHERE_SERVER"); v == "" {
 		t.Fatal("VSPHERE_SERVER must be set for acceptance tests")
+	}
+}
+
+func testAccSkipUnstable(t *testing.T) {
+	if skip, _ := strconv.ParseBool(os.Getenv("TF_VAR_VSPHERE_SKIP_UNSTABLE_TESTS")); skip {
+		t.Skip()
 	}
 }
 

--- a/vsphere/resource_vsphere_compute_cluster_host_group_test.go
+++ b/vsphere/resource_vsphere_compute_cluster_host_group_test.go
@@ -23,6 +23,7 @@ import (
 )
 
 func TestAccResourceVSphereComputeClusterHostGroup_basic(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -79,6 +80,7 @@ func TestAccResourceVSphereComputeClusterHostGroup_basic(t *testing.T) {
 }
 
 func TestAccResourceVSphereComputeClusterHostGroup_update(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()

--- a/vsphere/resource_vsphere_compute_cluster_test.go
+++ b/vsphere/resource_vsphere_compute_cluster_test.go
@@ -27,11 +27,11 @@ const (
 )
 
 func TestAccResourceVSphereComputeCluster_basic(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
 			testAccPreCheck(t)
-			testAccResourceVSphereComputeClusterPreCheck(t)
 		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccResourceVSphereComputeClusterCheckExists(false),
@@ -65,6 +65,7 @@ func TestAccResourceVSphereComputeCluster_basic(t *testing.T) {
 }
 
 func TestAccResourceVSphereComputeCluster_haAdmissionControlPolicyDisabled(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -86,6 +87,7 @@ func TestAccResourceVSphereComputeCluster_haAdmissionControlPolicyDisabled(t *te
 }
 
 func TestAccResourceVSphereComputeCluster_drsHAEnabled(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -107,6 +109,7 @@ func TestAccResourceVSphereComputeCluster_drsHAEnabled(t *testing.T) {
 }
 
 func TestAccResourceVSphereComputeCluster_vlcm(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -132,6 +135,7 @@ func TestAccResourceVSphereComputeCluster_vlcm(t *testing.T) {
 }
 
 func TestAccResourceVSphereComputeCluster_vsanDedupEnabled(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -155,6 +159,7 @@ func TestAccResourceVSphereComputeCluster_vsanDedupEnabled(t *testing.T) {
 }
 
 func TestAccResourceVSphereComputeCluster_vsanCompressionEnabled(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -178,6 +183,7 @@ func TestAccResourceVSphereComputeCluster_vsanCompressionEnabled(t *testing.T) {
 }
 
 func TestAccResourceVSphereComputeCluster_vsanPerfEnabled(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -200,6 +206,7 @@ func TestAccResourceVSphereComputeCluster_vsanPerfEnabled(t *testing.T) {
 }
 
 func TestAccResourceVSphereComputeCluster_vsanPerfVerboseEnabled(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -223,6 +230,7 @@ func TestAccResourceVSphereComputeCluster_vsanPerfVerboseEnabled(t *testing.T) {
 }
 
 func TestAccResourceVSphereComputeCluster_vsanPerfVerboseDiagnosticEnabled(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -247,6 +255,7 @@ func TestAccResourceVSphereComputeCluster_vsanPerfVerboseDiagnosticEnabled(t *te
 }
 
 func TestAccResourceVSphereComputeCluster_vsanUnmapEnabledwithVsanEnabled(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -269,6 +278,7 @@ func TestAccResourceVSphereComputeCluster_vsanUnmapEnabledwithVsanEnabled(t *tes
 }
 
 func TestAccResourceVSphereComputeCluster_vsanUnmapDisabledwithVsanDisabled(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -307,6 +317,7 @@ func TestAccResourceVSphereComputeCluster_vsanUnmapDisabledwithVsanDisabled(t *t
 }
 
 func TestAccResourceVSphereComputeCluster_vsanDITEncryption(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -331,6 +342,7 @@ func TestAccResourceVSphereComputeCluster_vsanDITEncryption(t *testing.T) {
 }
 
 func TestAccResourceVSphereComputeCluster_vsanEsaEnabled(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -354,6 +366,7 @@ func TestAccResourceVSphereComputeCluster_vsanEsaEnabled(t *testing.T) {
 }
 
 func TestAccResourceVSphereComputeCluster_faultDomain(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -400,6 +413,7 @@ func TestAccResourceVSphereComputeCluster_faultDomain(t *testing.T) {
 }
 
 func TestAccResourceVSphereComputeCluster_vsanStretchedCluster(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -445,6 +459,7 @@ func TestAccResourceVSphereComputeCluster_vsanStretchedCluster(t *testing.T) {
 }
 
 func TestAccResourceVSphereComputeCluster_explicitFailoverHost(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -469,6 +484,7 @@ func TestAccResourceVSphereComputeCluster_explicitFailoverHost(t *testing.T) {
 }
 
 func TestAccResourceVSphereComputeCluster_rename(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -497,6 +513,7 @@ func TestAccResourceVSphereComputeCluster_rename(t *testing.T) {
 }
 
 func TestAccResourceVSphereComputeCluster_inFolder(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -518,6 +535,7 @@ func TestAccResourceVSphereComputeCluster_inFolder(t *testing.T) {
 }
 
 func TestAccResourceVSphereComputeCluster_moveToFolder(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -546,6 +564,7 @@ func TestAccResourceVSphereComputeCluster_moveToFolder(t *testing.T) {
 }
 
 func TestAccResourceVSphereComputeCluster_singleTag(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -567,6 +586,7 @@ func TestAccResourceVSphereComputeCluster_singleTag(t *testing.T) {
 }
 
 func TestAccResourceVSphereComputeCluster_multipleTags(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -588,6 +608,7 @@ func TestAccResourceVSphereComputeCluster_multipleTags(t *testing.T) {
 }
 
 func TestAccResourceVSphereComputeCluster_switchTags(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -616,6 +637,7 @@ func TestAccResourceVSphereComputeCluster_switchTags(t *testing.T) {
 }
 
 func TestAccResourceVSphereComputeCluster_singleCustomAttribute(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -637,6 +659,7 @@ func TestAccResourceVSphereComputeCluster_singleCustomAttribute(t *testing.T) {
 }
 
 func TestAccResourceVSphereComputeCluster_multipleCustomAttribute(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -658,6 +681,7 @@ func TestAccResourceVSphereComputeCluster_multipleCustomAttribute(t *testing.T) 
 }
 
 func TestAccResourceVSphereComputeCluster_switchCustomAttribute(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -903,10 +927,11 @@ func testAccResourceVSphereComputeClusterConfigEmpty() string {
 %s
 
 resource "vsphere_compute_cluster" "compute_cluster" {
-  name          = "testacc-compute-cluster"
-  datacenter_id = data.vsphere_datacenter.rootdc1.id
+  name            = "testacc-compute-cluster"
+  datacenter_id   = "${data.vsphere_datacenter.rootdc1.id}"
 }
-`, testhelper.CombineConfigs(testhelper.ConfigDataRootDC1(), testhelper.ConfigDataRootPortGroup1()),
+`,
+		testhelper.CombineConfigs(testhelper.ConfigDataRootDC1(), testhelper.ConfigDataRootPortGroup1()),
 	)
 }
 
@@ -916,7 +941,7 @@ func testAccResourceVSphereComputeClusterConfigHAAdmissionControlPolicyDisabled(
 
 resource "vsphere_compute_cluster" "compute_cluster" {
   name                        = "testacc-compute-cluster"
-  datacenter_id               = data.vsphere_datacenter.rootdc1.id
+  datacenter_id               = "${data.vsphere_datacenter.rootdc1.id}"
   host_system_ids             = [data.vsphere_host.roothost3.id]
   ha_enabled                  = true
   ha_admission_control_policy = "disabled"
@@ -941,22 +966,22 @@ func testAccResourceVSphereComputeClusterConfigVSANDedupEnabledCompressEnabled()
 %s
 
 resource "vsphere_compute_cluster" "compute_cluster" {
-  name            = "testacc-compute-cluster"
-  datacenter_id   = data.vsphere_datacenter.rootdc1.id
-  host_system_ids = [data.vsphere_host.roothost3.id, data.vsphere_host.roothost4.id]
+  name                        = "testacc-compute-cluster"
+  datacenter_id               = data.vsphere_datacenter.rootdc1.id
+  host_system_ids             = [data.vsphere_host.roothost3.id, data.vsphere_host.roothost4.id]
 
-  vsan_enabled              = true
-  vsan_dedup_enabled        = true
-  vsan_compression_enabled  = true
+  vsan_enabled = true
+  vsan_dedup_enabled = true
+  vsan_compression_enabled = true
   force_evacuate_on_destroy = true
 }
 
-
-`, testhelper.CombineConfigs(
-		testhelper.ConfigDataRootDC1(),
-		testhelper.ConfigDataRootHost3(),
-		testhelper.ConfigDataRootHost4(),
-	),
+`,
+		testhelper.CombineConfigs(
+			testhelper.ConfigDataRootDC1(),
+			testhelper.ConfigDataRootHost3(),
+			testhelper.ConfigDataRootHost4(),
+		),
 	)
 }
 
@@ -965,22 +990,22 @@ func testAccResourceVSphereComputeClusterConfigVSANCompressionEnabledOnly() stri
 %s
 
 resource "vsphere_compute_cluster" "compute_cluster" {
-  name            = "testacc-compute-cluster"
-  datacenter_id   = data.vsphere_datacenter.rootdc1.id
-  host_system_ids = [data.vsphere_host.roothost3.id, data.vsphere_host.roothost4.id]
+  name                        = "testacc-compute-cluster"
+  datacenter_id               = data.vsphere_datacenter.rootdc1.id
+  host_system_ids             = [data.vsphere_host.roothost3.id, data.vsphere_host.roothost4.id]
 
-  vsan_enabled              = true
-  vsan_dedup_enabled        = false
-  vsan_compression_enabled  = true
+  vsan_enabled = true
+  vsan_dedup_enabled = false
+  vsan_compression_enabled = true
   force_evacuate_on_destroy = true
 }
 
-
-`, testhelper.CombineConfigs(
-		testhelper.ConfigDataRootDC1(),
-		testhelper.ConfigDataRootHost3(),
-		testhelper.ConfigDataRootHost4(),
-	),
+`,
+		testhelper.CombineConfigs(
+			testhelper.ConfigDataRootDC1(),
+			testhelper.ConfigDataRootHost3(),
+			testhelper.ConfigDataRootHost4(),
+		),
 	)
 }
 
@@ -989,21 +1014,21 @@ func testAccResourceVSphereComputeClusterConfigVSANPerfEnabled() string {
 %s
 
 resource "vsphere_compute_cluster" "compute_cluster" {
-  name            = "testacc-compute-cluster"
-  datacenter_id   = data.vsphere_datacenter.rootdc1.id
-  host_system_ids = [data.vsphere_host.roothost3.id, data.vsphere_host.roothost4.id]
+  name                        = "testacc-compute-cluster"
+  datacenter_id               = data.vsphere_datacenter.rootdc1.id
+  host_system_ids             = [data.vsphere_host.roothost3.id, data.vsphere_host.roothost4.id]
 
-  vsan_enabled              = true
-  vsan_performance_enabled  = true
+  vsan_enabled = true
+  vsan_performance_enabled = true
   force_evacuate_on_destroy = true
 }
 
-
-`, testhelper.CombineConfigs(
-		testhelper.ConfigDataRootDC1(),
-		testhelper.ConfigDataRootHost3(),
-		testhelper.ConfigDataRootHost4(),
-	),
+`,
+		testhelper.CombineConfigs(
+			testhelper.ConfigDataRootDC1(),
+			testhelper.ConfigDataRootHost3(),
+			testhelper.ConfigDataRootHost4(),
+		),
 	)
 }
 
@@ -1012,22 +1037,22 @@ func testAccResourceVSphereComputeClusterConfigVSANPerfVerboseEnabled() string {
 %s
 
 resource "vsphere_compute_cluster" "compute_cluster" {
-  name            = "testacc-compute-cluster"
-  datacenter_id   = data.vsphere_datacenter.rootdc1.id
-  host_system_ids = [data.vsphere_host.roothost3.id, data.vsphere_host.roothost4.id]
+  name                        = "testacc-compute-cluster"
+  datacenter_id               = data.vsphere_datacenter.rootdc1.id
+  host_system_ids             = [data.vsphere_host.roothost3.id, data.vsphere_host.roothost4.id]
 
-  vsan_enabled              = true
-  vsan_performance_enabled  = true
+  vsan_enabled = true
+  vsan_performance_enabled = true
   vsan_verbose_mode_enabled = true
   force_evacuate_on_destroy = true
 }
 
-
-`, testhelper.CombineConfigs(
-		testhelper.ConfigDataRootDC1(),
-		testhelper.ConfigDataRootHost3(),
-		testhelper.ConfigDataRootHost4(),
-	),
+`,
+		testhelper.CombineConfigs(
+			testhelper.ConfigDataRootDC1(),
+			testhelper.ConfigDataRootHost3(),
+			testhelper.ConfigDataRootHost4(),
+		),
 	)
 }
 
@@ -1036,23 +1061,23 @@ func testAccResourceVSphereComputeClusterConfigVSANPerfVerboseDiagnosticEnabled(
 %s
 
 resource "vsphere_compute_cluster" "compute_cluster" {
-  name            = "testacc-compute-cluster"
-  datacenter_id   = data.vsphere_datacenter.rootdc1.id
-  host_system_ids = [data.vsphere_host.roothost3.id, data.vsphere_host.roothost4.id]
+  name                        = "testacc-compute-cluster"
+  datacenter_id               = data.vsphere_datacenter.rootdc1.id
+  host_system_ids             = [data.vsphere_host.roothost3.id, data.vsphere_host.roothost4.id]
 
-  vsan_enabled                         = true
-  vsan_performance_enabled             = true
-  vsan_verbose_mode_enabled            = true
+  vsan_enabled = true
+  vsan_performance_enabled = true
+  vsan_verbose_mode_enabled = true
   vsan_network_diagnostic_mode_enabled = true
-  force_evacuate_on_destroy            = true
+  force_evacuate_on_destroy = true
 }
 
-
-`, testhelper.CombineConfigs(
-		testhelper.ConfigDataRootDC1(),
-		testhelper.ConfigDataRootHost3(),
-		testhelper.ConfigDataRootHost4(),
-	),
+`,
+		testhelper.CombineConfigs(
+			testhelper.ConfigDataRootDC1(),
+			testhelper.ConfigDataRootHost3(),
+			testhelper.ConfigDataRootHost4(),
+		),
 	)
 }
 
@@ -1061,9 +1086,9 @@ func testAccResourceVSphereComputeClusterConfigVSANDITEncryptionEnabled() string
 %s
 
 resource "vsphere_compute_cluster" "compute_cluster" {
-  name            = "testacc-compute-cluster"
-  datacenter_id   = data.vsphere_datacenter.rootdc1.id
-  host_system_ids = [data.vsphere_host.roothost3.id, data.vsphere_host.roothost4.id]
+  name                        = "testacc-compute-cluster"
+  datacenter_id               = data.vsphere_datacenter.rootdc1.id
+  host_system_ids             = [data.vsphere_host.roothost3.id, data.vsphere_host.roothost4.id]
 
   vsan_enabled                = true
   vsan_dit_encryption_enabled = true
@@ -1071,12 +1096,12 @@ resource "vsphere_compute_cluster" "compute_cluster" {
   force_evacuate_on_destroy   = true
 }
 
-
-`, testhelper.CombineConfigs(
-		testhelper.ConfigDataRootDC1(),
-		testhelper.ConfigDataRootHost3(),
-		testhelper.ConfigDataRootHost4(),
-	),
+`,
+		testhelper.CombineConfigs(
+			testhelper.ConfigDataRootDC1(),
+			testhelper.ConfigDataRootHost3(),
+			testhelper.ConfigDataRootHost4(),
+		),
 	)
 }
 
@@ -1085,21 +1110,21 @@ func testAccResourceVSphereComputeClusterConfigVSANUnmapEnabledwithVsanEnabled()
 %s
 
 resource "vsphere_compute_cluster" "compute_cluster" {
-  name            = "testacc-compute-cluster"
-  datacenter_id   = data.vsphere_datacenter.rootdc1.id
-  host_system_ids = [data.vsphere_host.roothost3.id, data.vsphere_host.roothost4.id]
+  name                        = "testacc-compute-cluster"
+  datacenter_id               = data.vsphere_datacenter.rootdc1.id
+  host_system_ids             = [data.vsphere_host.roothost3.id, data.vsphere_host.roothost4.id]
 
-  vsan_enabled              = true
-  vsan_unmap_enabled        = true
+  vsan_enabled = true
+  vsan_unmap_enabled = true
   force_evacuate_on_destroy = true
 }
 
-
-`, testhelper.CombineConfigs(
-		testhelper.ConfigDataRootDC1(),
-		testhelper.ConfigDataRootHost3(),
-		testhelper.ConfigDataRootHost4(),
-	),
+`,
+		testhelper.CombineConfigs(
+			testhelper.ConfigDataRootDC1(),
+			testhelper.ConfigDataRootHost3(),
+			testhelper.ConfigDataRootHost4(),
+		),
 	)
 }
 
@@ -1108,21 +1133,21 @@ func testAccResourceVSphereComputeClusterConfigVSANUnmapEnabledwithVsanDisabled(
 %s
 
 resource "vsphere_compute_cluster" "compute_cluster" {
-  name            = "testacc-compute-cluster"
-  datacenter_id   = data.vsphere_datacenter.rootdc1.id
-  host_system_ids = [data.vsphere_host.roothost3.id, data.vsphere_host.roothost4.id]
+  name                        = "testacc-compute-cluster"
+  datacenter_id               = data.vsphere_datacenter.rootdc1.id
+  host_system_ids             = [data.vsphere_host.roothost3.id, data.vsphere_host.roothost4.id]
 
-  vsan_enabled              = false
-  vsan_unmap_enabled        = true
+  vsan_enabled = false
+  vsan_unmap_enabled = true
   force_evacuate_on_destroy = true
 }
 
-
-`, testhelper.CombineConfigs(
-		testhelper.ConfigDataRootDC1(),
-		testhelper.ConfigDataRootHost3(),
-		testhelper.ConfigDataRootHost4(),
-	),
+`,
+		testhelper.CombineConfigs(
+			testhelper.ConfigDataRootDC1(),
+			testhelper.ConfigDataRootHost3(),
+			testhelper.ConfigDataRootHost4(),
+		),
 	)
 }
 
@@ -1131,21 +1156,21 @@ func testAccResourceVSphereComputeClusterConfigVSANUnmapDisabledwithVsanDisabled
 %s
 
 resource "vsphere_compute_cluster" "compute_cluster" {
-  name            = "testacc-compute-cluster"
-  datacenter_id   = data.vsphere_datacenter.rootdc1.id
-  host_system_ids = [data.vsphere_host.roothost3.id, data.vsphere_host.roothost4.id]
+  name                        = "testacc-compute-cluster"
+  datacenter_id               = data.vsphere_datacenter.rootdc1.id
+  host_system_ids             = [data.vsphere_host.roothost3.id, data.vsphere_host.roothost4.id]
 
-  vsan_enabled              = false
-  vsan_unmap_enabled        = false
+  vsan_enabled = false
+  vsan_unmap_enabled = false
   force_evacuate_on_destroy = true
 }
 
-
-`, testhelper.CombineConfigs(
-		testhelper.ConfigDataRootDC1(),
-		testhelper.ConfigDataRootHost3(),
-		testhelper.ConfigDataRootHost4(),
-	),
+`,
+		testhelper.CombineConfigs(
+			testhelper.ConfigDataRootDC1(),
+			testhelper.ConfigDataRootHost3(),
+			testhelper.ConfigDataRootHost4(),
+		),
 	)
 }
 
@@ -1154,22 +1179,22 @@ func testAccResourceVSphereComputeClusterConfigVSANEsaEnabled() string {
 %s
 
 resource "vsphere_compute_cluster" "compute_cluster" {
-  name            = "testacc-compute-cluster"
-  datacenter_id   = data.vsphere_datacenter.rootdc1.id
-  host_system_ids = [data.vsphere_host.roothost3.id, data.vsphere_host.roothost4.id]
+  name                        = "testacc-compute-cluster"
+  datacenter_id               = data.vsphere_datacenter.rootdc1.id
+  host_system_ids             = [data.vsphere_host.roothost3.id, data.vsphere_host.roothost4.id]
 
-  vsan_enabled              = true
-  vsan_esa_enabled          = true
-  vsan_unmap_enabled        = true
+  vsan_enabled = true
+  vsan_esa_enabled = true
+  vsan_unmap_enabled = true
   force_evacuate_on_destroy = true
 }
 
-
-`, testhelper.CombineConfigs(
-		testhelper.ConfigDataRootDC1(),
-		testhelper.ConfigDataRootHost3(),
-		testhelper.ConfigDataRootHost4(),
-	),
+`,
+		testhelper.CombineConfigs(
+			testhelper.ConfigDataRootDC1(),
+			testhelper.ConfigDataRootHost3(),
+			testhelper.ConfigDataRootHost4(),
+		),
 	)
 }
 
@@ -1177,27 +1202,28 @@ func testAccResourceVSphereComputeClusterConfigFaultDomains() string {
 	return fmt.Sprintf(`
 %s
 resource "vsphere_compute_cluster" "compute_cluster" {
-  name            = "testacc-compute-cluster"
-  datacenter_id   = data.vsphere_datacenter.rootdc1.id
-  host_system_ids = [data.vsphere_host.roothost3.id, data.vsphere_host.roothost4.id]
-  vsan_enabled    = true
+  name                        = "testacc-compute-cluster"
+  datacenter_id               = data.vsphere_datacenter.rootdc1.id
+  host_system_ids             = [data.vsphere_host.roothost3.id, data.vsphere_host.roothost4.id]
+  vsan_enabled = true
   vsan_fault_domains {
     fault_domain {
-      name     = "fd1"
+      name = "fd1"
       host_ids = [data.vsphere_host.roothost3.id]
     }
     fault_domain {
-      name     = "fd2"
+      name = "fd2"
       host_ids = [data.vsphere_host.roothost4.id]
     }
   }
   force_evacuate_on_destroy = true
 }
-`, testhelper.CombineConfigs(
-		testhelper.ConfigDataRootDC1(),
-		testhelper.ConfigDataRootHost3(),
-		testhelper.ConfigDataRootHost4(),
-	),
+`,
+		testhelper.CombineConfigs(
+			testhelper.ConfigDataRootDC1(),
+			testhelper.ConfigDataRootHost3(),
+			testhelper.ConfigDataRootHost4(),
+		),
 	)
 }
 
@@ -1206,26 +1232,26 @@ func testAccResourceVSphereComputeClusterStretchedClusterEnabled() string {
 %s
 
 resource "vsphere_compute_cluster" "compute_cluster" {
-  name            = "testacc-compute-cluster"
-  datacenter_id   = data.vsphere_datacenter.rootdc1.id
-  host_system_ids = [data.vsphere_host.roothost1.id, data.vsphere_host.roothost2.id]
+  name                        = "testacc-compute-cluster"
+  datacenter_id               = data.vsphere_datacenter.rootdc1.id
+  host_system_ids             = [data.vsphere_host.roothost1.id, data.vsphere_host.roothost2.id]
 
   vsan_enabled = true
   vsan_stretched_cluster {
     preferred_fault_domain_host_ids = [data.vsphere_host.roothost1.id]
     secondary_fault_domain_host_ids = [data.vsphere_host.roothost2.id]
-    witness_node                    = data.vsphere_host.roothost3.id
+    witness_node = data.vsphere_host.roothost3.id
   }
   force_evacuate_on_destroy = true
 }
 
-
-`, testhelper.CombineConfigs(
-		testhelper.ConfigDataRootDC1(),
-		testhelper.ConfigDataVsanHost1(),
-		testhelper.ConfigDataVsanHost2(),
-		testhelper.ConfigDataVsanWitnessHost(),
-	),
+`,
+		testhelper.CombineConfigs(
+			testhelper.ConfigDataRootDC1(),
+			testhelper.ConfigDataVsanHost1(),
+			testhelper.ConfigDataVsanHost2(),
+			testhelper.ConfigDataVsanWitnessHost(),
+		),
 	)
 }
 
@@ -1234,21 +1260,21 @@ func testAccResourceVSphereComputeClusterStretchedClusterDisabled() string {
 %s
 
 resource "vsphere_compute_cluster" "compute_cluster" {
-  name            = "testacc-compute-cluster"
-  datacenter_id   = data.vsphere_datacenter.rootdc1.id
-  host_system_ids = [data.vsphere_host.roothost1.id, data.vsphere_host.roothost2.id]
+  name                        = "testacc-compute-cluster"
+  datacenter_id               = data.vsphere_datacenter.rootdc1.id
+  host_system_ids             = [data.vsphere_host.roothost1.id, data.vsphere_host.roothost2.id]
 
-  vsan_enabled              = true
+  vsan_enabled = true
   force_evacuate_on_destroy = true
 }
 
-
-`, testhelper.CombineConfigs(
-		testhelper.ConfigDataRootDC1(),
-		testhelper.ConfigDataVsanHost1(),
-		testhelper.ConfigDataVsanHost2(),
-		testhelper.ConfigDataVsanWitnessHost(),
-	),
+`,
+		testhelper.CombineConfigs(
+			testhelper.ConfigDataRootDC1(),
+			testhelper.ConfigDataVsanHost1(),
+			testhelper.ConfigDataVsanHost2(),
+			testhelper.ConfigDataVsanWitnessHost(),
+		),
 	)
 }
 
@@ -1258,13 +1284,15 @@ func testAccResourceVSphereComputeClusterConfigBasic() string {
 
 resource "vsphere_compute_cluster" "compute_cluster" {
   name            = "testacc-compute-cluster"
-  datacenter_id   = data.vsphere_datacenter.rootdc1.id
-  host_system_ids = [data.vsphere_host.roothost3.id]
+  datacenter_id   = "${data.vsphere_datacenter.rootdc1.id}"
+  host_system_ids = [ data.vsphere_host.roothost3.id ]
 
   force_evacuate_on_destroy = true
 }
-`, testhelper.CombineConfigs(testhelper.ConfigDataRootDC1(),
-		testhelper.ConfigDataRootHost3()))
+`,
+		testhelper.CombineConfigs(
+			testhelper.ConfigDataRootDC1(),
+			testhelper.ConfigDataRootHost3()))
 }
 
 func testAccResourceVSphereComputeClusterConfigDRSHABasic() string {
@@ -1273,7 +1301,7 @@ func testAccResourceVSphereComputeClusterConfigDRSHABasic() string {
 
 resource "vsphere_compute_cluster" "compute_cluster" {
   name            = "testacc-compute-cluster"
-  datacenter_id   = data.vsphere_datacenter.rootdc1.id
+  datacenter_id   = "${data.vsphere_datacenter.rootdc1.id}"
   host_system_ids = [data.vsphere_host.roothost3.id]
 
   drs_enabled          = true
@@ -1281,17 +1309,18 @@ resource "vsphere_compute_cluster" "compute_cluster" {
 
   ha_enabled = true
 
-  force_evacuate_on_destroy = true
+	force_evacuate_on_destroy = true
 }
-`, testhelper.CombineConfigs(
-		testhelper.ConfigDataRootDC1(),
-		testhelper.ConfigDataRootPortGroup1(),
-		testhelper.ConfigDataRootHost3(),
-		testhelper.ConfigDataRootComputeCluster1(),
-		testhelper.ConfigDataRootHost2(),
-		testhelper.ConfigDataRootDS1(),
-		testhelper.ConfigDataRootVMNet(),
-	),
+`,
+		testhelper.CombineConfigs(
+			testhelper.ConfigDataRootDC1(),
+			testhelper.ConfigDataRootPortGroup1(),
+			testhelper.ConfigDataRootHost3(),
+			testhelper.ConfigDataRootComputeCluster1(),
+			testhelper.ConfigDataRootHost2(),
+			testhelper.ConfigDataRootDS1(),
+			testhelper.ConfigDataRootVMNet(),
+		),
 	)
 }
 
@@ -1303,7 +1332,7 @@ data "vsphere_host_base_images" "base_images" {}
 
 resource "vsphere_compute_cluster" "compute_cluster" {
   name            = "testacc-compute-cluster"
-  datacenter_id   = data.vsphere_datacenter.rootdc1.id
+  datacenter_id   = "${data.vsphere_datacenter.rootdc1.id}"
   host_system_ids = [data.vsphere_host.roothost3.id]
 
   force_evacuate_on_destroy = true
@@ -1324,7 +1353,7 @@ resource "vsphere_compute_cluster" "compute_cluster" {
 func testAccResourceVSphereComputeClusterImageConfig() string {
 	return `
 host_image {
-  esx_version = data.vsphere_host_base_images.base_images.version.0
+  esx_version = "${data.vsphere_host_base_images.base_images.version.0}"
   component {
     key = vsphere_offline_software_depot.depot.component.0.key
     version = vsphere_offline_software_depot.depot.component.0.version.0
@@ -1339,7 +1368,7 @@ func testAccResourceVSphereComputeClusterConfigDRSHABasicExplicitFailoverHost() 
 
 resource "vsphere_compute_cluster" "compute_cluster" {
   name            = "testacc-compute-cluster"
-  datacenter_id   = data.vsphere_datacenter.rootdc1.id
+  datacenter_id   = "${data.vsphere_datacenter.rootdc1.id}"
   host_system_ids = [data.vsphere_host.roothost3.id, data.vsphere_host.roothost4.id]
 
   drs_enabled          = true
@@ -1371,7 +1400,7 @@ func testAccResourceVSphereComputeClusterConfigWithName(name string) string {
 
 resource "vsphere_compute_cluster" "compute_cluster" {
   name          = "%s"
-  datacenter_id = data.vsphere_datacenter.rootdc1.id
+  datacenter_id = "${data.vsphere_datacenter.rootdc1.id}"
 }
 `,
 		testhelper.CombineConfigs(testhelper.ConfigDataRootDC1(), testhelper.ConfigDataRootPortGroup1()),
@@ -1388,15 +1417,15 @@ variable "folder" {
 }
 
 resource "vsphere_folder" "compute_cluster_folder" {
-  path          = var.folder
+  path          = "${var.folder}"
   type          = "host"
-  datacenter_id = data.vsphere_datacenter.rootdc1.id
+  datacenter_id = "${data.vsphere_datacenter.rootdc1.id}"
 }
 
 resource "vsphere_compute_cluster" "compute_cluster" {
   name          = "testacc-compute-cluster"
-  datacenter_id = data.vsphere_datacenter.rootdc1.id
-  folder        = vsphere_folder.compute_cluster_folder.path
+  datacenter_id = "${data.vsphere_datacenter.rootdc1.id}"
+  folder        = "${vsphere_folder.compute_cluster_folder.path}"
 }
 `,
 		testhelper.CombineConfigs(testhelper.ConfigDataRootDC1(), testhelper.ConfigDataRootPortGroup1()),
@@ -1419,14 +1448,16 @@ resource "vsphere_tag_category" "testacc-category" {
 
 resource "vsphere_tag" "testacc-tag" {
   name        = "testacc-tag"
-  category_id = vsphere_tag_category.testacc-category.id
+  category_id = "${vsphere_tag_category.testacc-category.id}"
 }
 
 resource "vsphere_compute_cluster" "compute_cluster" {
   name          = "testacc-compute-cluster"
-  datacenter_id = data.vsphere_datacenter.rootdc1.id
+  datacenter_id = "${data.vsphere_datacenter.rootdc1.id}"
 
-  tags = [vsphere_tag.testacc-tag.id]
+  tags = [
+    "${vsphere_tag.testacc-tag.id}",
+  ]
 }
 `,
 		testhelper.CombineConfigs(testhelper.ConfigDataRootDC1(), testhelper.ConfigDataRootPortGroup1()),
@@ -1455,20 +1486,20 @@ resource "vsphere_tag_category" "testacc-category" {
 
 resource "vsphere_tag" "testacc-tag" {
   name        = "testacc-tag"
-  category_id = vsphere_tag_category.testacc-category.id
+  category_id = "${vsphere_tag_category.testacc-category.id}"
 }
 
 resource "vsphere_tag" "testacc-tags-alt" {
-  count       = length(var.extra_tags)
-  name        = var.extra_tags[count.index]
-  category_id = vsphere_tag_category.testacc-category.id
+  count       = "${length(var.extra_tags)}"
+  name        = "${var.extra_tags[count.index]}"
+  category_id = "${vsphere_tag_category.testacc-category.id}"
 }
 
 resource "vsphere_compute_cluster" "compute_cluster" {
   name          = "testacc-compute-cluster"
-  datacenter_id = data.vsphere_datacenter.rootdc1.id
+  datacenter_id = "${data.vsphere_datacenter.rootdc1.id}"
 
-  tags = vsphere_tag.testacc-tags-alt.*.id
+  tags = "${vsphere_tag.testacc-tags-alt.*.id}"
 }
 `,
 		testhelper.CombineConfigs(testhelper.ConfigDataRootDC1(), testhelper.ConfigDataRootPortGroup1()),
@@ -1486,15 +1517,15 @@ resource "vsphere_custom_attribute" "testacc-attribute" {
 
 locals {
   attrs = {
-    vsphere_custom_attribute.testacc-attribute.id = "value"
+    "${vsphere_custom_attribute.testacc-attribute.id}" = "value"
   }
 }
 
 resource "vsphere_compute_cluster" "compute_cluster" {
   name          = "testacc-compute-cluster"
-  datacenter_id = data.vsphere_datacenter.rootdc1.id
+  datacenter_id = "${data.vsphere_datacenter.rootdc1.id}"
 
-  custom_attributes = local.attrs
+  custom_attributes = "${local.attrs}"
 }
 `,
 		testhelper.CombineConfigs(testhelper.ConfigDataRootDC1(), testhelper.ConfigDataRootPortGroup1()),
@@ -1517,17 +1548,18 @@ resource "vsphere_custom_attribute" "testacc-attribute-2" {
 
 locals {
   attrs = {
-    vsphere_custom_attribute.testacc-attribute.id   = "value"
-    vsphere_custom_attribute.testacc-attribute-2.id = "value-2"
+    "${vsphere_custom_attribute.testacc-attribute.id}" = "value"
+    "${vsphere_custom_attribute.testacc-attribute-2.id}" = "value-2"
   }
 }
 
 resource "vsphere_compute_cluster" "compute_cluster" {
   name          = "testacc-compute-cluster"
-  datacenter_id = data.vsphere_datacenter.rootdc1.id
+  datacenter_id = "${data.vsphere_datacenter.rootdc1.id}"
 
-  custom_attributes = local.attrs
+  custom_attributes = "${local.attrs}"
 }
-`, testhelper.CombineConfigs(testhelper.ConfigDataRootDC1(), testhelper.ConfigDataRootPortGroup1()),
+`,
+		testhelper.CombineConfigs(testhelper.ConfigDataRootDC1(), testhelper.ConfigDataRootPortGroup1()),
 	)
 }

--- a/vsphere/resource_vsphere_compute_cluster_vm_affinity_rule_test.go
+++ b/vsphere/resource_vsphere_compute_cluster_vm_affinity_rule_test.go
@@ -24,6 +24,7 @@ import (
 )
 
 func TestAccResourceVSphereComputeClusterVMAffinityRule_basic(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -85,6 +86,7 @@ func TestAccResourceVSphereComputeClusterVMAffinityRule_basic(t *testing.T) {
 }
 
 func TestAccResourceVSphereComputeClusterVMAffinityRule_updateEnabled(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -123,6 +125,7 @@ func TestAccResourceVSphereComputeClusterVMAffinityRule_updateEnabled(t *testing
 }
 
 func TestAccResourceVSphereComputeClusterVMAffinityRule_updateCount(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()

--- a/vsphere/resource_vsphere_compute_cluster_vm_anti_affinity_rule_test.go
+++ b/vsphere/resource_vsphere_compute_cluster_vm_anti_affinity_rule_test.go
@@ -24,6 +24,7 @@ import (
 )
 
 func TestAccResourceVSphereComputeClusterVMAntiAffinityRule_basic(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -85,6 +86,7 @@ func TestAccResourceVSphereComputeClusterVMAntiAffinityRule_basic(t *testing.T) 
 }
 
 func TestAccResourceVSphereComputeClusterVMAntiAffinityRule_updateEnabled(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -123,6 +125,7 @@ func TestAccResourceVSphereComputeClusterVMAntiAffinityRule_updateEnabled(t *tes
 }
 
 func TestAccResourceVSphereComputeClusterVMAntiAffinityRule_updateCount(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()

--- a/vsphere/resource_vsphere_compute_cluster_vm_dependency_rule_test.go
+++ b/vsphere/resource_vsphere_compute_cluster_vm_dependency_rule_test.go
@@ -22,6 +22,7 @@ import (
 )
 
 func TestAccResourceVSphereComputeClusterVMDependencyRule_basic(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -90,6 +91,7 @@ func TestAccResourceVSphereComputeClusterVMDependencyRule_basic(t *testing.T) {
 }
 
 func TestAccResourceVSphereComputeClusterVMDependencyRule_altGroup(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -117,6 +119,7 @@ func TestAccResourceVSphereComputeClusterVMDependencyRule_altGroup(t *testing.T)
 }
 
 func TestAccResourceVSphereComputeClusterVMDependencyRule_updateEnabled(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -157,6 +160,7 @@ func TestAccResourceVSphereComputeClusterVMDependencyRule_updateEnabled(t *testi
 }
 
 func TestAccResourceVSphereComputeClusterVMDependencyRule_updateGroup(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()

--- a/vsphere/resource_vsphere_compute_cluster_vm_group_test.go
+++ b/vsphere/resource_vsphere_compute_cluster_vm_group_test.go
@@ -24,6 +24,7 @@ import (
 )
 
 func TestAccResourceVSphereComputeClusterVMGroup_basic(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -80,6 +81,7 @@ func TestAccResourceVSphereComputeClusterVMGroup_basic(t *testing.T) {
 }
 
 func TestAccResourceVSphereComputeClusterVMGroup_update(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()

--- a/vsphere/resource_vsphere_compute_cluster_vm_host_rule_test.go
+++ b/vsphere/resource_vsphere_compute_cluster_vm_host_rule_test.go
@@ -22,6 +22,7 @@ import (
 )
 
 func TestAccResourceVSphereComputeClusterVMHostRule_basic(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -92,6 +93,7 @@ func TestAccResourceVSphereComputeClusterVMHostRule_basic(t *testing.T) {
 }
 
 func TestAccResourceVSphereComputeClusterVMHostRule_antiAffinity(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -120,6 +122,7 @@ func TestAccResourceVSphereComputeClusterVMHostRule_antiAffinity(t *testing.T) {
 }
 
 func TestAccResourceVSphereComputeClusterVMHostRule_updateEnabled(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -162,6 +165,7 @@ func TestAccResourceVSphereComputeClusterVMHostRule_updateEnabled(t *testing.T) 
 }
 
 func TestAccResourceVSphereComputeClusterVMHostRule_updateAffinity(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()

--- a/vsphere/resource_vsphere_content_library_item_test.go
+++ b/vsphere/resource_vsphere_content_library_item_test.go
@@ -18,6 +18,7 @@ import (
 )
 
 func TestAccResourceVSphereContentLibraryItem_localOva(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -54,6 +55,7 @@ func TestAccResourceVSphereContentLibraryItem_localOva(t *testing.T) {
 }
 
 func TestAccResourceVSphereContentLibraryItem_remoteOvf(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -97,6 +99,7 @@ func TestAccResourceVSphereContentLibraryItem_remoteOvf(t *testing.T) {
 }
 
 func TestAccResourceVSphereContentLibraryItem_remoteOva(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()

--- a/vsphere/resource_vsphere_content_library_test.go
+++ b/vsphere/resource_vsphere_content_library_test.go
@@ -20,7 +20,6 @@ func TestAccResourceVSphereContentLibrary_basic(t *testing.T) {
 		PreCheck: func() {
 			RunSweepers()
 			testAccPreCheck(t)
-			testAccResourceVSphereContentLibraryPreCheck(t)
 		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccResourceVSphereContentLibraryCheckExists(false),
@@ -49,6 +48,7 @@ func TestAccResourceVSphereContentLibrary_basic(t *testing.T) {
 }
 
 func TestAccResourceVSphereContentLibrary_subscribed(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -75,6 +75,7 @@ func TestAccResourceVSphereContentLibrary_subscribed(t *testing.T) {
 	})
 }
 func TestAccResourceVSphereContentLibrary_authenticated(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -132,7 +133,7 @@ func testAccResourceVSphereContentLibraryName(expected *regexp.Regexp) resource.
 }
 
 func testaccresourcevspherecontentlibraryconfigBase() string {
-	return testhelper.CombineConfigs(testhelper.ConfigDataRootDC1(), testhelper.ConfigDataRootHost1(), testhelper.ConfigDataRootDS1(), testhelper.ConfigDataRootHost2(), testhelper.ConfigResDS1(), testhelper.ConfigDataRootComputeCluster1(), testhelper.ConfigResResourcePool1(), testhelper.ConfigDataRootPortGroup1())
+	return testhelper.CombineConfigs(testhelper.ConfigDataRootDC1(), testhelper.ConfigDataRootHost3(), testhelper.ConfigDataRootDS1(), testhelper.ConfigDataRootHost2(), testhelper.ConfigDataRootComputeCluster1(), testhelper.ConfigResResourcePool1(), testhelper.ConfigDataRootPortGroup1())
 }
 
 func testaccresourcevspherecontentlibraryconfigAuthenticated() string {

--- a/vsphere/resource_vsphere_custom_attribute_test.go
+++ b/vsphere/resource_vsphere_custom_attribute_test.go
@@ -14,6 +14,7 @@ import (
 )
 
 func TestAccResourceVSphereCustomAttribute_basic(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -53,6 +54,7 @@ func TestAccResourceVSphereCustomAttribute_basic(t *testing.T) {
 	})
 }
 func TestAccResourceVSphereCustomAttribute_withType(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -73,6 +75,7 @@ func TestAccResourceVSphereCustomAttribute_withType(t *testing.T) {
 	})
 }
 func TestAccResourceVSphereCustomAttribute_rename(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -99,6 +102,7 @@ func TestAccResourceVSphereCustomAttribute_rename(t *testing.T) {
 }
 
 func TestAccResourceVSphereCustomAttribute_changeType(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()

--- a/vsphere/resource_vsphere_datacenter_test.go
+++ b/vsphere/resource_vsphere_datacenter_test.go
@@ -163,6 +163,7 @@ func TestAccResourceVSphereDatacenter_createOnSubfolder(t *testing.T) {
 	dcFolder := "dc-folder"
 	name := "testDC"
 
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -189,6 +190,7 @@ func TestAccResourceVSphereDatacenter_createOnSubfolder(t *testing.T) {
 }
 
 func TestAccResourceVSphereDatacenter_singleTag(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -212,6 +214,7 @@ func TestAccResourceVSphereDatacenter_singleTag(t *testing.T) {
 }
 
 func TestAccResourceVSphereDatacenter_modifyTags(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -245,6 +248,7 @@ func TestAccResourceVSphereDatacenter_modifyTags(t *testing.T) {
 }
 
 func TestAccResourceVSphereDatacenter_singleCustomAttribute(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -268,6 +272,7 @@ func TestAccResourceVSphereDatacenter_singleCustomAttribute(t *testing.T) {
 }
 
 func TestAccResourceVSphereDatacenter_modifyCustomAttribute(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()

--- a/vsphere/resource_vsphere_datastore_cluster_test.go
+++ b/vsphere/resource_vsphere_datastore_cluster_test.go
@@ -27,6 +27,7 @@ const (
 )
 
 func TestAccResourceVSphereDatastoreCluster_basic(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -66,6 +67,7 @@ func TestAccResourceVSphereDatastoreCluster_basic(t *testing.T) {
 }
 
 func TestAccResourceVSphereDatastoreCluster_sdrsEnabled(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -87,6 +89,7 @@ func TestAccResourceVSphereDatastoreCluster_sdrsEnabled(t *testing.T) {
 }
 
 func TestAccResourceVSphereDatastoreCluster_rename(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -115,6 +118,7 @@ func TestAccResourceVSphereDatastoreCluster_rename(t *testing.T) {
 }
 
 func TestAccResourceVSphereDatastoreCluster_inFolder(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -136,6 +140,7 @@ func TestAccResourceVSphereDatastoreCluster_inFolder(t *testing.T) {
 }
 
 func TestAccResourceVSphereDatastoreCluster_moveToFolder(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -164,6 +169,7 @@ func TestAccResourceVSphereDatastoreCluster_moveToFolder(t *testing.T) {
 }
 
 func TestAccResourceVSphereDatastoreCluster_sdrsOverrides(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -187,6 +193,7 @@ func TestAccResourceVSphereDatastoreCluster_sdrsOverrides(t *testing.T) {
 }
 
 func TestAccResourceVSphereDatastoreCluster_miscTweaks(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -214,6 +221,7 @@ func TestAccResourceVSphereDatastoreCluster_miscTweaks(t *testing.T) {
 }
 
 func TestAccResourceVSphereDatastoreCluster_reservableIops(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -250,6 +258,7 @@ func TestAccResourceVSphereDatastoreCluster_reservableIops(t *testing.T) {
 }
 
 func TestAccResourceVSphereDatastoreCluster_freeSpace(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -286,6 +295,7 @@ func TestAccResourceVSphereDatastoreCluster_freeSpace(t *testing.T) {
 }
 
 func TestAccResourceVSphereDatastoreCluster_singleTag(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -307,6 +317,7 @@ func TestAccResourceVSphereDatastoreCluster_singleTag(t *testing.T) {
 }
 
 func TestAccResourceVSphereDatastoreCluster_multipleTags(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -328,6 +339,7 @@ func TestAccResourceVSphereDatastoreCluster_multipleTags(t *testing.T) {
 }
 
 func TestAccResourceVSphereDatastoreCluster_switchTags(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -356,6 +368,7 @@ func TestAccResourceVSphereDatastoreCluster_switchTags(t *testing.T) {
 }
 
 func TestAccResourceVSphereDatastoreCluster_singleCustomAttribute(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -377,6 +390,7 @@ func TestAccResourceVSphereDatastoreCluster_singleCustomAttribute(t *testing.T) 
 }
 
 func TestAccResourceVSphereDatastoreCluster_multipleCustomAttribute(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -398,6 +412,7 @@ func TestAccResourceVSphereDatastoreCluster_multipleCustomAttribute(t *testing.T
 }
 
 func TestAccResourceVSphereDatastoreCluster_switchCustomAttribute(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()

--- a/vsphere/resource_vsphere_datastore_cluster_vm_anti_affinity_rule_test.go
+++ b/vsphere/resource_vsphere_datastore_cluster_vm_anti_affinity_rule_test.go
@@ -24,6 +24,7 @@ import (
 )
 
 func TestAccResourceVSphereDatastoreClusterVMAntiAffinityRule_basic(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -85,6 +86,7 @@ func TestAccResourceVSphereDatastoreClusterVMAntiAffinityRule_basic(t *testing.T
 }
 
 func TestAccResourceVSphereDatastoreClusterVMAntiAffinityRule_updateEnabled(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -123,6 +125,7 @@ func TestAccResourceVSphereDatastoreClusterVMAntiAffinityRule_updateEnabled(t *t
 }
 
 func TestAccResourceVSphereDatastoreClusterVMAntiAffinityRule_updateCount(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()

--- a/vsphere/resource_vsphere_distributed_port_group_test.go
+++ b/vsphere/resource_vsphere_distributed_port_group_test.go
@@ -20,7 +20,6 @@ func TestAccResourceVSphereDistributedPortGroup_basic(t *testing.T) {
 		PreCheck: func() {
 			RunSweepers()
 			testAccPreCheck(t)
-			testAccResourceVSphereDistributedPortGroupPreCheck()
 		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccResourceVSphereDistributedPortGroupExists(false),
@@ -53,6 +52,7 @@ func TestAccResourceVSphereDistributedPortGroup_basic(t *testing.T) {
 }
 
 func TestAccResourceVSphereDistributedPortGroup_inheritPolicyDiffCheck(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -73,6 +73,7 @@ func TestAccResourceVSphereDistributedPortGroup_inheritPolicyDiffCheck(t *testin
 }
 
 func TestAccResourceVSphereDistributedPortGroup_inheritPolicyDiffCheckVlanRangeTypeSetEdition(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -93,6 +94,7 @@ func TestAccResourceVSphereDistributedPortGroup_inheritPolicyDiffCheckVlanRangeT
 }
 
 func TestAccResourceVSphereDistributedPortGroup_overrideVlan(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -115,6 +117,7 @@ func TestAccResourceVSphereDistributedPortGroup_overrideVlan(t *testing.T) {
 }
 
 func TestAccResourceVSphereDistributedPortGroup_singleTag(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -136,6 +139,7 @@ func TestAccResourceVSphereDistributedPortGroup_singleTag(t *testing.T) {
 }
 
 func TestAccResourceVSphereDistributedPortGroup_multiTag(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -157,6 +161,7 @@ func TestAccResourceVSphereDistributedPortGroup_multiTag(t *testing.T) {
 }
 
 func TestAccResourceVSphereDistributedPortGroup_singleCustomAttribute(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -178,6 +183,7 @@ func TestAccResourceVSphereDistributedPortGroup_singleCustomAttribute(t *testing
 }
 
 func TestAccResourceVSphereDistributedPortGroup_multiCustomAttribute(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()

--- a/vsphere/resource_vsphere_distributed_virtual_switch_pvlan_mapping_test.go
+++ b/vsphere/resource_vsphere_distributed_virtual_switch_pvlan_mapping_test.go
@@ -17,6 +17,7 @@ import (
 )
 
 func TestAccResourceVSphereDistributedVirtualSwitchPvlanMapping_basic(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()

--- a/vsphere/resource_vsphere_distributed_virtual_switch_test.go
+++ b/vsphere/resource_vsphere_distributed_virtual_switch_test.go
@@ -30,7 +30,6 @@ func TestAccResourceVSphereDistributedVirtualSwitch_basic(t *testing.T) {
 		PreCheck: func() {
 			RunSweepers()
 			testAccPreCheck(t)
-			testAccResourceVSphereDistributedVirtualSwitchPreCheck(t)
 		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccResourceVSphereDistributedVirtualSwitchExists(false),
@@ -63,6 +62,7 @@ func TestAccResourceVSphereDistributedVirtualSwitch_basic(t *testing.T) {
 }
 
 func TestAccResourceVSphereDistributedVirtualSwitch_noHosts(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -83,6 +83,7 @@ func TestAccResourceVSphereDistributedVirtualSwitch_noHosts(t *testing.T) {
 }
 
 func TestAccResourceVSphereDistributedVirtualSwitch_removeNIC(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -109,6 +110,7 @@ func TestAccResourceVSphereDistributedVirtualSwitch_removeNIC(t *testing.T) {
 }
 
 func TestAccResourceVSphereDistributedVirtualSwitch_standbyWithExplicitFailoverOrder(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -132,6 +134,7 @@ func TestAccResourceVSphereDistributedVirtualSwitch_standbyWithExplicitFailoverO
 }
 
 func TestAccResourceVSphereDistributedVirtualSwitch_basicToStandbyWithFailover(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -161,6 +164,7 @@ func TestAccResourceVSphereDistributedVirtualSwitch_basicToStandbyWithFailover(t
 }
 
 func TestAccResourceVSphereDistributedVirtualSwitch_upgradeVersion(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -189,6 +193,7 @@ func TestAccResourceVSphereDistributedVirtualSwitch_upgradeVersion(t *testing.T)
 }
 
 func TestAccResourceVSphereDistributedVirtualSwitch_networkResourceControl(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -213,6 +218,7 @@ func TestAccResourceVSphereDistributedVirtualSwitch_networkResourceControl(t *te
 }
 
 func TestAccResourceVSphereDistributedVirtualSwitch_explicitUplinks(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -234,6 +240,7 @@ func TestAccResourceVSphereDistributedVirtualSwitch_explicitUplinks(t *testing.T
 }
 
 func TestAccResourceVSphereDistributedVirtualSwitch_modifyUplinks(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -274,6 +281,7 @@ func TestAccResourceVSphereDistributedVirtualSwitch_modifyUplinks(t *testing.T) 
 }
 
 func TestAccResourceVSphereDistributedVirtualSwitch_inFolder(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -295,6 +303,7 @@ func TestAccResourceVSphereDistributedVirtualSwitch_inFolder(t *testing.T) {
 }
 
 func TestAccResourceVSphereDistributedVirtualSwitch_singleTag(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -316,6 +325,7 @@ func TestAccResourceVSphereDistributedVirtualSwitch_singleTag(t *testing.T) {
 }
 
 func TestAccResourceVSphereDistributedVirtualSwitch_modifyTags(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -344,6 +354,7 @@ func TestAccResourceVSphereDistributedVirtualSwitch_modifyTags(t *testing.T) {
 }
 
 func TestAccResourceVSphereDistributedVirtualSwitch_netflow(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -365,6 +376,7 @@ func TestAccResourceVSphereDistributedVirtualSwitch_netflow(t *testing.T) {
 }
 
 func TestAccResourceVSphereDistributedVirtualSwitch_vlanRanges(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -387,6 +399,7 @@ func TestAccResourceVSphereDistributedVirtualSwitch_vlanRanges(t *testing.T) {
 }
 
 func TestAccResourceVSphereDistributedVirtualSwitch_singleCustomAttribute(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -408,6 +421,7 @@ func TestAccResourceVSphereDistributedVirtualSwitch_singleCustomAttribute(t *tes
 }
 
 func TestAccResourceVSphereDistributedVirtualSwitch_multiCustomAttribute(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -648,15 +662,16 @@ func testAccResourceVSphereDistributedVirtualSwitchConfig() string {
 
 resource "vsphere_distributed_virtual_switch" "dvs" {
   name          = "testacc-dvs1"
-  datacenter_id = data.vsphere_datacenter.rootdc1.id
+  datacenter_id = "${data.vsphere_datacenter.rootdc1.id}"
 
   host {
-    host_system_id = data.vsphere_host.roothost2.id
-    devices        = ["%s"]
+    host_system_id = data.vsphere_host.roothost3.id
+    devices = ["%s"]
   }
 }
-`, testhelper.CombineConfigs(testhelper.ConfigDataRootDC1(), testhelper.ConfigDataRootHost2()),
-		testhelper.HostNic0,
+`,
+		testhelper.CombineConfigs(testhelper.ConfigDataRootDC1(), testhelper.ConfigDataRootHost3()),
+		testhelper.HostNic1,
 	)
 }
 
@@ -676,18 +691,19 @@ variable "dvs_version" {
 
 resource "vsphere_distributed_virtual_switch" "dvs" {
   name          = "testacc-dvs1"
-  datacenter_id = data.vsphere_datacenter.rootdc1.id
-  version       = var.dvs_version
+  datacenter_id = "${data.vsphere_datacenter.rootdc1.id}"
+  version       = "${var.dvs_version}"
 
   host {
-    host_system_id = data.vsphere_host.roothost1.id
-    devices        = var.network_interfaces
+    host_system_id = "${data.vsphere_host.roothost1.id}"
+    devices = "${var.network_interfaces}"
   }
 }
-`, testhelper.CombineConfigs(
-		testhelper.ConfigDataRootDC1(),
-		testhelper.ConfigDataRootPortGroup1(),
-		testhelper.ConfigDataRootHost1()),
+`,
+		testhelper.CombineConfigs(
+			testhelper.ConfigDataRootDC1(),
+			testhelper.ConfigDataRootPortGroup1(),
+			testhelper.ConfigDataRootHost1()),
 		testhelper.HostNic0,
 		version,
 	)
@@ -705,24 +721,25 @@ variable "network_interfaces" {
 
 resource "vsphere_distributed_virtual_switch" "dvs" {
   name          = "testacc-dvs1"
-  datacenter_id = data.vsphere_datacenter.rootdc1.id
+  datacenter_id = "${data.vsphere_datacenter.rootdc1.id}"
 
   host {
-    host_system_id = data.vsphere_host.roothost1.id
-    devices        = var.network_interfaces
+    host_system_id = "${data.vsphere_host.roothost1.id}"
+    devices = "${var.network_interfaces}"
   }
 
   host {
-    host_system_id = data.vsphere_host.roothost2.id
-    devices        = var.network_interfaces
+    host_system_id = "${data.vsphere_host.roothost2.id}"
+    devices = "${var.network_interfaces}"
   }
 }
-`, testhelper.CombineConfigs(
-		testhelper.ConfigDataRootDC1(),
-		testhelper.ConfigDataRootPortGroup1(),
-		testhelper.ConfigDataRootHost1(),
-		testhelper.ConfigDataRootHost2(),
-	),
+`,
+		testhelper.CombineConfigs(
+			testhelper.ConfigDataRootDC1(),
+			testhelper.ConfigDataRootPortGroup1(),
+			testhelper.ConfigDataRootHost1(),
+			testhelper.ConfigDataRootHost2(),
+		),
 		testhelper.HostNic0,
 	)
 }
@@ -740,26 +757,27 @@ variable "network_interfaces" {
 
 resource "vsphere_distributed_virtual_switch" "dvs" {
   name          = "testacc-dvs1"
-  datacenter_id = data.vsphere_datacenter.rootdc1.id
+  datacenter_id = "${data.vsphere_datacenter.rootdc1.id}"
 
   network_resource_control_enabled = true
   network_resource_control_version = "version3"
 
   host {
-    host_system_id = data.vsphere_host.roothost1.id
-    devices        = var.network_interfaces
+    host_system_id = "${data.vsphere_host.roothost1.id}"
+    devices = "${var.network_interfaces}"
   }
 
   host {
-    host_system_id = data.vsphere_host.roothost2.id
-    devices        = var.network_interfaces
+    host_system_id = "${data.vsphere_host.roothost2.id}"
+    devices = "${var.network_interfaces}"
   }
 }
-`, testhelper.CombineConfigs(
-		testhelper.ConfigDataRootDC1(),
-		testhelper.ConfigDataRootPortGroup1(),
-		testhelper.ConfigDataRootHost1(),
-		testhelper.ConfigDataRootHost2()),
+`,
+		testhelper.CombineConfigs(
+			testhelper.ConfigDataRootDC1(),
+			testhelper.ConfigDataRootPortGroup1(),
+			testhelper.ConfigDataRootHost1(),
+			testhelper.ConfigDataRootHost2()),
 		testhelper.HostNic0,
 	)
 }
@@ -777,25 +795,26 @@ variable "network_interfaces" {
 
 resource "vsphere_distributed_virtual_switch" "dvs" {
   name          = "testacc-dvs1"
-  datacenter_id = data.vsphere_datacenter.rootdc1.id
+  datacenter_id = "${data.vsphere_datacenter.rootdc1.id}"
 
   uplinks = var.network_interfaces
 
   host {
-    host_system_id = data.vsphere_host.roothost1.id
-    devices        = var.network_interfaces
+    host_system_id = "${data.vsphere_host.roothost1.id}"
+    devices = "${var.network_interfaces}"
   }
 
   host {
-    host_system_id = data.vsphere_host.roothost2.id
-    devices        = var.network_interfaces
+    host_system_id = "${data.vsphere_host.roothost2.id}"
+    devices = "${var.network_interfaces}"
   }
 }
-`, testhelper.CombineConfigs(
-		testhelper.ConfigDataRootDC1(),
-		testhelper.ConfigDataRootPortGroup1(),
-		testhelper.ConfigDataRootHost1(),
-		testhelper.ConfigDataRootHost2()),
+`,
+		testhelper.CombineConfigs(
+			testhelper.ConfigDataRootDC1(),
+			testhelper.ConfigDataRootPortGroup1(),
+			testhelper.ConfigDataRootHost1(),
+			testhelper.ConfigDataRootHost2()),
 		testhelper.HostNic0,
 		testhelper.HostNic1,
 	)
@@ -808,32 +827,33 @@ func testAccResourceVSphereDistributedVirtualSwitchConfigStandbyLink() string {
 variable "network_interfaces" {
   default = [
     "%s",
-    "%s"
+	"%s"
   ]
 }
 
 resource "vsphere_distributed_virtual_switch" "dvs" {
   name          = "testacc-dvs1"
-  datacenter_id = data.vsphere_datacenter.rootdc1.id
+  datacenter_id = "${data.vsphere_datacenter.rootdc1.id}"
 
   uplinks         = var.network_interfaces
   active_uplinks  = [var.network_interfaces.0]
   standby_uplinks = [var.network_interfaces.1]
 
   host {
-    host_system_id = data.vsphere_host.roothost1.id
-    devices        = var.network_interfaces
+    host_system_id = "${data.vsphere_host.roothost1.id}"
+    devices = "${var.network_interfaces}"
   }
 
   host {
-    host_system_id = data.vsphere_host.roothost2.id
-    devices        = var.network_interfaces
+    host_system_id = "${data.vsphere_host.roothost2.id}"
+    devices = "${var.network_interfaces}"
   }
 }
-`, testhelper.CombineConfigs(
-		testhelper.ConfigDataRootDC1(),
-		testhelper.ConfigDataRootHost1(),
-		testhelper.ConfigDataRootHost2()),
+`,
+		testhelper.CombineConfigs(
+			testhelper.ConfigDataRootDC1(),
+			testhelper.ConfigDataRootHost1(),
+			testhelper.ConfigDataRootHost2()),
 		testhelper.HostNic0,
 		testhelper.HostNic1,
 	)
@@ -845,7 +865,7 @@ func testAccResourceVSphereDistributedVirtualSwitchConfigNoHosts() string {
 
 resource "vsphere_distributed_virtual_switch" "dvs" {
   name          = "testacc-dvs1"
-  datacenter_id = data.vsphere_datacenter.rootdc1.id
+  datacenter_id = "${data.vsphere_datacenter.rootdc1.id}"
 }
 `,
 		testhelper.CombineConfigs(testhelper.ConfigDataRootDC1(), testhelper.ConfigDataRootPortGroup1()),
@@ -859,13 +879,13 @@ func testAccResourceVSphereDistributedVirtualSwitchConfigInFolder() string {
 resource "vsphere_folder" "folder" {
   path          = "tf-network-folder"
   type          = "network"
-  datacenter_id = data.vsphere_datacenter.rootdc1.id
+  datacenter_id = "${data.vsphere_datacenter.rootdc1.id}"
 }
 
 resource "vsphere_distributed_virtual_switch" "dvs" {
   name          = "testacc-dvs1"
-  datacenter_id = data.vsphere_datacenter.rootdc1.id
-  folder        = vsphere_folder.folder.path
+  datacenter_id = "${data.vsphere_datacenter.rootdc1.id}"
+  folder        = "${vsphere_folder.folder.path}"
 }
 `,
 		testhelper.CombineConfigs(testhelper.ConfigDataRootDC1(), testhelper.ConfigDataRootPortGroup1()),
@@ -887,15 +907,16 @@ resource "vsphere_tag_category" "testacc-category" {
 
 resource "vsphere_tag" "testacc-tag" {
   name        = "testacc-tag"
-  category_id = vsphere_tag_category.testacc-category.id
+  category_id = "${vsphere_tag_category.testacc-category.id}"
 }
 
 resource "vsphere_distributed_virtual_switch" "dvs" {
   name          = "testacc-dvs1"
-  datacenter_id = data.vsphere_datacenter.rootdc1.id
-  tags          = [vsphere_tag.testacc-tag.id]
+  datacenter_id = "${data.vsphere_datacenter.rootdc1.id}"
+  tags          = ["${vsphere_tag.testacc-tag.id}"]
 }
-`, testhelper.CombineConfigs(testhelper.ConfigDataRootDC1(), testhelper.ConfigDataRootPortGroup1()),
+`,
+		testhelper.CombineConfigs(testhelper.ConfigDataRootDC1(), testhelper.ConfigDataRootPortGroup1()),
 	)
 }
 
@@ -921,19 +942,19 @@ resource "vsphere_tag_category" "testacc-category" {
 
 resource "vsphere_tag" "testacc-tag" {
   name        = "testacc-tag"
-  category_id = vsphere_tag_category.testacc-category.id
+  category_id = "${vsphere_tag_category.testacc-category.id}"
 }
 
 resource "vsphere_tag" "testacc-tags-alt" {
-  count       = length(var.extra_tags)
-  name        = var.extra_tags[count.index]
-  category_id = vsphere_tag_category.testacc-category.id
+  count       = "${length(var.extra_tags)}"
+  name        = "${var.extra_tags[count.index]}"
+  category_id = "${vsphere_tag_category.testacc-category.id}"
 }
 
 resource "vsphere_distributed_virtual_switch" "dvs" {
   name          = "testacc-dvs1"
-  datacenter_id = data.vsphere_datacenter.rootdc1.id
-  tags          = vsphere_tag.testacc-tags-alt.*.id
+  datacenter_id = "${data.vsphere_datacenter.rootdc1.id}"
+  tags          = "${vsphere_tag.testacc-tags-alt.*.id}"
 }
 `,
 		testhelper.CombineConfigs(testhelper.ConfigDataRootDC1(), testhelper.ConfigDataRootPortGroup1()),
@@ -946,7 +967,7 @@ func testAccResourceVSphereDistributedVirtualSwitchConfigNetflow() string {
 
 resource "vsphere_distributed_virtual_switch" "dvs" {
   name          = "testacc-dvs1"
-  datacenter_id = data.vsphere_datacenter.rootdc1.id
+  datacenter_id = "${data.vsphere_datacenter.rootdc1.id}"
 
   ipv4_address                  = "10.0.0.100"
   netflow_enabled               = true
@@ -969,7 +990,7 @@ func testAccResourceVSphereDistributedVirtualSwitchConfigMultiVlanRange() string
 
 resource "vsphere_distributed_virtual_switch" "dvs" {
   name          = "testacc-dvs1"
-  datacenter_id = data.vsphere_datacenter.rootdc1.id
+  datacenter_id = "${data.vsphere_datacenter.rootdc1.id}"
 
   vlan_range {
     min_vlan = 1000
@@ -997,15 +1018,15 @@ resource "vsphere_custom_attribute" "testacc-attribute" {
 
 locals {
   vs_attrs = {
-    vsphere_custom_attribute.testacc-attribute.id = "value"
+    "${vsphere_custom_attribute.testacc-attribute.id}" = "value"
   }
 }
 
 resource "vsphere_distributed_virtual_switch" "dvs" {
   name          = "testacc-dvs1"
-  datacenter_id = data.vsphere_datacenter.rootdc1.id
+  datacenter_id = "${data.vsphere_datacenter.rootdc1.id}"
 
-  custom_attributes = local.vs_attrs
+  custom_attributes = "${local.vs_attrs}"
 }
 `,
 		testhelper.CombineConfigs(testhelper.ConfigDataRootDC1(), testhelper.ConfigDataRootPortGroup1()),
@@ -1029,24 +1050,25 @@ resource "vsphere_custom_attribute" "testacc-attribute" {
 }
 
 resource "vsphere_custom_attribute" "testacc-attribute-alt" {
-  count               = length(var.custom_attrs)
-  name                = var.custom_attrs[count.index]
+  count               = "${length(var.custom_attrs)}"
+  name                = "${var.custom_attrs[count.index]}"
   managed_object_type = "VmwareDistributedVirtualSwitch"
 }
 
 locals {
   vs_attrs = {
-    vsphere_custom_attribute.testacc-attribute-alt.0.id = "value"
-    vsphere_custom_attribute.testacc-attribute-alt.1.id = "value-2"
+    "${vsphere_custom_attribute.testacc-attribute-alt.0.id}" = "value"
+    "${vsphere_custom_attribute.testacc-attribute-alt.1.id}" = "value-2"
   }
 }
 
 resource "vsphere_distributed_virtual_switch" "dvs" {
   name          = "testacc-dvs1"
-  datacenter_id = data.vsphere_datacenter.rootdc1.id
+  datacenter_id = "${data.vsphere_datacenter.rootdc1.id}"
 
-  custom_attributes = local.vs_attrs
+  custom_attributes = "${local.vs_attrs}"
 }
-`, testhelper.CombineConfigs(testhelper.ConfigDataRootDC1(), testhelper.ConfigDataRootPortGroup1()),
+`,
+		testhelper.CombineConfigs(testhelper.ConfigDataRootDC1(), testhelper.ConfigDataRootPortGroup1()),
 	)
 }

--- a/vsphere/resource_vsphere_dpm_host_override_test.go
+++ b/vsphere/resource_vsphere_dpm_host_override_test.go
@@ -22,6 +22,7 @@ import (
 )
 
 func TestAccResourceVSphereDPMHostOverride_basic(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -73,6 +74,7 @@ func TestAccResourceVSphereDPMHostOverride_basic(t *testing.T) {
 }
 
 func TestAccResourceVSphereDPMHostOverride_overrides(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -94,6 +96,7 @@ func TestAccResourceVSphereDPMHostOverride_overrides(t *testing.T) {
 }
 
 func TestAccResourceVSphereDPMHostOverride_update(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()

--- a/vsphere/resource_vsphere_drs_vm_override_test.go
+++ b/vsphere/resource_vsphere_drs_vm_override_test.go
@@ -23,6 +23,7 @@ import (
 )
 
 func TestAccResourceVSphereDRSVMOverride_drs(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -74,6 +75,7 @@ func TestAccResourceVSphereDRSVMOverride_drs(t *testing.T) {
 }
 
 func TestAccResourceVSphereDRSVMOverride_automationLevel(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -95,6 +97,7 @@ func TestAccResourceVSphereDRSVMOverride_automationLevel(t *testing.T) {
 }
 
 func TestAccResourceVSphereDRSVMOverride_update(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()

--- a/vsphere/resource_vsphere_entity_permissions_test.go
+++ b/vsphere/resource_vsphere_entity_permissions_test.go
@@ -19,6 +19,7 @@ import (
 const EntityPermissionResource = "entity_permission1"
 
 func TestAccResourcevsphereEntityPermissions_basic(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)

--- a/vsphere/resource_vsphere_file_test.go
+++ b/vsphere/resource_vsphere_file_test.go
@@ -18,6 +18,7 @@ import (
 
 // TestAccResourceVSphereFile_basic verifies the basic functionality of the resource.
 func TestAccResourceVSphereFile_basic(t *testing.T) {
+	testAccSkipUnstable(t)
 	testFileData := []byte("test file data")
 	testFile := "/tmp/tf_test.txt"
 	err := os.WriteFile(testFile, testFileData, 0600)
@@ -64,6 +65,7 @@ func TestAccResourceVSphereFile_basic(t *testing.T) {
 // TestAccResourceVSphereFile_uploadWithCreateDirectories verifies uploading files with nested directories.
 // creation.
 func TestAccResourceVSphereFile_uploadWithCreateDirectories(t *testing.T) {
+	testAccSkipUnstable(t)
 	testFileData := []byte("test file data")
 	testFile := "/tmp/tf_test.txt"
 	err := os.WriteFile(testFile, testFileData, 0600)
@@ -130,6 +132,7 @@ func TestAccResourceVSphereFile_uploadWithCreateDirectories(t *testing.T) {
 
 // TestAccResourceVSphereFile_basicUploadAndCopy verifies uploading and copying files.
 func TestAccResourceVSphereFile_basicUploadAndCopy(t *testing.T) {
+	testAccSkipUnstable(t)
 	testFileData := []byte("test file data")
 	sourceFile := "/tmp/tf_test.txt"
 	uploadResourceName := "myfileupload"
@@ -187,6 +190,7 @@ func TestAccResourceVSphereFile_basicUploadAndCopy(t *testing.T) {
 
 // TestAccResourceVSphereFile_renamePostCreation verifies the renaming of a resource during creation and update phases.
 func TestAccResourceVSphereFile_renamePostCreation(t *testing.T) {
+	testAccSkipUnstable(t)
 	testFileData := []byte("test file data")
 	testFile := "/tmp/tf_test.txt"
 	err := os.WriteFile(testFile, testFileData, 0600)
@@ -249,6 +253,7 @@ func TestAccResourceVSphereFile_renamePostCreation(t *testing.T) {
 
 // TestAccResourceVSphereFile_uploadAndCopyAndUpdate verifies uploading, copying, and updating files.
 func TestAccResourceVSphereFile_uploadAndCopyAndUpdate(t *testing.T) {
+	testAccSkipUnstable(t)
 	testFileData := []byte("test file data")
 	sourceFile := "/tmp/tf_test.txt"
 	uploadResourceName := "myfileupload"

--- a/vsphere/resource_vsphere_folder_test.go
+++ b/vsphere/resource_vsphere_folder_test.go
@@ -24,6 +24,7 @@ const testAccResourceVSphereFolderConfigExpectedParentName = "terraform-test-par
 const testAccResourceVSphereFolderConfigOOBName = "terraform-test-oob"
 
 func TestAccResourceVSphereFolder_vmFolder(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -69,6 +70,7 @@ func TestAccResourceVSphereFolder_vmFolder(t *testing.T) {
 }
 
 func TestAccResourceVSphereFolder_datastoreFolder(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -93,6 +95,7 @@ func TestAccResourceVSphereFolder_datastoreFolder(t *testing.T) {
 }
 
 func TestAccResourceVSphereFolder_networkFolder(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -117,6 +120,7 @@ func TestAccResourceVSphereFolder_networkFolder(t *testing.T) {
 }
 
 func TestAccResourceVSphereFolder_hostFolder(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -165,6 +169,7 @@ func TestAccResourceVSphereFolder_datacenterFolder(t *testing.T) {
 }
 
 func TestAccResourceVSphereFolder_rename(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -200,6 +205,7 @@ func TestAccResourceVSphereFolder_rename(t *testing.T) {
 }
 
 func TestAccResourceVSphereFolder_subfolder(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -225,6 +231,7 @@ func TestAccResourceVSphereFolder_subfolder(t *testing.T) {
 }
 
 func TestAccResourceVSphereFolder_moveToSubfolder(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -262,6 +269,7 @@ func TestAccResourceVSphereFolder_moveToSubfolder(t *testing.T) {
 }
 
 func TestAccResourceVSphereFolder_tags(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -284,6 +292,7 @@ func TestAccResourceVSphereFolder_tags(t *testing.T) {
 }
 
 func TestAccResourceVSphereFolder_modifyTags(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -315,6 +324,7 @@ func TestAccResourceVSphereFolder_modifyTags(t *testing.T) {
 }
 
 func TestAccResourceVSphereFolder_modifyTagsMultiStage(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -352,6 +362,7 @@ func TestAccResourceVSphereFolder_modifyTagsMultiStage(t *testing.T) {
 }
 
 func TestAccResourceVSphereFolder_customAttributes(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -374,6 +385,7 @@ func TestAccResourceVSphereFolder_customAttributes(t *testing.T) {
 }
 
 func TestAccResourceVSphereFolder_modifyCustomAttributes(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -405,6 +417,7 @@ func TestAccResourceVSphereFolder_modifyCustomAttributes(t *testing.T) {
 }
 
 func TestAccResourceVSphereFolder_removeAllCustomAttributes(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -438,6 +451,7 @@ func TestAccResourceVSphereFolder_removeAllCustomAttributes(t *testing.T) {
 func TestAccResourceVSphereFolder_preventDeleteIfNotEmpty(t *testing.T) {
 	var s *terraform.State
 
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()

--- a/vsphere/resource_vsphere_guest_os_customization_test.go
+++ b/vsphere/resource_vsphere_guest_os_customization_test.go
@@ -17,6 +17,7 @@ import (
 func TestAccResourceVSpherGOSC_windows_basic(t *testing.T) {
 	goscName := acctest.RandomWithPrefix("win")
 	goscResourceName := acctest.RandomWithPrefix("gosc")
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -36,6 +37,7 @@ func TestAccResourceVSpherGOSC_windows_basic(t *testing.T) {
 func TestAccResourceVSpherGOSC_windows_workGroup(t *testing.T) {
 	goscName := acctest.RandomWithPrefix("win")
 	goscResourceName := acctest.RandomWithPrefix("gosc")
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -55,6 +57,7 @@ func TestAccResourceVSpherGOSC_windows_workGroup(t *testing.T) {
 func TestAccResourceVSpherGOSC_linux(t *testing.T) {
 	goscName := acctest.RandomWithPrefix("lin")
 	goscResourceName := acctest.RandomWithPrefix("gosc")
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -74,6 +77,7 @@ func TestAccResourceVSpherGOSC_linux(t *testing.T) {
 func TestAccResourceVSpherGOSC_sysprep(t *testing.T) {
 	goscName := acctest.RandomWithPrefix("lin")
 	goscResourceName := acctest.RandomWithPrefix("gosc")
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()

--- a/vsphere/resource_vsphere_ha_vm_override_test.go
+++ b/vsphere/resource_vsphere_ha_vm_override_test.go
@@ -23,6 +23,7 @@ import (
 )
 
 func TestAccResourceVSphereHAVMOverride_basic(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -110,6 +111,7 @@ func TestAccResourceVSphereHAVMOverride_basic(t *testing.T) {
 }
 
 func TestAccResourceVSphereHAVMOverride_complete(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -149,6 +151,7 @@ func TestAccResourceVSphereHAVMOverride_complete(t *testing.T) {
 }
 
 func TestAccResourceVSphereHAVMOverride_update(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()

--- a/vsphere/resource_vsphere_host_port_group_test.go
+++ b/vsphere/resource_vsphere_host_port_group_test.go
@@ -20,7 +20,6 @@ func TestAccResourceVSphereHostPortGroup_basic(t *testing.T) {
 		PreCheck: func() {
 			RunSweepers()
 			testAccPreCheck(t)
-			testAccResourceVSphereHostPortGroupPreCheck(t)
 		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccResourceVSphereHostPortGroupExists(false),
@@ -36,6 +35,7 @@ func TestAccResourceVSphereHostPortGroup_basic(t *testing.T) {
 }
 
 func TestAccResourceVSphereHostPortGroup_complexWithOverrides(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -60,6 +60,7 @@ func TestAccResourceVSphereHostPortGroup_complexWithOverrides(t *testing.T) {
 }
 
 func TestAccResourceVSphereHostPortGroup_basicToComplex(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -176,7 +177,7 @@ func testAccResourceVSphereHostPortGroupCheckEffectivePromisc(expected bool) res
 
 func testAccResourceVSphereHostPortGroupConfig() string {
 	return fmt.Sprintf(`
-variable "host_nic0" {
+variable "host_nic1" {
   default = "%s"
 }
 
@@ -191,8 +192,8 @@ resource "vsphere_host_virtual_switch" "switch" {
   name           = "vSwitchTerraformTest2"
   host_system_id = data.vsphere_host.esxi_host.id
 
-  network_adapters = [var.host_nic0]
-  active_nics      = [var.host_nic0]
+  network_adapters = [var.host_nic1]
+  active_nics      = [var.host_nic1]
   standby_nics     = []
 }
 
@@ -201,9 +202,9 @@ resource "vsphere_host_port_group" "pg" {
   host_system_id      = data.vsphere_host.esxi_host.id
   virtual_switch_name = vsphere_host_virtual_switch.switch.name
 }
-`, testhelper.HostNic0,
+`, testhelper.HostNic1,
 		testhelper.CombineConfigs(testhelper.ConfigDataRootDC1(), testhelper.ConfigDataRootPortGroup1()),
-		os.Getenv("TF_VAR_VSPHERE_ESXI1"))
+		os.Getenv("TF_VAR_VSPHERE_ESXI3"))
 }
 
 func testAccResourceVSphereHostPortGroupConfigWithOverrides() string {

--- a/vsphere/resource_vsphere_host_virtual_switch_test.go
+++ b/vsphere/resource_vsphere_host_virtual_switch_test.go
@@ -21,7 +21,6 @@ func TestAccResourceVSphereHostVirtualSwitch_basic(t *testing.T) {
 		PreCheck: func() {
 			RunSweepers()
 			testAccPreCheck(t)
-			testAccResourceVSphereHostVirtualSwitchPreCheck(t)
 		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccResourceVSphereHostVirtualSwitchExists(false),
@@ -53,6 +52,7 @@ func TestAccResourceVSphereHostVirtualSwitch_basic(t *testing.T) {
 }
 
 func TestAccResourceVSphereHostVirtualSwitch_removeNIC(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -79,6 +79,7 @@ func TestAccResourceVSphereHostVirtualSwitch_removeNIC(t *testing.T) {
 }
 
 func TestAccResourceVSphereHostVirtualSwitch_noNICs(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -100,6 +101,7 @@ func TestAccResourceVSphereHostVirtualSwitch_noNICs(t *testing.T) {
 }
 
 func TestAccResourceVSphereHostVirtualSwitch_badActiveNICList(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -119,6 +121,7 @@ func TestAccResourceVSphereHostVirtualSwitch_badActiveNICList(t *testing.T) {
 }
 
 func TestAccResourceVSphereHostVirtualSwitch_badStandbyNICList(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -138,6 +141,7 @@ func TestAccResourceVSphereHostVirtualSwitch_badStandbyNICList(t *testing.T) {
 }
 
 func TestAccResourceVSphereHostVirtualSwitch_removeAllNICs(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -233,11 +237,11 @@ func testAccResourceVSphereHostVirtualSwitchNoBridge() resource.TestCheckFunc {
 
 func testAccResourceVSphereHostVirtualSwitchConfig() string {
 	return fmt.Sprintf(`
-variable "host_nic0" {
+variable "host_nic1" {
   default = "%s"
 }
 
-variable "host_nic1" {
+variable "host_nic2" {
   default = "%s"
 }
 
@@ -252,15 +256,15 @@ resource "vsphere_host_virtual_switch" "switch" {
   name           = "vSwitchTerraformTest2"
   host_system_id = data.vsphere_host.esxi_host.id
 
-  network_adapters = [var.host_nic0, var.host_nic1]
+  network_adapters = [var.host_nic1, var.host_nic2]
 
-  active_nics  = [var.host_nic0]
-  standby_nics = [var.host_nic1]
+  active_nics  = [var.host_nic1]
+  standby_nics = [var.host_nic2]
 }
-`, testhelper.HostNic0,
-		testhelper.HostNic1,
+`, testhelper.HostNic1,
+		testhelper.HostNic2,
 		testhelper.CombineConfigs(testhelper.ConfigDataRootDC1(), testhelper.ConfigDataRootPortGroup1()),
-		os.Getenv("TF_VAR_VSPHERE_ESXI1"))
+		os.Getenv("TF_VAR_VSPHERE_ESXI3"))
 }
 
 func testAccResourceVSphereHostVirtualSwitchConfigSingleNIC() string {

--- a/vsphere/resource_vsphere_license_test.go
+++ b/vsphere/resource_vsphere_license_test.go
@@ -26,6 +26,7 @@ resource "vsphere_license" "foo" {
 `
 
 func TestAccResourceVSphereLicense_basic(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -46,6 +47,7 @@ func TestAccResourceVSphereLicense_basic(t *testing.T) {
 }
 
 func TestAccResourceVSphereLicense_invalid(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -66,6 +68,7 @@ func TestAccResourceVSphereLicense_invalid(t *testing.T) {
 }
 
 func TestAccResourceVSphereLicense_withLabelsOnVCenter(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -88,6 +91,7 @@ func TestAccResourceVSphereLicense_withLabelsOnVCenter(t *testing.T) {
 }
 
 func TestAccResourceVSphereLicense_withLabelsOnESXiServer(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()

--- a/vsphere/resource_vsphere_nas_datastore_test.go
+++ b/vsphere/resource_vsphere_nas_datastore_test.go
@@ -19,6 +19,7 @@ import (
 )
 
 func TestAccResourceVSphereNasDatastore_basic(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -45,6 +46,7 @@ func TestAccResourceVSphereNasDatastore_basic(t *testing.T) {
 }
 
 func TestAccResourceVSphereNasDatastore_multiHost(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -66,6 +68,7 @@ func TestAccResourceVSphereNasDatastore_multiHost(t *testing.T) {
 }
 
 func TestAccResourceVSphereNasDatastore_basicToMultiHost(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -93,6 +96,7 @@ func TestAccResourceVSphereNasDatastore_basicToMultiHost(t *testing.T) {
 }
 
 func TestAccResourceVSphereNasDatastore_multiHostToBasic(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -120,6 +124,7 @@ func TestAccResourceVSphereNasDatastore_multiHostToBasic(t *testing.T) {
 }
 
 func TestAccResourceVSphereNasDatastore_renameDatastore(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -147,6 +152,7 @@ func TestAccResourceVSphereNasDatastore_renameDatastore(t *testing.T) {
 }
 
 func TestAccResourceVSphereNasDatastore_inFolder(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -174,6 +180,7 @@ func TestAccResourceVSphereNasDatastore_inFolder(t *testing.T) {
 }
 
 func TestAccResourceVSphereNasDatastore_moveToFolder(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -202,6 +209,7 @@ func TestAccResourceVSphereNasDatastore_moveToFolder(t *testing.T) {
 }
 
 func TestAccResourceVSphereNasDatastore_inDatastoreCluster(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -224,6 +232,7 @@ func TestAccResourceVSphereNasDatastore_inDatastoreCluster(t *testing.T) {
 }
 
 func TestAccResourceVSphereNasDatastore_moveToDatastoreCluster(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -251,6 +260,7 @@ func TestAccResourceVSphereNasDatastore_moveToDatastoreCluster(t *testing.T) {
 }
 
 func TestAccResourceVSphereNasDatastore_singleTag(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -272,6 +282,7 @@ func TestAccResourceVSphereNasDatastore_singleTag(t *testing.T) {
 }
 
 func TestAccResourceVSphereNasDatastore_modifyTags(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -300,6 +311,7 @@ func TestAccResourceVSphereNasDatastore_modifyTags(t *testing.T) {
 }
 
 func TestAccResourceVSphereNasDatastore_singleCustomAttribute(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -321,6 +333,7 @@ func TestAccResourceVSphereNasDatastore_singleCustomAttribute(t *testing.T) {
 }
 
 func TestAccResourceVSphereNasDatastore_multiCustomAttribute(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()

--- a/vsphere/resource_vsphere_offline_software_depot_test.go
+++ b/vsphere/resource_vsphere_offline_software_depot_test.go
@@ -15,6 +15,7 @@ import (
 )
 
 func TestAccResourceVSphereOfflineSoftwareDepot_basic(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()

--- a/vsphere/resource_vsphere_resource_pool_test.go
+++ b/vsphere/resource_vsphere_resource_pool_test.go
@@ -22,7 +22,6 @@ func TestAccResourceVSphereResourcePool_basic(t *testing.T) {
 		PreCheck: func() {
 			RunSweepers()
 			testAccPreCheck(t)
-			testAccResourceVSphereResourcePoolPreCheck(t)
 		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccResourceVSphereResourcePoolCheckExists(false),
@@ -70,6 +69,7 @@ func TestAccResourceVSphereResourcePool_basic(t *testing.T) {
 }
 
 func TestAccResourceVSphereResourcePool_updateRename(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -99,6 +99,7 @@ func TestAccResourceVSphereResourcePool_updateRename(t *testing.T) {
 }
 
 func TestAccResourceVSphereResourcePool_updateToCustom(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -144,6 +145,7 @@ func TestAccResourceVSphereResourcePool_updateToCustom(t *testing.T) {
 }
 
 func TestAccResourceVSphereResourcePool_updateToDefaults(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -188,6 +190,7 @@ func TestAccResourceVSphereResourcePool_updateToDefaults(t *testing.T) {
 }
 
 func TestAccResourceVSphereResourcePool_esxiHost(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -208,6 +211,7 @@ func TestAccResourceVSphereResourcePool_esxiHost(t *testing.T) {
 }
 
 func TestAccResourceVSphereResourcePool_updateParent(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -236,6 +240,7 @@ func TestAccResourceVSphereResourcePool_updateParent(t *testing.T) {
 }
 
 func TestAccResourceVSphereResourcePool_tags(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()

--- a/vsphere/resource_vsphere_role_test.go
+++ b/vsphere/resource_vsphere_role_test.go
@@ -51,6 +51,7 @@ func TestAccResourceVsphereRole_createRole(t *testing.T) {
 
 func TestAccResourceVsphereRole_addPrivileges(t *testing.T) {
 	roleName := "terraform_role" + acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
@@ -84,6 +85,7 @@ func TestAccResourceVsphereRole_addPrivileges(t *testing.T) {
 
 func TestAccResourceVsphereRole_removePrivileges(t *testing.T) {
 	roleName := "terraform_role" + acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
@@ -116,6 +118,7 @@ func TestAccResourceVsphereRole_removePrivileges(t *testing.T) {
 }
 
 func TestAccResourceVsphereRole_importSystemRoleShouldError(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)

--- a/vsphere/resource_vsphere_storage_drs_vm_override_test.go
+++ b/vsphere/resource_vsphere_storage_drs_vm_override_test.go
@@ -22,6 +22,7 @@ import (
 )
 
 func TestAccResourceVSphereStorageDrsVMOverride_basic(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -73,6 +74,7 @@ func TestAccResourceVSphereStorageDrsVMOverride_basic(t *testing.T) {
 }
 
 func TestAccResourceVSphereStorageDrsVMOverride_overrides(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -94,6 +96,7 @@ func TestAccResourceVSphereStorageDrsVMOverride_overrides(t *testing.T) {
 }
 
 func TestAccResourceVSphereStorageDrsVMOverride_update(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()

--- a/vsphere/resource_vsphere_supervisor_test.go
+++ b/vsphere/resource_vsphere_supervisor_test.go
@@ -14,6 +14,7 @@ import (
 )
 
 func TestAccResourceVSphereSupervisor_basic(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccCheckEnvVariables(t, []string{
@@ -39,6 +40,7 @@ func TestAccResourceVSphereSupervisor_basic(t *testing.T) {
 }
 
 func TestAccResourceVSphereSupervisor_full(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccCheckEnvVariables(t, []string{

--- a/vsphere/resource_vsphere_tag_category_test.go
+++ b/vsphere/resource_vsphere_tag_category_test.go
@@ -18,6 +18,7 @@ import (
 )
 
 func TestAccResourceVSphereTagCategory_basic(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -58,6 +59,7 @@ func TestAccResourceVSphereTagCategory_basic(t *testing.T) {
 }
 
 func TestAccResourceVSphereTagCategory_addType(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -90,6 +92,7 @@ func TestAccResourceVSphereTagCategory_addType(t *testing.T) {
 }
 
 func TestAccResourceVSphereTagCategory_removeTypeShouldError(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -113,6 +116,7 @@ func TestAccResourceVSphereTagCategory_removeTypeShouldError(t *testing.T) {
 }
 
 func TestAccResourceVSphereTagCategory_invalidTypeShouldError(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -130,6 +134,7 @@ func TestAccResourceVSphereTagCategory_invalidTypeShouldError(t *testing.T) {
 }
 
 func TestAccResourceVSphereTagCategory_rename(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -156,6 +161,7 @@ func TestAccResourceVSphereTagCategory_rename(t *testing.T) {
 }
 
 func TestAccResourceVSphereTagCategory_singleCardinality(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -176,6 +182,7 @@ func TestAccResourceVSphereTagCategory_singleCardinality(t *testing.T) {
 }
 
 func TestAccResourceVSphereTagCategory_multiCardinality(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()

--- a/vsphere/resource_vsphere_tag_test.go
+++ b/vsphere/resource_vsphere_tag_test.go
@@ -67,6 +67,7 @@ func TestAccResourceVSphereTag_basic(t *testing.T) {
 }
 
 func TestAccResourceVSphereTag_changeName(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -93,6 +94,7 @@ func TestAccResourceVSphereTag_changeName(t *testing.T) {
 }
 
 func TestAccResourceVSphereTag_changeDescription(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -119,6 +121,7 @@ func TestAccResourceVSphereTag_changeDescription(t *testing.T) {
 }
 
 func TestAccResourceVSphereTag_detachAllTags(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()

--- a/vsphere/resource_vsphere_vapp_container_test.go
+++ b/vsphere/resource_vsphere_vapp_container_test.go
@@ -23,6 +23,7 @@ const (
 )
 
 func TestAccResourceVSphereVAppContainer_basic(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -75,6 +76,7 @@ func TestAccResourceVSphereVAppContainer_basic(t *testing.T) {
 }
 
 func TestAccResourceVSphereVAppContainer_childImport(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -115,6 +117,7 @@ func TestAccResourceVSphereVAppContainer_childImport(t *testing.T) {
 }
 
 func TestAccResourceVSphereVAppContainer_vmBasic(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -136,6 +139,7 @@ func TestAccResourceVSphereVAppContainer_vmBasic(t *testing.T) {
 }
 
 func TestAccResourceVSphereVAppContainer_vmMoveIntoVApp(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -163,6 +167,7 @@ func TestAccResourceVSphereVAppContainer_vmMoveIntoVApp(t *testing.T) {
 }
 
 func TestAccResourceVSphereVAppContainer_vmSDRS(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -184,6 +189,7 @@ func TestAccResourceVSphereVAppContainer_vmSDRS(t *testing.T) {
 }
 
 func TestAccResourceVSphereVAppContainer_vmClone(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -205,6 +211,7 @@ func TestAccResourceVSphereVAppContainer_vmClone(t *testing.T) {
 }
 
 func TestAccResourceVSphereVAppContainer_vmCloneSDRS(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -226,6 +233,7 @@ func TestAccResourceVSphereVAppContainer_vmCloneSDRS(t *testing.T) {
 }
 
 func TestAccResourceVSphereVAppContainer_vmMoveIntoVAppSDRS(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()

--- a/vsphere/resource_vsphere_vapp_entity_test.go
+++ b/vsphere/resource_vsphere_vapp_entity_test.go
@@ -17,6 +17,7 @@ import (
 )
 
 func TestAccResourceVSphereVAppEntity_basic(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -48,6 +49,7 @@ func TestAccResourceVSphereVAppEntity_basic(t *testing.T) {
 }
 
 func TestAccResourceVSphereVAppEntity_nonDefault(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -74,6 +76,7 @@ func TestAccResourceVSphereVAppEntity_nonDefault(t *testing.T) {
 }
 
 func TestAccResourceVSphereVAppEntity_update(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -112,6 +115,7 @@ func TestAccResourceVSphereVAppEntity_update(t *testing.T) {
 }
 
 func TestAccResourceVSphereVAppEntity_multi(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -148,6 +152,7 @@ func TestAccResourceVSphereVAppEntity_multi(t *testing.T) {
 }
 
 func TestAccResourceVSphereVAppEntity_multiUpdate(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()

--- a/vsphere/resource_vsphere_virtual_disk_test.go
+++ b/vsphere/resource_vsphere_virtual_disk_test.go
@@ -25,7 +25,6 @@ func TestAccResourceVSphereVirtualDisk_basic(t *testing.T) {
 		PreCheck: func() {
 			RunSweepers()
 			testAccPreCheck(t)
-			testAccResourceVSphereVirtualDiskPreCheck(t)
 		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccVSphereVirtualDiskExists("vsphere_virtual_disk.foo", false),
@@ -43,6 +42,7 @@ func TestAccResourceVSphereVirtualDisk_basic(t *testing.T) {
 func TestAccResourceVSphereVirtualDisk_extend(t *testing.T) {
 	rString := acctest.RandString(5)
 
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -73,6 +73,7 @@ func TestAccResourceVSphereVirtualDisk_extend(t *testing.T) {
 func TestAccResourceVSphereVirtualDisk_multi(t *testing.T) {
 	rString := acctest.RandString(5)
 
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -101,6 +102,7 @@ func TestAccResourceVSphereVirtualDisk_multi(t *testing.T) {
 func TestAccResourceVSphereVirtualDisk_multiWithParent(t *testing.T) {
 	rString := acctest.RandString(5)
 
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -129,6 +131,7 @@ func TestAccResourceVSphereVirtualDisk_multiWithParent(t *testing.T) {
 func TestAccResourceVSphereVirtualDisk_withParent(t *testing.T) {
 	rString := acctest.RandString(5)
 
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -220,10 +223,14 @@ resource "vsphere_virtual_disk" "foo" {
   adapter_type = "lsiLogic"
   type         = "thin"
   datacenter   = data.vsphere_datacenter.rootdc1.name
-  datastore    = vsphere_nas_datastore.ds1.name
+  datastore    = data.vsphere_datastore.rootds1.name
 }
 `,
-		testhelper.CombineConfigs(testhelper.ConfigDataRootDC1(), testhelper.ConfigDataRootHost1(), testhelper.ConfigDataRootHost2(), testhelper.ConfigResDS1()),
+		testhelper.CombineConfigs(
+			testhelper.ConfigDataRootDC1(),
+			testhelper.ConfigDataRootHost1(),
+			testhelper.ConfigDataRootHost2(),
+			testhelper.ConfigDataRootDS1()),
 		rName,
 	)
 }

--- a/vsphere/resource_vsphere_virtual_machine_class_test.go
+++ b/vsphere/resource_vsphere_virtual_machine_class_test.go
@@ -11,7 +11,11 @@ import (
 )
 
 func TestAccResourceVSphereVmClass_basic(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
@@ -25,7 +29,11 @@ func TestAccResourceVSphereVmClass_basic(t *testing.T) {
 }
 
 func TestAccResourceVSphereVmClass_vgpu(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{

--- a/vsphere/resource_vsphere_virtual_machine_snapshot_test.go
+++ b/vsphere/resource_vsphere_virtual_machine_snapshot_test.go
@@ -17,6 +17,7 @@ import (
 )
 
 func TestAccResourceVSphereVirtualMachineSnapshot_basic(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()

--- a/vsphere/resource_vsphere_virtual_machine_test.go
+++ b/vsphere/resource_vsphere_virtual_machine_test.go
@@ -44,7 +44,6 @@ func TestAccResourceVSphereVirtualMachine_basic(t *testing.T) {
 		PreCheck: func() {
 			RunSweepers()
 			testAccPreCheck(t)
-			testAccResourceVSphereVirtualMachinePreCheck(t)
 		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccResourceVSphereVirtualMachineCheckExists(false),
@@ -82,6 +81,7 @@ func TestAccResourceVSphereVirtualMachine_basic(t *testing.T) {
 }
 
 func TestAccResourceVSphereVirtualMachine_hardwareVersionBare(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -103,6 +103,7 @@ func TestAccResourceVSphereVirtualMachine_hardwareVersionBare(t *testing.T) {
 }
 
 func TestAccResourceVSphereVirtualMachine_hardwareVersionUpgrade(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -131,6 +132,7 @@ func TestAccResourceVSphereVirtualMachine_hardwareVersionUpgrade(t *testing.T) {
 }
 
 func TestAccResourceVSphereVirtualMachine_hardwareVersionInvalidVersion(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -153,6 +155,7 @@ func TestAccResourceVSphereVirtualMachine_hardwareVersionInvalidVersion(t *testi
 }
 
 func TestAccResourceVSphereVirtualMachine_hardwareVersionDowngrade(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -178,6 +181,7 @@ func TestAccResourceVSphereVirtualMachine_hardwareVersionDowngrade(t *testing.T)
 }
 
 func TestAccResourceVSphereVirtualMachine_hardwareVersionClone(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -199,6 +203,7 @@ func TestAccResourceVSphereVirtualMachine_hardwareVersionClone(t *testing.T) {
 }
 
 func TestAccResourceVSphereVirtualMachineContentLibrary_basic(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -220,6 +225,7 @@ func TestAccResourceVSphereVirtualMachineContentLibrary_basic(t *testing.T) {
 }
 
 func TestAccResourceVSphereVirtualMachine_ignoreValidationOnComputedValue(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -239,6 +245,7 @@ func TestAccResourceVSphereVirtualMachine_ignoreValidationOnComputedValue(t *tes
 }
 
 func TestAccResourceVSphereVirtualMachine_highLatencySensitivity(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -260,6 +267,7 @@ func TestAccResourceVSphereVirtualMachine_highLatencySensitivity(t *testing.T) {
 }
 
 func TestAccResourceVSphereVirtualMachine_ESXiOnly(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -283,6 +291,7 @@ func TestAccResourceVSphereVirtualMachine_ESXiOnly(t *testing.T) {
 func TestAccResourceVSphereVirtualMachine_shutdownOK(t *testing.T) {
 	var state *terraform.State
 
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -315,6 +324,7 @@ func TestAccResourceVSphereVirtualMachine_shutdownOK(t *testing.T) {
 func TestAccResourceVSphereVirtualMachine_reCreateOnDeletion(t *testing.T) {
 	var state *terraform.State
 
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -351,6 +361,7 @@ func TestAccResourceVSphereVirtualMachine_reCreateOnDeletion(t *testing.T) {
 }
 
 func TestAccResourceVSphereVirtualMachine_multiDevice(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -372,6 +383,7 @@ func TestAccResourceVSphereVirtualMachine_multiDevice(t *testing.T) {
 }
 
 func TestAccResourceVSphereVirtualMachine_addDevices(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -400,6 +412,7 @@ func TestAccResourceVSphereVirtualMachine_addDevices(t *testing.T) {
 
 func TestAccResourceVSphereVirtualMachine_removeMiddleDevices(t *testing.T) {
 	var state *terraform.State
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -439,6 +452,7 @@ func TestAccResourceVSphereVirtualMachine_removeMiddleDevices(t *testing.T) {
 }
 
 func TestAccResourceVSphereVirtualMachine_removeMiddleDevicesChangeDiskUnit(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -467,6 +481,7 @@ func TestAccResourceVSphereVirtualMachine_removeMiddleDevicesChangeDiskUnit(t *t
 }
 
 func TestAccResourceVSphereVirtualMachine_highDiskUnitNumbers(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -493,6 +508,7 @@ func TestAccResourceVSphereVirtualMachine_highDiskUnitNumbers(t *testing.T) {
 }
 
 func TestAccResourceVSphereVirtualMachine_highDiskUnitInsufficientBus(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -511,6 +527,7 @@ func TestAccResourceVSphereVirtualMachine_highDiskUnitInsufficientBus(t *testing
 }
 
 func TestAccResourceVSphereVirtualMachine_highDiskUnitsToRegularSingleController(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -543,6 +560,7 @@ func TestAccResourceVSphereVirtualMachine_highDiskUnitsToRegularSingleController
 }
 
 func TestAccResourceVSphereVirtualMachine_scsiBusSharing(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -564,6 +582,7 @@ func TestAccResourceVSphereVirtualMachine_scsiBusSharing(t *testing.T) {
 }
 
 func TestAccResourceVSphereVirtualMachine_scsiBusSharingUpdate(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -593,6 +612,7 @@ func TestAccResourceVSphereVirtualMachine_scsiBusSharingUpdate(t *testing.T) {
 
 func TestAccResourceVSphereVirtualMachine_disksKeepOnRemove(t *testing.T) {
 	var disks []map[string]string
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -621,6 +641,7 @@ func TestAccResourceVSphereVirtualMachine_disksKeepOnRemove(t *testing.T) {
 }
 
 func TestAccResourceVSphereVirtualMachine_cdromClientMapping(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -642,6 +663,7 @@ func TestAccResourceVSphereVirtualMachine_cdromClientMapping(t *testing.T) {
 }
 
 func TestAccResourceVSphereVirtualMachine_vAppIsoBasic(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -663,6 +685,7 @@ func TestAccResourceVSphereVirtualMachine_vAppIsoBasic(t *testing.T) {
 }
 
 func TestAccResourceVSphereVirtualMachine_vAppIsoNoVApp(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -686,6 +709,7 @@ func TestAccResourceVSphereVirtualMachine_vAppIsoNoVApp(t *testing.T) {
 }
 
 func TestAccResourceVSphereVirtualMachine_vAppIsoNoCdrom(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -708,6 +732,7 @@ func TestAccResourceVSphereVirtualMachine_vAppIsoNoCdrom(t *testing.T) {
 }
 
 func TestAccResourceVSphereVirtualMachine_vAppIsoConfigIsoIgnored(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -732,6 +757,7 @@ func TestAccResourceVSphereVirtualMachine_vAppIsoConfigIsoIgnored(t *testing.T) 
 
 func TestAccResourceVSphereVirtualMachine_vAppIsoChangeCdromBacking(t *testing.T) {
 	var state *terraform.State
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -761,6 +787,7 @@ func TestAccResourceVSphereVirtualMachine_vAppIsoChangeCdromBacking(t *testing.T
 
 func TestAccResourceVSphereVirtualMachine_vAppIsoPoweredOffCdromRead(t *testing.T) {
 	var state *terraform.State
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -793,6 +820,7 @@ func TestAccResourceVSphereVirtualMachine_vAppIsoPoweredOffCdromRead(t *testing.
 }
 
 func TestAccResourceVSphereVirtualMachine_vvtdAndVbs(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
@@ -812,6 +840,7 @@ func TestAccResourceVSphereVirtualMachine_vvtdAndVbs(t *testing.T) {
 }
 
 func TestAccResourceVSphereVirtualMachine_cdromNoParameters(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -833,6 +862,7 @@ func TestAccResourceVSphereVirtualMachine_cdromNoParameters(t *testing.T) {
 }
 
 func TestAccResourceVSphereVirtualMachine_cdromIsoBacking(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -852,6 +882,7 @@ func TestAccResourceVSphereVirtualMachine_cdromIsoBacking(t *testing.T) {
 	})
 }
 func TestAccResourceVSphereVirtualMachine_cdromConflictingParameters(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -870,6 +901,7 @@ func TestAccResourceVSphereVirtualMachine_cdromConflictingParameters(t *testing.
 }
 
 func TestAccResourceVSphereVirtualMachine_maximumNumberOfNICs(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -891,6 +923,7 @@ func TestAccResourceVSphereVirtualMachine_maximumNumberOfNICs(t *testing.T) {
 }
 
 func TestAccResourceVSphereVirtualMachine_upgradeCPUAndRam(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -922,6 +955,7 @@ func TestAccResourceVSphereVirtualMachine_upgradeCPUAndRam(t *testing.T) {
 }
 
 func TestAccResourceVSphereVirtualMachine_modifyAnnotation(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -950,6 +984,7 @@ func TestAccResourceVSphereVirtualMachine_modifyAnnotation(t *testing.T) {
 }
 
 func TestAccResourceVSphereVirtualMachine_growDisk(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -978,6 +1013,7 @@ func TestAccResourceVSphereVirtualMachine_growDisk(t *testing.T) {
 }
 
 func TestAccResourceVSphereVirtualMachine_swapSCSIBus(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -1006,6 +1042,7 @@ func TestAccResourceVSphereVirtualMachine_swapSCSIBus(t *testing.T) {
 }
 
 func TestAccResourceVSphereVirtualMachine_extraConfig(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -1035,6 +1072,7 @@ func TestAccResourceVSphereVirtualMachine_extraConfig(t *testing.T) {
 }
 
 func TestAccResourceVSphereVirtualMachine_extraConfigSwapKeys(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -1064,6 +1102,7 @@ func TestAccResourceVSphereVirtualMachine_extraConfigSwapKeys(t *testing.T) {
 }
 
 func TestAccResourceVSphereVirtualMachine_attachExistingVmdk(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -1085,6 +1124,7 @@ func TestAccResourceVSphereVirtualMachine_attachExistingVmdk(t *testing.T) {
 }
 
 func TestAccResourceVSphereVirtualMachine_attachExistingVmdkTaint(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -1114,6 +1154,7 @@ func TestAccResourceVSphereVirtualMachine_attachExistingVmdkTaint(t *testing.T) 
 }
 
 func TestAccResourceVSphereVirtualMachine_resourcePoolMove(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -1142,6 +1183,7 @@ func TestAccResourceVSphereVirtualMachine_resourcePoolMove(t *testing.T) {
 }
 
 func TestAccResourceVSphereVirtualMachine_vAppContainerAndFolder(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -1160,6 +1202,7 @@ func TestAccResourceVSphereVirtualMachine_vAppContainerAndFolder(t *testing.T) {
 }
 
 func TestAccResourceVSphereVirtualMachine_vAppContainerMove(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -1195,6 +1238,7 @@ func TestAccResourceVSphereVirtualMachine_vAppContainerMove(t *testing.T) {
 }
 
 func TestAccResourceVSphereVirtualMachine_inFolder(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -1216,6 +1260,7 @@ func TestAccResourceVSphereVirtualMachine_inFolder(t *testing.T) {
 }
 
 func TestAccResourceVSphereVirtualMachine_moveToFolder(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -1243,6 +1288,7 @@ func TestAccResourceVSphereVirtualMachine_moveToFolder(t *testing.T) {
 }
 
 func TestAccResourceVSphereVirtualMachine_staticMAC(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -1264,6 +1310,7 @@ func TestAccResourceVSphereVirtualMachine_staticMAC(t *testing.T) {
 }
 
 func TestAccResourceVSphereVirtualMachine_singleTag(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -1285,6 +1332,7 @@ func TestAccResourceVSphereVirtualMachine_singleTag(t *testing.T) {
 }
 
 func TestAccResourceVSphereVirtualMachine_multipleTags(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -1306,6 +1354,7 @@ func TestAccResourceVSphereVirtualMachine_multipleTags(t *testing.T) {
 }
 
 func TestAccResourceVSphereVirtualMachine_switchTags(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -1336,6 +1385,7 @@ func TestAccResourceVSphereVirtualMachine_switchTags(t *testing.T) {
 func TestAccResourceVSphereVirtualMachine_renamedDiskInPlaceOfExisting(t *testing.T) {
 	var state *terraform.State
 
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -1386,6 +1436,7 @@ func TestAccResourceVSphereVirtualMachine_renamedDiskInPlaceOfExisting(t *testin
 }
 
 func TestAccResourceVSphereVirtualMachine_blockComputedDiskName(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -1410,6 +1461,7 @@ func TestAccResourceVSphereVirtualMachine_blockComputedDiskName(t *testing.T) {
 }
 
 func TestAccResourceVSphereVirtualMachine_blockVAppSettingsOnNonClones(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -1428,6 +1480,7 @@ func TestAccResourceVSphereVirtualMachine_blockVAppSettingsOnNonClones(t *testin
 }
 
 func TestAccResourceVSphereVirtualMachine_blockVAppSettingsOnNonClonesAfterCreation(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -1458,6 +1511,7 @@ func TestAccResourceVSphereVirtualMachine_blockVAppSettingsOnNonClonesAfterCreat
 }
 
 func TestAccResourceVSphereVirtualMachine_blockDiskLabelStartingWithOrphanedPrefix(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -1477,6 +1531,7 @@ func TestAccResourceVSphereVirtualMachine_blockDiskLabelStartingWithOrphanedPref
 }
 
 func TestAccResourceVSphereVirtualMachine_createIntoEmptyClusterNoEnvironmentBrowser(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -1495,6 +1550,7 @@ func TestAccResourceVSphereVirtualMachine_createIntoEmptyClusterNoEnvironmentBro
 }
 
 func TestAccResourceVSphereVirtualMachine_cloneFromTemplate(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -1515,6 +1571,7 @@ func TestAccResourceVSphereVirtualMachine_cloneFromTemplate(t *testing.T) {
 }
 
 func TestAccResourceVSphereVirtualMachine_clonePoweredOn(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -1535,6 +1592,7 @@ func TestAccResourceVSphereVirtualMachine_clonePoweredOn(t *testing.T) {
 }
 
 func TestAccResourceVSphereVirtualMachine_cloneCustomizeWithNewResourcePool(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -1557,6 +1615,7 @@ func TestAccResourceVSphereVirtualMachine_cloneCustomizeWithNewResourcePool(t *t
 func TestAccResourceVSphereVirtualMachine_cloneCustomizeForceNewWithDatastore(t *testing.T) {
 	var state *terraform.State
 
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -1608,6 +1667,7 @@ func TestAccResourceVSphereVirtualMachine_cloneCustomizeForceNewWithDatastore(t 
 func TestAccResourceVSphereVirtualMachine_cloneModifyDiskAndSCSITypeAtSameTime(t *testing.T) {
 	var state *terraform.State
 
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -1646,8 +1706,8 @@ func TestAccResourceVSphereVirtualMachine_cloneModifyDiskAndSCSITypeAtSameTime(t
 func TestAccResourceVSphereVirtualMachine_cloneMultiNICWithSameGateway(t *testing.T) {
 	// This test is intentionally disabled by default.
 	// Requires a Windows virtual machine template to run this test.
-	t.Skip()
 
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -1668,6 +1728,7 @@ func TestAccResourceVSphereVirtualMachine_cloneMultiNICWithSameGateway(t *testin
 }
 
 func TestAccResourceVSphereVirtualMachine_cloneMultiNICFromSingleNICTemplate(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -1688,6 +1749,7 @@ func TestAccResourceVSphereVirtualMachine_cloneMultiNICFromSingleNICTemplate(t *
 }
 
 func TestAccResourceVSphereVirtualMachine_cloneMultiNICSRIOVFromVMXNET3Template(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -1708,6 +1770,7 @@ func TestAccResourceVSphereVirtualMachine_cloneMultiNICSRIOVFromVMXNET3Template(
 }
 
 func TestAccResourceVSphereVirtualMachine_cloneWithDifferentTimezone(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -1728,6 +1791,7 @@ func TestAccResourceVSphereVirtualMachine_cloneWithDifferentTimezone(t *testing.
 }
 
 func TestAccResourceVSphereVirtualMachine_cloneBlockESXi(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -1752,6 +1816,7 @@ func TestAccResourceVSphereVirtualMachine_cloneBlockESXi(t *testing.T) {
 }
 
 func TestAccResourceVSphereVirtualMachine_cloneWithBadTimezone(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -1794,6 +1859,7 @@ func TestAccResourceVSphereVirtualMachine_cloneWithBadTimezone(t *testing.T) {
 //}
 
 func TestAccResourceVSphereVirtualMachine_cloneWithBadSizeWithLinkedClone(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -1813,6 +1879,7 @@ func TestAccResourceVSphereVirtualMachine_cloneWithBadSizeWithLinkedClone(t *tes
 }
 
 func TestAccResourceVSphereVirtualMachine_cloneWithBadSizeWithoutLinkedClone(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -1832,6 +1899,7 @@ func TestAccResourceVSphereVirtualMachine_cloneWithBadSizeWithoutLinkedClone(t *
 }
 
 func TestAccResourceVSphereVirtualMachine_cloneIntoEmptyCluster(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
@@ -1852,6 +1920,7 @@ func TestAccResourceVSphereVirtualMachine_cloneIntoEmptyCluster(t *testing.T) {
 }
 
 func TestAccResourceVSphereVirtualMachine_cloneWithDifferentHostname(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -1872,6 +1941,7 @@ func TestAccResourceVSphereVirtualMachine_cloneWithDifferentHostname(t *testing.
 	})
 }
 func TestAccResourceVSphereVirtualMachine_cloneWithDiskTypeChange(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -1893,6 +1963,7 @@ func TestAccResourceVSphereVirtualMachine_cloneWithDiskTypeChange(t *testing.T) 
 }
 
 func TestAccResourceVSphereVirtualMachine_cloneOnDsCuster(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -1914,6 +1985,7 @@ func TestAccResourceVSphereVirtualMachine_cloneOnDsCuster(t *testing.T) {
 }
 
 func TestAccResourceVSphereVirtualMachine_cpuHotAdd(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -1945,6 +2017,7 @@ func TestAccResourceVSphereVirtualMachine_cpuHotAdd(t *testing.T) {
 }
 
 func TestAccResourceVSphereVirtualMachine_memoryHotAdd(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -1976,6 +2049,7 @@ func TestAccResourceVSphereVirtualMachine_memoryHotAdd(t *testing.T) {
 }
 
 func TestAccResourceVSphereVirtualMachine_dualStackIPv4AndIPv6(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -1997,6 +2071,7 @@ func TestAccResourceVSphereVirtualMachine_dualStackIPv4AndIPv6(t *testing.T) {
 }
 
 func TestAccResourceVSphereVirtualMachine_hostCheck(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -2025,6 +2100,7 @@ func TestAccResourceVSphereVirtualMachine_hostCheck(t *testing.T) {
 }
 
 func TestAccResourceVSphereVirtualMachine_hostVMotion(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -2053,6 +2129,7 @@ func TestAccResourceVSphereVirtualMachine_hostVMotion(t *testing.T) {
 }
 
 func TestAccResourceVSphereVirtualMachine_resourcePoolVMotion(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -2081,6 +2158,7 @@ func TestAccResourceVSphereVirtualMachine_resourcePoolVMotion(t *testing.T) {
 }
 
 func TestAccResourceVSphereVirtualMachine_storageVMotionGlobalSetting(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -2117,6 +2195,7 @@ func TestAccResourceVSphereVirtualMachine_storageVMotionGlobalSetting(t *testing
 }
 
 func TestAccResourceVSphereVirtualMachine_storageVMotionSingleDisk(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -2152,6 +2231,7 @@ func TestAccResourceVSphereVirtualMachine_storageVMotionSingleDisk(t *testing.T)
 }
 
 func TestAccResourceVSphereVirtualMachine_storageVMotionPinDatastore(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -2187,6 +2267,7 @@ func TestAccResourceVSphereVirtualMachine_storageVMotionPinDatastore(t *testing.
 }
 
 func TestAccResourceVSphereVirtualMachine_storageVMotionRenamedVirtualMachine(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -2230,6 +2311,7 @@ func TestAccResourceVSphereVirtualMachine_storageVMotionRenamedVirtualMachine(t 
 func TestAccResourceVSphereVirtualMachine_storageVMotionLinkedClones(t *testing.T) {
 	var state *terraform.State
 
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -2269,6 +2351,7 @@ func TestAccResourceVSphereVirtualMachine_storageVMotionLinkedClones(t *testing.
 }
 
 func TestAccResourceVSphereVirtualMachine_storageVMotionBlockExternallyAttachedDisks(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -2300,6 +2383,7 @@ func TestAccResourceVSphereVirtualMachine_storageVMotionBlockExternallyAttachedD
 }
 
 func TestAccResourceVSphereVirtualMachine_singleCustomAttribute(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -2321,6 +2405,7 @@ func TestAccResourceVSphereVirtualMachine_singleCustomAttribute(t *testing.T) {
 }
 
 func TestAccResourceVSphereVirtualMachine_multiCustomAttribute(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -2342,6 +2427,7 @@ func TestAccResourceVSphereVirtualMachine_multiCustomAttribute(t *testing.T) {
 }
 
 func TestAccResourceVSphereVirtualMachine_switchCustomAttribute(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -2370,6 +2456,7 @@ func TestAccResourceVSphereVirtualMachine_switchCustomAttribute(t *testing.T) {
 }
 
 func TestAccResourceVSphereVirtualMachine_multipleDisksAtDifferentSCSISlotsImport(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -2411,6 +2498,7 @@ func TestAccResourceVSphereVirtualMachine_multipleDisksAtDifferentSCSISlotsImpor
 }
 
 func TestAccResourceVSphereVirtualMachine_cloneImport(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -2493,6 +2581,7 @@ func TestAccResourceVSphereVirtualMachine_cloneImport(t *testing.T) {
 }
 
 func TestAccResourceVSphereVirtualMachine_interpolatedDisk(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -2517,6 +2606,7 @@ func TestAccResourceVSphereVirtualMachine_interpolatedDisk(t *testing.T) {
 
 func TestAccResourceVSphereVirtualMachine_deployOvfFromUrl(t *testing.T) {
 	vmName := "terraform_test_vm_" + acctest.RandStringFromCharSet(4, acctest.CharSetAlphaNum)
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -2539,6 +2629,7 @@ func TestAccResourceVSphereVirtualMachine_deployOvfFromUrl(t *testing.T) {
 
 func TestAccResourceVSphereVirtualMachine_deployOvaFromUrl(t *testing.T) {
 	vmName := "terraform_test_vm_" + acctest.RandStringFromCharSet(4, acctest.CharSetAlphaNum)
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
@@ -2563,6 +2654,7 @@ func TestAccResourceVSphereVirtualMachine_deployOvaFromUrl(t *testing.T) {
 
 func TestAccResourceVSphereVirtualMachine_cloneWithCustomizationSpec(t *testing.T) {
 	goscName := acctest.RandomWithPrefix("gosc")
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -2583,6 +2675,7 @@ func TestAccResourceVSphereVirtualMachine_cloneWithCustomizationSpec(t *testing.
 }
 
 func TestAccResourceVSphereVirtualMachine_SRIOV(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -2604,6 +2697,7 @@ func TestAccResourceVSphereVirtualMachine_SRIOV(t *testing.T) {
 }
 
 func TestAccResourceVSphereVirtualMachine_createMemoryReservationLockedToMax(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -2626,6 +2720,7 @@ func TestAccResourceVSphereVirtualMachine_createMemoryReservationLockedToMax(t *
 
 func TestAccResourceVSphereVirtualMachine_deployOvfFromUrlMultipleVmsSameName(t *testing.T) {
 	ovfNameTpl := "terraform_test_vm_" + acctest.RandStringFromCharSet(4, acctest.CharSetAlphaNum)
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
@@ -2652,6 +2747,7 @@ func TestAccResourceVSphereVirtualMachine_deployOvfFromUrlMultipleVmsSameName(t 
 }
 
 func TestAccResourceVSphereVirtualMachine_nvmeController(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -3632,7 +3728,6 @@ func testAccResourceVSphereVirtualMachineConfigBase() string {
 		testhelper.ConfigDataRootHost1(),
 		testhelper.ConfigDataRootHost2(),
 		testhelper.ConfigDataRootDS1(),
-		testhelper.ConfigResDS1(),
 		testhelper.ConfigDataRootComputeCluster1(),
 		testhelper.ConfigResResourcePool1(),
 		testhelper.ConfigDataRootPortGroup1())
@@ -3803,7 +3898,7 @@ func testAccResourceVSphereVirtualMachineConfigBasic() string {
 resource "vsphere_virtual_machine" "vm" {
   name             = "testacc-test"
   resource_pool_id = vsphere_resource_pool.pool1.id
-  datastore_id     = vsphere_nas_datastore.ds1.id
+  datastore_id     = data.vsphere_datastore.rootds1.id
 
   num_cpus = 2
   memory   = 2048
@@ -3818,6 +3913,7 @@ resource "vsphere_virtual_machine" "vm" {
   disk {
     label = "disk0"
     size  = 20
+    io_reservation = 1
   }
 }
 `,

--- a/vsphere/resource_vsphere_vmfs_datastore_test.go
+++ b/vsphere/resource_vsphere_vmfs_datastore_test.go
@@ -28,7 +28,6 @@ func TestAccResourceVSphereVmfsDatastore_basic(t *testing.T) {
 		PreCheck: func() {
 			RunSweepers()
 			testAccPreCheck(t)
-			testAccResourceVSphereVmfsDatastorePreCheck(t)
 		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccResourceVSphereVmfsDatastoreExists(false),
@@ -59,6 +58,7 @@ func TestAccResourceVSphereVmfsDatastore_basic(t *testing.T) {
 }
 
 func TestAccResourceVSphereVmfsDatastore_multiDisk(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -79,6 +79,7 @@ func TestAccResourceVSphereVmfsDatastore_multiDisk(t *testing.T) {
 }
 
 func TestAccResourceVSphereVmfsDatastore_discoveryViaDatasource(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -99,6 +100,7 @@ func TestAccResourceVSphereVmfsDatastore_discoveryViaDatasource(t *testing.T) {
 }
 
 func TestAccResourceVSphereVmfsDatastore_addDisksThroughUpdate(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -125,6 +127,7 @@ func TestAccResourceVSphereVmfsDatastore_addDisksThroughUpdate(t *testing.T) {
 }
 
 func TestAccResourceVSphereVmfsDatastore_renameDatastore(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -152,6 +155,7 @@ func TestAccResourceVSphereVmfsDatastore_renameDatastore(t *testing.T) {
 }
 
 func TestAccResourceVSphereVmfsDatastore_withFolder(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -179,6 +183,7 @@ func TestAccResourceVSphereVmfsDatastore_withFolder(t *testing.T) {
 }
 
 func TestAccResourceVSphereVmfsDatastore_moveToFolderAfter(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -207,6 +212,7 @@ func TestAccResourceVSphereVmfsDatastore_moveToFolderAfter(t *testing.T) {
 }
 
 func TestAccResourceVSphereVmfsDatastore_withDatastoreCluster(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -229,6 +235,7 @@ func TestAccResourceVSphereVmfsDatastore_withDatastoreCluster(t *testing.T) {
 }
 
 func TestAccResourceVSphereVmfsDatastore_moveToDatastoreClusterAfter(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -256,6 +263,7 @@ func TestAccResourceVSphereVmfsDatastore_moveToDatastoreClusterAfter(t *testing.
 }
 
 func TestAccResourceVSphereVmfsDatastore_singleTag(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -277,6 +285,7 @@ func TestAccResourceVSphereVmfsDatastore_singleTag(t *testing.T) {
 }
 
 func TestAccResourceVSphereVmfsDatastore_modifyTags(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -305,6 +314,7 @@ func TestAccResourceVSphereVmfsDatastore_modifyTags(t *testing.T) {
 }
 
 func TestAccResourceVSphereVmfsDatastore_badDiskEntry(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -328,6 +338,7 @@ func TestAccResourceVSphereVmfsDatastore_badDiskEntry(t *testing.T) {
 }
 
 func TestAccResourceVSphereVmfsDatastore_duplicateDiskEntry(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -351,6 +362,7 @@ func TestAccResourceVSphereVmfsDatastore_duplicateDiskEntry(t *testing.T) {
 }
 
 func TestAccResourceVSphereVmfsDatastore_singleCustomAttribute(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -372,6 +384,7 @@ func TestAccResourceVSphereVmfsDatastore_singleCustomAttribute(t *testing.T) {
 }
 
 func TestAccResourceVSphereVmfsDatastore_multiCustomAttribute(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -480,7 +493,6 @@ variable "disk0" {
 }
 
 %s
-
 
 resource "vsphere_vmfs_datastore" "datastore" {
   name           = "%s"

--- a/vsphere/resource_vsphere_vnic_test.go
+++ b/vsphere/resource_vsphere_vnic_test.go
@@ -60,6 +60,7 @@ func TestAccResourceVSphereVNic_dvs_default(t *testing.T) {
 }
 
 func TestAccResourceVSphereVNic_dvs_vmotion(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -72,6 +73,7 @@ func TestAccResourceVSphereVNic_dvs_vmotion(t *testing.T) {
 }
 
 func TestAccResourceVSphereVNic_hvs_default(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -97,6 +99,7 @@ func TestAccResourceVSphereVNic_hvs_default(t *testing.T) {
 }
 
 func TestAccResourceVSphereVNic_hvs_vmotion(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -122,6 +125,7 @@ func TestAccResourceVSphereVNic_hvs_vmotion(t *testing.T) {
 }
 
 func TestAccResourceVSphereVNic_services_nonDefaultNetstack(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -147,6 +151,7 @@ func TestAccResourceVSphereVNic_services_nonDefaultNetstack(t *testing.T) {
 }
 
 func TestAccResourceVSphereVNic_services_invalid(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -173,6 +178,7 @@ func TestAccResourceVSphereVNic_services_invalid(t *testing.T) {
 }
 
 func TestAccResourceVSphereVNic_services_valid(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -382,22 +388,22 @@ func testaccvspherevnicconfigHvs(netConfig string) string {
 	return fmt.Sprintf(`
 %s
 
-data "vsphere_host" "h1" {
-  name          = "%s"
-  datacenter_id = data.vsphere_datacenter.rootdc1.id
-}
+	data "vsphere_host" "h1" {
+	  name          = "%s"
+	  datacenter_id = data.vsphere_datacenter.rootdc1.id
+	}
 
-resource "vsphere_host_port_group" "p1" {
-  name                = "ko-pg"
-  virtual_switch_name = "vSwitch0"
-  host_system_id      = data.vsphere_host.h1.id
-}
+	resource "vsphere_host_port_group" "p1" {
+	  name                     = "ko-pg"
+	  virtual_switch_name = "vSwitch0"
+	  host_system_id   = data.vsphere_host.h1.id
+	}
 
-resource "vsphere_vnic" "v1" {
-  host      = data.vsphere_host.h1.id
-  portgroup = vsphere_host_port_group.p1.name
+	resource "vsphere_vnic" "v1" {
+	  host      = data.vsphere_host.h1.id
+	  portgroup = vsphere_host_port_group.p1.name
 	  %s
-}
+	}
 	`, testhelper.CombineConfigs(testhelper.ConfigDataRootDC1(), testhelper.ConfigDataRootPortGroup1()),
 		os.Getenv("TF_VAR_VSPHERE_ESXI3"),
 		netConfig)
@@ -407,30 +413,30 @@ func testaccvspherevnicconfigDvs(netConfig string) string {
 	return fmt.Sprintf(`
 %s
 
-resource "vsphere_distributed_virtual_switch" "d1" {
-  name          = "hashi-dc_DVPG0"
-  datacenter_id = data.vsphere_datacenter.rootdc1.id
-  host {
-    host_system_id = data.vsphere_host.roothost2.id
-    devices        = ["%s"]
-  }
-}
+	resource "vsphere_distributed_virtual_switch" "d1" {
+	  name          = "hashi-dc_DVPG0"
+	  datacenter_id = data.vsphere_datacenter.rootdc1.id
+	  host {
+		host_system_id = data.vsphere_host.roothost3.id
+		devices        = ["%s"]
+	  }
+	}
 
-resource "vsphere_distributed_port_group" "p1" {
-  name                            = "ko-pg"
-  vlan_id                         = 1234
-  distributed_virtual_switch_uuid = vsphere_distributed_virtual_switch.d1.id
-}
+	resource "vsphere_distributed_port_group" "p1" {
+	  name                            = "ko-pg"
+	  vlan_id                         = 1234
+	  distributed_virtual_switch_uuid = vsphere_distributed_virtual_switch.d1.id
+	}
 
-resource "vsphere_vnic" "v1" {
-  host                    = data.vsphere_host.roothost2.id
-  distributed_switch_port = vsphere_distributed_virtual_switch.d1.id
-  distributed_port_group  = vsphere_distributed_port_group.p1.id
+	resource "vsphere_vnic" "v1" {
+	  host                    = data.vsphere_host.roothost3.id
+	  distributed_switch_port = vsphere_distributed_virtual_switch.d1.id
+	  distributed_port_group  = vsphere_distributed_port_group.p1.id
 	  %s
-}
+	}
 	`, testhelper.CombineConfigs(
 		testhelper.ConfigDataRootDC1(),
-		testhelper.ConfigDataRootHost2(),
+		testhelper.ConfigDataRootHost3(),
 	),
 		testhelper.HostNic1,
 		netConfig)


### PR DESCRIPTION
### Summary

#### What

This change aims at having at least one stable test for each resource/datasource that can be run on a regular basis (e.g. prior to each release).
Not all resources and data sources have a test enabled - some require a more complex setup or don't have working tests at all. This can be resolved at a later point.

#### How

I've created a mechanism to mark unstable tests. There is a function in `provider_test.go` called `testAccSkipUnstable` which is called in the beginning of each unstable test case. This function will skip the tests calling it whenver a specific environment variable is set. If the variable is not set the full set of tests will be executed.

All tests that are being enabled in this PR can run on the following environment

> vCenter
>> [Datacenter] acc-test-dc
>>> [Cluster] acc-test-cluster
>>>> [ESXi] ESXi 1
>>>> [ESXi] ESXi 1
>>> [ESXi] ESXi 3
>> [Datastore] acc-test-nfs

> [ESXi] ESXi 4 (spare and not connected)

#### What's next

The next steps are to go over all resources and data sources one more time and to stabilize and enable as many tests as possible. This can be done in meaningful chunks as we go along since some cases may also require modifications to the standard testbed.

### Type

- [ ] `fix`: Bug Fix
- [ ] `feat`: Feature or Enhancement
- [ ] `docs`: Documentation
- [X] `refactor`: Refactoring
- [ ] `chore`: Build, Dependencies, Workflows, etc.
- [ ] `other`: Other (Please describe.)

### Breaking Changes?

- [ ] Yes, there are breaking changes.
- [X] No, there are no breaking changes.

### Tests

- [ ] Tests have been added or updated.
- [X] Tests have been completed.

<details>

<summary>✅ Full test run output</summary>

```
HWRQ7QD9K0:tests zhelyazkovs$ time ./run_tests.sh
📦 github.com/vmware/terraform-provider-vsphere/vsphere
  ✅ TestAccClient_noPersistence (1.99s)
2025/05/19 16:04:10 [DEBUG] Cached SOAP client session data not valid or persistence not enabled, new session necessary
2025/05/19 16:04:10 [DEBUG] Creating new SOAP API session on endpoint 10.161.234.148
2025/05/19 16:04:11 [DEBUG] SOAP API session creation successful
2025/05/19 16:04:11 [DEBUG] VMWare vSphere Client configured for URL: 10.161.234.148
2025/05/19 16:04:11 [DEBUG] Setting up REST client
2025/05/19 16:04:12 [DEBUG] CIS REST client configuration successful
  ✅ TestAccClient_persistence (3.69s)
2025/05/19 16:04:07 [DEBUG] Attempting to locate SOAP client session data in "/var/folders/1l/k006pg4j7694fmg9dgh5zz840000gp/T/tf-vsphere-test-vimsessiondir51094611/234d87023e27797fd5a46a355770ad25c87ef3742fae327289d6daaa79a56e24"
2025/05/19 16:04:07 [DEBUG] SOAP client session data not found in "/var/folders/1l/k006pg4j7694fmg9dgh5zz840000gp/T/tf-vsphere-test-vimsessiondir51094611/234d87023e27797fd5a46a355770ad25c87ef3742fae327289d6daaa79a56e24"
2025/05/19 16:04:07 [DEBUG] Cached SOAP client session data not valid or persistence not enabled, new session necessary
2025/05/19 16:04:07 [DEBUG] Creating new SOAP API session on endpoint 10.161.234.148
2025/05/19 16:04:08 [DEBUG] SOAP API session creation successful
2025/05/19 16:04:08 [DEBUG] VMWare vSphere Client configured for URL: 10.161.234.148
2025/05/19 16:04:08 [DEBUG] Setting up REST client
2025/05/19 16:04:08 [DEBUG] CIS REST client configuration successful
2025/05/19 16:04:09 [DEBUG] Will persist SOAP client session data to "/var/folders/1l/k006pg4j7694fmg9dgh5zz840000gp/T/tf-vsphere-test-vimsessiondir51094611/234d87023e27797fd5a46a355770ad25c87ef3742fae327289d6daaa79a56e24"
2025/05/19 16:04:09 [DEBUG] Attempting to locate SOAP client session data in "/var/folders/1l/k006pg4j7694fmg9dgh5zz840000gp/T/tf-vsphere-test-vimsessiondir51094611/234d87023e27797fd5a46a355770ad25c87ef3742fae327289d6daaa79a56e24"
2025/05/19 16:04:09 [DEBUG] Cached SOAP client session loaded successfully
2025/05/19 16:04:09 [DEBUG] VMWare vSphere Client configured for URL: 10.161.234.148
2025/05/19 16:04:09 [DEBUG] Setting up REST client
2025/05/19 16:04:10 [DEBUG] CIS REST client configuration successful
2025/05/19 16:04:10 [DEBUG] Will persist SOAP client session data to "/var/folders/1l/k006pg4j7694fmg9dgh5zz840000gp/T/tf-vsphere-test-vimsessiondir51094611/234d87023e27797fd5a46a355770ad25c87ef3742fae327289d6daaa79a56e24"
  🚧 TestAccDataSourceVSphereComputeClusterHostGroup_basic (0s)
    provider_test.go:47:
  🚧 TestAccDataSourceVSphereComputeCluster_absolutePathNoDatacenter (0s)
    provider_test.go:47:
  🚧 TestAccDataSourceVSphereComputeCluster_basic (0s)
    provider_test.go:47:
  🚧 TestAccDataSourceVSphereContentLibraryItem_basic (0s)
    provider_test.go:47:
  ✅ TestAccDataSourceVSphereContentLibrary_basic (1m1.43s)
  ✅ TestAccDataSourceVSphereCustomAttribute_basic (47.52s)
  ✅ TestAccDataSourceVSphereDatacenter_basic (47.05s)
  🚧 TestAccDataSourceVSphereDatacenter_defaultDatacenter (0s)
    provider_test.go:47:
  🚧 TestAccDataSourceVSphereDatacenter_getVirtualMachines (0s)
    provider_test.go:47:
  🚧 TestAccDataSourceVSphereDatastoreCluster_absolutePathNoDatacenter (0s)
    provider_test.go:47:
  🚧 TestAccDataSourceVSphereDatastoreCluster_basic (0s)
    provider_test.go:47:
  🚧 TestAccDataSourceVSphereDatastoreCluster_getDatastores (0s)
    provider_test.go:47:
  🚧 TestAccDataSourceVSphereDatastoreStats_basic (0s)
    provider_test.go:47:
  ✅ TestAccDataSourceVSphereDatastore_basic (54.39s)
  🚧 TestAccDataSourceVSphereDatastore_getStats (0s)
    provider_test.go:47:
  🚧 TestAccDataSourceVSphereDatastore_noDatacenterAndAbsolutePath (0s)
    provider_test.go:47:
  🚧 TestAccDataSourceVSphereDistributedVirtualSwitch_CreatePortgroup (0s)
    provider_test.go:47:
  🚧 TestAccDataSourceVSphereDistributedVirtualSwitch_absolutePathNoDatacenterSpecified (0s)
    provider_test.go:47:
  ✅ TestAccDataSourceVSphereDistributedVirtualSwitch_basic (1m3.45s)
  🚧 TestAccDataSourceVSphereDynamic_multiResult (0s)
    provider_test.go:47:
  🚧 TestAccDataSourceVSphereDynamic_multiTag (33.38s)
    provider_test.go:47:
  ✅ TestAccDataSourceVSphereDynamic_regexAndTag (1m30.92s)
categoryID: urn:vmomi:InventoryServiceCategory:d2dff13c-7240-47ce-bca4-3408503513f0:GLOBAL
categoryID: urn:vmomi:InventoryServiceCategory:d2dff13c-7240-47ce-bca4-3408503513f0:GLOBAL
categoryID: urn:vmomi:InventoryServiceCategory:7ec95886-230d-4436-87af-de465934925e:GLOBAL
  🚧 TestAccDataSourceVSphereDynamic_typeFilter (33.99s)
    provider_test.go:47:
  ✅ TestAccDataSourceVSphereFolder_basic (57.47s)
  🚧 TestAccDataSourceVSphereGOSC_basic (0s)
    provider_test.go:47:
  ✅ TestAccDataSourceVSphereHostThumbprint_basic (10.59s)
  ✅ TestAccDataSourceVSphereHost_basic (51.15s)
  🚧 TestAccDataSourceVSphereHost_defaultHost (0s)
    provider_test.go:47:
  🚧 TestAccDataSourceVSphereLicense_basic (0s)
    provider_test.go:47:
  🚧 TestAccDataSourceVSphereNetwork_absolutePathNoDatacenter (0s)
    provider_test.go:47:
  ✅ TestAccDataSourceVSphereNetwork_dvsPortgroup (1m10.98s)
  🚧 TestAccDataSourceVSphereNetwork_hostPortgroups (0s)
    provider_test.go:47:
  🚧 TestAccDataSourceVSphereNetwork_withTimeout (0s)
    provider_test.go:47:
  ✅ TestAccDataSourceVSphereResourcePool_basic (1m4.31s)
  🚧 TestAccDataSourceVSphereResourcePool_defaultResourcePoolForESXi (0s)
    provider_test.go:47:
  🚧 TestAccDataSourceVSphereResourcePool_emptyNameOnVCenterShouldError (0s)
    provider_test.go:47:
  🚧 TestAccDataSourceVSphereResourcePool_noDatacenterAndAbsolutePath (0s)
    provider_test.go:47:
  🚧 TestAccDataSourceVSphereResourcePool_withInvalidParentIdError (0s)
    provider_test.go:47:
  🚧 TestAccDataSourceVSphereResourcePool_withParentId (0s)
    provider_test.go:47:
  🚧 TestAccDataSourceVSphereResourcePool_withParentIdAndMissingNameError (0s)
    provider_test.go:47:
  🚧 TestAccDataSourceVSphereResourcePool_withParentIdAndNamePathError (0s)
    provider_test.go:47:
  🚧 TestAccDataSourceVSphereResourcePool_withParentIdAndNotFoundNameError (0s)
    provider_test.go:47:
  ✅ TestAccDataSourceVSphereRole_basic (15.99s)
  🚧 TestAccDataSourceVSphereRole_systemRoleData (0s)
    provider_test.go:47:
  ✅ TestAccDataSourceVSphereTagCategory_basic (51.16s)
  🚧 TestAccDataSourceVSphereTag_basic (0s)
    provider_test.go:47:
  🚧 TestAccDataSourceVSphereVAppContainer_basic (0s)
    provider_test.go:47:
  🚧 TestAccDataSourceVSphereVAppContainer_path (0s)
    provider_test.go:47:
  🚧 TestAccDataSourceVSphereVirtualMachine_basic (0s)
    provider_test.go:47:
  🚧 TestAccDataSourceVSphereVirtualMachine_moid (0s)
    provider_test.go:47:
  🚧 TestAccDataSourceVSphereVirtualMachine_nameAndFolder (0s)
    provider_test.go:47:
  🚧 TestAccDataSourceVSphereVirtualMachine_noDatacenterAndAbsolutePath (0s)
    provider_test.go:47:
  🚧 TestAccDataSourceVSphereVirtualMachine_uuid (0s)
    provider_test.go:47:
  🚧 TestAccDataSourceVSphereVmfsDisks_basic (0s)
    provider_test.go:47:
  ✅ TestAccResourceVMStoragePolicy_basic (55.07s)
categoryID: urn:vmomi:InventoryServiceCategory:94b94227-d5e4-4fe9-bf9f-45e9286fb874:GLOBAL
categoryID: urn:vmomi:InventoryServiceCategory:818daec5-4446-47e1-a209-e32975659a86:GLOBAL
categoryID: urn:vmomi:InventoryServiceCategory:818daec5-4446-47e1-a209-e32975659a86:GLOBAL
  🚧 TestAccResourceVSpherGOSC_linux (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSpherGOSC_sysprep (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSpherGOSC_windows_basic (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSpherGOSC_windows_workGroup (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereComputeClusterHostGroup_basic (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereComputeClusterHostGroup_update (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereComputeClusterVMAffinityRule_basic (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereComputeClusterVMAffinityRule_updateCount (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereComputeClusterVMAffinityRule_updateEnabled (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereComputeClusterVMAntiAffinityRule_basic (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereComputeClusterVMAntiAffinityRule_updateCount (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereComputeClusterVMAntiAffinityRule_updateEnabled (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereComputeClusterVMDependencyRule_altGroup (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereComputeClusterVMDependencyRule_basic (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereComputeClusterVMDependencyRule_updateEnabled (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereComputeClusterVMDependencyRule_updateGroup (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereComputeClusterVMGroup_basic (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereComputeClusterVMGroup_update (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereComputeClusterVMHostRule_antiAffinity (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereComputeClusterVMHostRule_basic (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereComputeClusterVMHostRule_updateAffinity (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereComputeClusterVMHostRule_updateEnabled (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereComputeCluster_basic (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereComputeCluster_drsHAEnabled (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereComputeCluster_explicitFailoverHost (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereComputeCluster_faultDomain (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereComputeCluster_haAdmissionControlPolicyDisabled (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereComputeCluster_inFolder (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereComputeCluster_moveToFolder (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereComputeCluster_multipleCustomAttribute (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereComputeCluster_multipleTags (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereComputeCluster_rename (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereComputeCluster_singleCustomAttribute (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereComputeCluster_singleTag (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereComputeCluster_switchCustomAttribute (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereComputeCluster_switchTags (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereComputeCluster_vlcm (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereComputeCluster_vsanCompressionEnabled (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereComputeCluster_vsanDITEncryption (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereComputeCluster_vsanDedupEnabled (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereComputeCluster_vsanEsaEnabled (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereComputeCluster_vsanPerfEnabled (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereComputeCluster_vsanPerfVerboseDiagnosticEnabled (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereComputeCluster_vsanPerfVerboseEnabled (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereComputeCluster_vsanStretchedCluster (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereComputeCluster_vsanUnmapDisabledwithVsanDisabled (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereComputeCluster_vsanUnmapEnabledwithVsanEnabled (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereContentLibraryItem_localOva (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereContentLibraryItem_remoteOva (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereContentLibraryItem_remoteOvf (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereContentLibrary_authenticated (0s)
    provider_test.go:47:
  ✅ TestAccResourceVSphereContentLibrary_basic (1m7.97s)
  🚧 TestAccResourceVSphereContentLibrary_subscribed (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereCustomAttribute_basic (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereCustomAttribute_changeType (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereCustomAttribute_rename (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereCustomAttribute_withType (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereDPMHostOverride_basic (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereDPMHostOverride_overrides (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereDPMHostOverride_update (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereDRSVMOverride_automationLevel (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereDRSVMOverride_drs (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereDRSVMOverride_update (0s)
    provider_test.go:47:
  ✅ TestAccResourceVSphereDatacenter_createOnRootFolder (31.26s)
  🚧 TestAccResourceVSphereDatacenter_createOnSubfolder (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereDatacenter_modifyCustomAttribute (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereDatacenter_modifyTags (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereDatacenter_singleCustomAttribute (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereDatacenter_singleTag (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereDatastoreClusterVMAntiAffinityRule_basic (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereDatastoreClusterVMAntiAffinityRule_updateCount (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereDatastoreClusterVMAntiAffinityRule_updateEnabled (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereDatastoreCluster_basic (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereDatastoreCluster_freeSpace (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereDatastoreCluster_inFolder (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereDatastoreCluster_miscTweaks (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereDatastoreCluster_moveToFolder (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereDatastoreCluster_multipleCustomAttribute (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereDatastoreCluster_multipleTags (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereDatastoreCluster_rename (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereDatastoreCluster_reservableIops (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereDatastoreCluster_sdrsEnabled (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereDatastoreCluster_sdrsOverrides (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereDatastoreCluster_singleCustomAttribute (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereDatastoreCluster_singleTag (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereDatastoreCluster_switchCustomAttribute (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereDatastoreCluster_switchTags (0s)
    provider_test.go:47:
  ✅ TestAccResourceVSphereDistributedPortGroup_basic (1m7.8s)
  🚧 TestAccResourceVSphereDistributedPortGroup_inheritPolicyDiffCheck (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereDistributedPortGroup_inheritPolicyDiffCheckVlanRangeTypeSetEdition (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereDistributedPortGroup_multiCustomAttribute (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereDistributedPortGroup_multiTag (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereDistributedPortGroup_overrideVlan (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereDistributedPortGroup_singleCustomAttribute (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereDistributedPortGroup_singleTag (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereDistributedVirtualSwitchPvlanMapping_basic (0s)
    provider_test.go:47:
  ✅ TestAccResourceVSphereDistributedVirtualSwitch_basic (1m14.47s)
  🚧 TestAccResourceVSphereDistributedVirtualSwitch_basicToStandbyWithFailover (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereDistributedVirtualSwitch_explicitUplinks (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereDistributedVirtualSwitch_inFolder (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereDistributedVirtualSwitch_modifyTags (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereDistributedVirtualSwitch_modifyUplinks (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereDistributedVirtualSwitch_multiCustomAttribute (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereDistributedVirtualSwitch_netflow (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereDistributedVirtualSwitch_networkResourceControl (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereDistributedVirtualSwitch_noHosts (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereDistributedVirtualSwitch_removeNIC (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereDistributedVirtualSwitch_singleCustomAttribute (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereDistributedVirtualSwitch_singleTag (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereDistributedVirtualSwitch_standbyWithExplicitFailoverOrder (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereDistributedVirtualSwitch_upgradeVersion (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereDistributedVirtualSwitch_vlanRanges (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereFile_basic (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereFile_basicUploadAndCopy (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereFile_renamePostCreation (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereFile_uploadAndCopyAndUpdate (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereFile_uploadWithCreateDirectories (0s)
    provider_test.go:47:
  ✅ TestAccResourceVSphereFolderMigrateState_basic (2.9s)
  ✅ TestAccResourceVSphereFolderMigrateState_empty (0s)
  🚧 TestAccResourceVSphereFolder_customAttributes (0s)
    provider_test.go:47:
  ✅ TestAccResourceVSphereFolder_datacenterFolder (59.21s)
  🚧 TestAccResourceVSphereFolder_datastoreFolder (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereFolder_hostFolder (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereFolder_modifyCustomAttributes (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereFolder_modifyTags (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereFolder_modifyTagsMultiStage (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereFolder_moveToSubfolder (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereFolder_networkFolder (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereFolder_preventDeleteIfNotEmpty (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereFolder_removeAllCustomAttributes (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereFolder_rename (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereFolder_subfolder (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereFolder_tags (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereFolder_vmFolder (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereHAVMOverride_basic (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereHAVMOverride_complete (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereHAVMOverride_update (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereHostNTPServers (0s)
    resource_vsphere_host_test.go:449: NTP_SERVERS environment variable is not set, using fallback value
    provider_test.go:47:
  ✅ TestAccResourceVSphereHostNtpService (0s)
  🚧 TestAccResourceVSphereHostNtpService/Enabled=false,Policy=automatic (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereHostNtpService/Enabled=false,Policy=off (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereHostNtpService/Enabled=false,Policy=on (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereHostNtpService/Enabled=true,Policy=automatic (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereHostNtpService/Enabled=true,Policy=off (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereHostNtpService/Enabled=true,Policy=on (0s)
    provider_test.go:47:
  ✅ TestAccResourceVSphereHostPortGroup_basic (1m5.55s)
  🚧 TestAccResourceVSphereHostPortGroup_basicToComplex (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereHostPortGroup_complexWithOverrides (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereHostVirtualSwitch_badActiveNICList (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereHostVirtualSwitch_badStandbyNICList (0s)
    provider_test.go:47:
  ✅ TestAccResourceVSphereHostVirtualSwitch_basic (1m8.43s)
  🚧 TestAccResourceVSphereHostVirtualSwitch_noNICs (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereHostVirtualSwitch_removeAllNICs (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereHostVirtualSwitch_removeNIC (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereHost_basic (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereHost_connection (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereHost_emptyLicense (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereHost_lockdown (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereHost_lockdown_invalid (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereHost_maintenance (0s)
    provider_test.go:47:
  ✅ TestAccResourceVSphereHost_rootFolder (1m59.43s)
2025/05/19 16:23:36 Building HostConnectSpec for host: 10.161.245.12
2025/05/19 16:24:08 Looking for mode disabled in lockdown modes map[string]types.HostLockdownMode{"disabled":"lockdownDisabled", "normal":"lockdownNormal", "strict":"lockdownStrict"}
2025/05/19 16:24:08 Found match for disabled. Returning lockdownDisabled.
NTP Servers for host: []
Policy for service ntpd is off
Number of services found: 25
Checking service: DCUI
Checking service: TSM
Checking service: TSM-SSH
Checking service: apiForwarder
Checking service: attestd
Checking service: dpd
Checking service: entropyd
Checking service: gpuManager
Checking service: hbrsrv
Checking service: infravisor
Checking service: kmxd
Checking service: lbtd
Checking service: lwisOomCheck
Checking service: lwsmd
Checking service: nsx-sfhc
Checking service: ntpd
Enabled for service ntpd is false
2025/05/19 16:24:14 Looking for mode lockdownDisabled in lockdown modes map[types.HostLockdownMode]string{"lockdownDisabled":"disabled", "lockdownNormal":"normal", "lockdownStrict":"strict"}
2025/05/19 16:24:14 Found match for lockdownDisabled. Returning disabled.
2025/05/19 16:24:14 Setting lockdown to disabled
NTP Servers for host: []
Policy for service ntpd is off
Number of services found: 25
Checking service: DCUI
Checking service: TSM
Checking service: TSM-SSH
Checking service: apiForwarder
Checking service: attestd
Checking service: dpd
Checking service: entropyd
Checking service: gpuManager
Checking service: hbrsrv
Checking service: infravisor
Checking service: kmxd
Checking service: lbtd
Checking service: lwisOomCheck
Checking service: lwsmd
Checking service: nsx-sfhc
Checking service: ntpd
Enabled for service ntpd is false
2025/05/19 16:24:24 Looking for mode lockdownDisabled in lockdown modes map[types.HostLockdownMode]string{"lockdownDisabled":"disabled", "lockdownNormal":"normal", "lockdownStrict":"strict"}
2025/05/19 16:24:24 Found match for lockdownDisabled. Returning disabled.
2025/05/19 16:24:24 Setting lockdown to disabled
  🚧 TestAccResourceVSphereLicense_basic (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereLicense_invalid (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereLicense_withLabelsOnESXiServer (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereLicense_withLabelsOnVCenter (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereNasDatastore_basic (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereNasDatastore_basicToMultiHost (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereNasDatastore_inDatastoreCluster (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereNasDatastore_inFolder (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereNasDatastore_modifyTags (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereNasDatastore_moveToDatastoreCluster (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereNasDatastore_moveToFolder (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereNasDatastore_multiCustomAttribute (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereNasDatastore_multiHost (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereNasDatastore_multiHostToBasic (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereNasDatastore_renameDatastore (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereNasDatastore_singleCustomAttribute (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereNasDatastore_singleTag (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereOfflineSoftwareDepot_basic (0s)
    provider_test.go:47:
  ✅ TestAccResourceVSphereResourcePool_basic (1m8.66s)
  🚧 TestAccResourceVSphereResourcePool_esxiHost (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereResourcePool_tags (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereResourcePool_updateParent (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereResourcePool_updateRename (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereResourcePool_updateToCustom (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereResourcePool_updateToDefaults (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereStorageDrsVMOverride_basic (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereStorageDrsVMOverride_overrides (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereStorageDrsVMOverride_update (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereSupervisor_basic (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereSupervisor_full (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereTagCategory_addType (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereTagCategory_basic (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereTagCategory_invalidTypeShouldError (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereTagCategory_multiCardinality (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereTagCategory_removeTypeShouldError (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereTagCategory_rename (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereTagCategory_singleCardinality (0s)
    provider_test.go:47:
  ✅ TestAccResourceVSphereTag_basic (56.26s)
categoryID: urn:vmomi:InventoryServiceCategory:1c3d61d4-3b82-453f-900f-6012a847f993:GLOBAL
  🚧 TestAccResourceVSphereTag_changeDescription (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereTag_changeName (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereTag_detachAllTags (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereVAppContainer_basic (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereVAppContainer_childImport (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereVAppContainer_vmBasic (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereVAppContainer_vmClone (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereVAppContainer_vmCloneSDRS (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereVAppContainer_vmMoveIntoVApp (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereVAppContainer_vmMoveIntoVAppSDRS (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereVAppContainer_vmSDRS (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereVAppEntity_basic (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereVAppEntity_multi (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereVAppEntity_multiUpdate (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereVAppEntity_nonDefault (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereVAppEntity_update (0s)
    provider_test.go:47:
  ✅ TestAccResourceVSphereVNic_dvs_default (6m47.16s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereVNic_dvs_vmotion (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereVNic_hvs_default (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereVNic_hvs_vmotion (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereVNic_services_invalid (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereVNic_services_nonDefaultNetstack (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereVNic_services_valid (0s)
    provider_test.go:47:
  ✅ TestAccResourceVSphereVirtualDisk_basic (1m13.21s)
  🚧 TestAccResourceVSphereVirtualDisk_extend (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereVirtualDisk_multi (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereVirtualDisk_multiWithParent (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereVirtualDisk_withParent (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereVirtualMachineContentLibrary_basic (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereVirtualMachineSnapshot_basic (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereVirtualMachine_ESXiOnly (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereVirtualMachine_SRIOV (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereVirtualMachine_addDevices (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereVirtualMachine_attachExistingVmdk (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereVirtualMachine_attachExistingVmdkTaint (0s)
    provider_test.go:47:
  ✅ TestAccResourceVSphereVirtualMachine_basic (1m32.05s)
  🚧 TestAccResourceVSphereVirtualMachine_blockComputedDiskName (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereVirtualMachine_blockDiskLabelStartingWithOrphanedPrefix (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereVirtualMachine_blockVAppSettingsOnNonClones (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereVirtualMachine_blockVAppSettingsOnNonClonesAfterCreation (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereVirtualMachine_cdromClientMapping (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereVirtualMachine_cdromConflictingParameters (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereVirtualMachine_cdromIsoBacking (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereVirtualMachine_cdromNoParameters (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereVirtualMachine_cloneBlockESXi (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereVirtualMachine_cloneCustomizeForceNewWithDatastore (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereVirtualMachine_cloneCustomizeWithNewResourcePool (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereVirtualMachine_cloneFromTemplate (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereVirtualMachine_cloneImport (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereVirtualMachine_cloneIntoEmptyCluster (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereVirtualMachine_cloneModifyDiskAndSCSITypeAtSameTime (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereVirtualMachine_cloneMultiNICFromSingleNICTemplate (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereVirtualMachine_cloneMultiNICSRIOVFromVMXNET3Template (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereVirtualMachine_cloneMultiNICWithSameGateway (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereVirtualMachine_cloneOnDsCuster (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereVirtualMachine_clonePoweredOn (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereVirtualMachine_cloneWithBadSizeWithLinkedClone (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereVirtualMachine_cloneWithBadSizeWithoutLinkedClone (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereVirtualMachine_cloneWithBadTimezone (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereVirtualMachine_cloneWithCustomizationSpec (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereVirtualMachine_cloneWithDifferentHostname (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereVirtualMachine_cloneWithDifferentTimezone (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereVirtualMachine_cloneWithDiskTypeChange (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereVirtualMachine_cpuHotAdd (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereVirtualMachine_createIntoEmptyClusterNoEnvironmentBrowser (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereVirtualMachine_createMemoryReservationLockedToMax (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereVirtualMachine_deployOvaFromUrl (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereVirtualMachine_deployOvfFromUrl (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereVirtualMachine_deployOvfFromUrlMultipleVmsSameName (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereVirtualMachine_disksKeepOnRemove (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereVirtualMachine_dualStackIPv4AndIPv6 (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereVirtualMachine_extraConfig (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereVirtualMachine_extraConfigSwapKeys (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereVirtualMachine_growDisk (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereVirtualMachine_hardwareVersionBare (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereVirtualMachine_hardwareVersionClone (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereVirtualMachine_hardwareVersionDowngrade (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereVirtualMachine_hardwareVersionInvalidVersion (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereVirtualMachine_hardwareVersionUpgrade (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereVirtualMachine_highDiskUnitInsufficientBus (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereVirtualMachine_highDiskUnitNumbers (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereVirtualMachine_highDiskUnitsToRegularSingleController (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereVirtualMachine_highLatencySensitivity (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereVirtualMachine_hostCheck (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereVirtualMachine_hostVMotion (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereVirtualMachine_ignoreValidationOnComputedValue (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereVirtualMachine_inFolder (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereVirtualMachine_interpolatedDisk (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereVirtualMachine_maximumNumberOfNICs (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereVirtualMachine_memoryHotAdd (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereVirtualMachine_migrateStateV2 (0s)
    resource_vsphere_virtual_machine_migrate_test.go:26: set TF_VAR_VSPHERE_VM_V1_PATH to run vsphere_virtual_machine state migration tests
  🚧 TestAccResourceVSphereVirtualMachine_migrateStateV3FromV1 (0s)
    resource_vsphere_virtual_machine_migrate_test.go:26: set TF_VAR_VSPHERE_VM_V1_PATH to run vsphere_virtual_machine state migration tests
  🚧 TestAccResourceVSphereVirtualMachine_migrateStateV3_fromV2 (0s)
    resource_vsphere_virtual_machine_migrate_test.go:26: set TF_VAR_VSPHERE_VM_V1_PATH to run vsphere_virtual_machine state migration tests
  🚧 TestAccResourceVSphereVirtualMachine_modifyAnnotation (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereVirtualMachine_moveToFolder (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereVirtualMachine_multiCustomAttribute (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereVirtualMachine_multiDevice (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereVirtualMachine_multipleDisksAtDifferentSCSISlotsImport (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereVirtualMachine_multipleTags (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereVirtualMachine_nvmeController (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereVirtualMachine_reCreateOnDeletion (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereVirtualMachine_removeMiddleDevices (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereVirtualMachine_removeMiddleDevicesChangeDiskUnit (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereVirtualMachine_renamedDiskInPlaceOfExisting (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereVirtualMachine_resourcePoolMove (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereVirtualMachine_resourcePoolVMotion (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereVirtualMachine_scsiBusSharing (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereVirtualMachine_scsiBusSharingUpdate (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereVirtualMachine_shutdownOK (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereVirtualMachine_singleCustomAttribute (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereVirtualMachine_singleTag (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereVirtualMachine_staticMAC (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereVirtualMachine_storageVMotionBlockExternallyAttachedDisks (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereVirtualMachine_storageVMotionGlobalSetting (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereVirtualMachine_storageVMotionLinkedClones (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereVirtualMachine_storageVMotionPinDatastore (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereVirtualMachine_storageVMotionRenamedVirtualMachine (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereVirtualMachine_storageVMotionSingleDisk (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereVirtualMachine_swapSCSIBus (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereVirtualMachine_switchCustomAttribute (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereVirtualMachine_switchTags (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereVirtualMachine_upgradeCPUAndRam (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereVirtualMachine_vAppContainerAndFolder (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereVirtualMachine_vAppContainerMove (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereVirtualMachine_vAppIsoBasic (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereVirtualMachine_vAppIsoChangeCdromBacking (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereVirtualMachine_vAppIsoConfigIsoIgnored (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereVirtualMachine_vAppIsoNoCdrom (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereVirtualMachine_vAppIsoNoVApp (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereVirtualMachine_vAppIsoPoweredOffCdromRead (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereVirtualMachine_vvtdAndVbs (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereVmClass_basic (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereVmClass_vgpu (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereVmfsDatastore_addDisksThroughUpdate (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereVmfsDatastore_badDiskEntry (0s)
    provider_test.go:47:
  ✅ TestAccResourceVSphereVmfsDatastore_basic (1m36.71s)
  🚧 TestAccResourceVSphereVmfsDatastore_discoveryViaDatasource (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereVmfsDatastore_duplicateDiskEntry (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereVmfsDatastore_modifyTags (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereVmfsDatastore_moveToDatastoreClusterAfter (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereVmfsDatastore_moveToFolderAfter (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereVmfsDatastore_multiCustomAttribute (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereVmfsDatastore_multiDisk (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereVmfsDatastore_renameDatastore (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereVmfsDatastore_singleCustomAttribute (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereVmfsDatastore_singleTag (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereVmfsDatastore_withDatastoreCluster (0s)
    provider_test.go:47:
  🚧 TestAccResourceVSphereVmfsDatastore_withFolder (0s)
    provider_test.go:47:
  🚧 TestAccResourceVsphereRole_addPrivileges (0s)
    provider_test.go:47:
  ✅ TestAccResourceVsphereRole_createRole (18.2s)
  🚧 TestAccResourceVsphereRole_importSystemRoleShouldError (0s)
    provider_test.go:47:
  🚧 TestAccResourceVsphereRole_removePrivileges (0s)
    provider_test.go:47:
  🚧 TestAccResourcevsphereEntityPermissions_basic (0s)
    provider_test.go:47:
  ✅ TestComputeInstanceMigrateState_empty (0s)
  ✅ TestNewConfig (0s)
  ✅ TestProvider (0s)
  ✅ TestVSphereVirtualMachine_migrateStateV1 (0s)


real	30m14.401s
user	0m39.693s
sys	0m19.285s
```

</details>

<details>

<summary>✅ FIltered test run output (skipped tests removed)</summary>

```
HWRQ7QD9K0:tests zhelyazkovs$ cat gotest.log | grep -E '"Output":"--- PASS|"Output":"--- FAIL' | gotestfmt
📦 github.com/vmware/terraform-provider-vsphere/vsphere
  ✅ TestAccClient_noPersistence (1.99s)
  ✅ TestAccClient_persistence (3.69s)
  ✅ TestAccDataSourceVSphereContentLibrary_basic (1m1.43s)
  ✅ TestAccDataSourceVSphereCustomAttribute_basic (47.52s)
  ✅ TestAccDataSourceVSphereDatacenter_basic (47.05s)
  ✅ TestAccDataSourceVSphereDatastore_basic (54.39s)
  ✅ TestAccDataSourceVSphereDistributedVirtualSwitch_basic (1m3.45s)
  ✅ TestAccDataSourceVSphereDynamic_regexAndTag (1m30.92s)
  ✅ TestAccDataSourceVSphereFolder_basic (57.47s)
  ✅ TestAccDataSourceVSphereHostThumbprint_basic (10.59s)
  ✅ TestAccDataSourceVSphereHost_basic (51.15s)
  ✅ TestAccDataSourceVSphereNetwork_dvsPortgroup (1m10.98s)
  ✅ TestAccDataSourceVSphereResourcePool_basic (1m4.31s)
  ✅ TestAccDataSourceVSphereRole_basic (15.99s)
  ✅ TestAccDataSourceVSphereTagCategory_basic (51.16s)
  ✅ TestAccResourceVMStoragePolicy_basic (55.07s)
  ✅ TestAccResourceVSphereContentLibrary_basic (1m7.97s)
  ✅ TestAccResourceVSphereDatacenter_createOnRootFolder (31.26s)
  ✅ TestAccResourceVSphereDistributedPortGroup_basic (1m7.8s)
  ✅ TestAccResourceVSphereDistributedVirtualSwitch_basic (1m14.47s)
  ✅ TestAccResourceVSphereFolderMigrateState_basic (2.9s)
  ✅ TestAccResourceVSphereFolderMigrateState_empty (0s)
  ✅ TestAccResourceVSphereFolder_datacenterFolder (59.21s)
  ✅ TestAccResourceVSphereHostNtpService (0s)
  ✅ TestAccResourceVSphereHostPortGroup_basic (1m5.55s)
  ✅ TestAccResourceVSphereHostVirtualSwitch_basic (1m8.43s)
  ✅ TestAccResourceVSphereHost_rootFolder (1m59.43s)
  ✅ TestAccResourceVSphereResourcePool_basic (1m8.66s)
  ✅ TestAccResourceVSphereTag_basic (56.26s)
  ✅ TestAccResourceVSphereVNic_dvs_default (6m47.16s)
  ✅ TestAccResourceVSphereVirtualDisk_basic (1m13.21s)
  ✅ TestAccResourceVSphereVirtualMachine_basic (1m32.05s)
  ✅ TestAccResourceVSphereVmfsDatastore_basic (1m36.71s)
  ✅ TestAccResourceVsphereRole_createRole (18.2s)
  ✅ TestComputeInstanceMigrateState_empty (0s)
  ✅ TestNewConfig (0s)
  ✅ TestProvider (0s)
  ✅ TestVSphereVirtualMachine_migrateStateV1 (0s)
```

</details>

Output:

### Documentation

- [ ] Documentation has been added or updated.

### Issue References

https://github.com/vmware/terraform-provider-vsphere/issues/2508

### Release Note



### Additional Information


