### PR TITLE
chore: remove network interface resource allocation gate

### DIFF
--- a/vsphere/internal/virtualdevice/virtual_machine_network_interface_subresource.go
+++ b/vsphere/internal/virtualdevice/virtual_machine_network_interface_subresource.go
@@ -1194,12 +1194,6 @@ func (r *NetworkInterfaceSubresource) blockBandwidthSettingsSriov() error {
 func (r *NetworkInterfaceSubresource) ValidateDiff() error {
 	log.Printf("[DEBUG] %s: Beginning diff validation", r)
 
-	if r.Get("adapter_type") != networkInterfaceSubresourceTypeSriov {
-		if err := r.restrictResourceAllocationSettings(); err != nil {
-			return err
-		}
-	}
-
 	// Ensure physical adapter is set on all (and only on) SR-IOV NICs
 	if r.Get("adapter_type").(string) == networkInterfaceSubresourceTypeSriov {
 		if len(r.Get("physical_function").(string)) == 0 {
@@ -1218,26 +1212,6 @@ func (r *NetworkInterfaceSubresource) ValidateDiff() error {
 	}
 
 	log.Printf("[DEBUG] %s: Diff validation complete", r)
-	return nil
-}
-
-func (r *NetworkInterfaceSubresource) restrictResourceAllocationSettings() error {
-	rs := NetworkInterfaceSubresourceSchema()
-	keys := []string{
-		"bandwidth_limit",
-		"bandwidth_reservation",
-		"bandwidth_share_level",
-		"bandwidth_share_count",
-	}
-	for _, key := range keys {
-		expected := rs[key].Default
-		if expected == nil {
-			expected = rs[key].ZeroValue()
-		}
-		if r.Get(key) != expected {
-			return fmt.Errorf("%s requires vSphere 6.0 or higher", key)
-		}
-	}
 	return nil
 }
 


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 no-inline-html -->

<!--
    NOTE: Do NOT enter content between the comment markers <!- and ->.

    In order to have the best experience with our community, we recommend that you read the code of
    conduct and contributing guidelines before submitting a pull request.

    By submitting this pull request, you confirm that you have read, understood, and agreed to the
    project's code of conduct and contributing guidelines.

    Please use conventional commits to format the title of the pull request and the commit messages.

    For more information, please refer to https://www.conventionalcommits.org and the contributing
    guidelines for this project.
-->

### Summary

This pull request simplifies the `ValidateDiff` method in the `NetworkInterfaceSubresource` by removing redundant bandwidth restriction logic for non-SR-IOV network interfaces. The most important changes include deleting the `restrictResourceAllocationSettings` method and its associated calls, which were no longer necessary.

Simplification of `ValidateDiff` method:

* Removed the call to `restrictResourceAllocationSettings` for non-SR-IOV network interfaces. This eliminates unnecessary checks for bandwidth-related settings when the adapter type is not SR-IOV. (`vsphere/internal/virtualdevice/virtual_machine_network_interface_subresource.go`, [vsphere/internal/virtualdevice/virtual_machine_network_interface_subresource.goL1197-L1202](diffhunk://#diff-e8de2d20cbf49f2db545eafc50b5230673e69274016a107bc7c75f6adcb1d635L1197-L1202))
* Deleted the `restrictResourceAllocationSettings` method entirely, along with its logic for validating default values for bandwidth-related settings. This method was no longer required after the change to `ValidateDiff`. (`vsphere/internal/virtualdevice/virtual_machine_network_interface_subresource.go`, [vsphere/internal/virtualdevice/virtual_machine_network_interface_subresource.goL1224-L1243](diffhunk://#diff-e8de2d20cbf49f2db545eafc50b5230673e69274016a107bc7c75f6adcb1d635L1224-L1243))

### Type

<!--
    Please check the one(s) that applies to this pull request using "x".
-->

- [ ] `fix`: Bug Fix
- [ ] `feat`: Feature or Enhancement
- [ ] `docs`: Documentation
- [ ] `refactor`: Refactoring
- [x] `chore`: Build, Dependencies, Workflows, etc.
- [ ] `other`: Other (Please describe.)

### Breaking Changes?

<!--
    Please check the one that applies to this pull request using "x".
    If this pull request contains a breaking change, please describe the impact and mitigation path.
-->

- [ ] Yes, there are breaking changes.
- [x] No, there are no breaking changes.

### Tests

<!--
    Please check the one(s) that applies to this pull request using "x".
    For bug fixes and enhancements/features, please ensure that tests and documentation have been completed and provide details.
-->

- [ ] Tests have been added or updated.
- [x] Tests have been completed.

Output:

<!--
    Please provide the output of the acceptance tests as applicable.
-->

### Documentation

<!--
    Please check the one(s) that applies to this pull request using "x".
    For enhancements/features, please ensure that documentation has been updated.
-->

- [ ] Documentation has been added or updated.

### Issue References

<!--
    Is this related to any GitHub issue(s)? If so, please provide the issue number(s) that are closed or resolved by this pull request.

    For bug fixes and enhancements/features, please ensure that a GitHub issue has been created and provide the issue number(s) here.

    Please use the 'Closes', 'Resolves', or 'Fixes' keywords followed by the a hash and issue number.
    This will link the pull request to the issue(s) and automatically close them when the pull request is merged.

    Example:

    Closes #000
    Resolves #001
    Fixes #002
-->

### Release Note

<!--
    Please provide context for the release notes.

    For example:

    ```
    - `r/foo` - Added support for foo. (#xxx)
    ```
-->

### Additional Information

<!--
    Please provide any additional information that may be helpful.
-->
