### PR TITLE
refactor: stabilize and enable data source tests

### DIFF
--- a/docs/resources/datastore_cluster.md
+++ b/docs/resources/datastore_cluster.md
@@ -142,6 +142,8 @@ use the cluster default automation level.
 The following options control I/O load balancing for Storage DRS on the
 datastore cluster.
 
+I/O load balancing for Storage DRS is not available on vSphere 9.0 and later.
+
 * `sdrs_io_load_balance_enabled` - (Optional) Enable I/O load balancing for
   this datastore cluster. Default: `true`.
 * `sdrs_io_latency_threshold` - (Optional) The I/O latency threshold, in

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 . setup_env_vars.sh
-TF_ACC=1 go test -run -json -v ../vsphere -timeout 360m 2>&1 | tee gotest.log | gotestfmt
+TF_ACC=1 go test -json -v ../vsphere -timeout 360m 2>&1 | tee gotest.log | gotestfmt

--- a/vsphere/data_source_vsphere_compute_cluster_host_group_test.go
+++ b/vsphere/data_source_vsphere_compute_cluster_host_group_test.go
@@ -14,12 +14,10 @@ import (
 )
 
 func TestAccDataSourceVSphereComputeClusterHostGroup_basic(t *testing.T) {
-	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
 			testAccPreCheck(t)
-			testAccResourceVSphereComputeClusterHostGroupPreCheck(t)
 		},
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{

--- a/vsphere/data_source_vsphere_compute_cluster_test.go
+++ b/vsphere/data_source_vsphere_compute_cluster_test.go
@@ -14,7 +14,6 @@ import (
 )
 
 func TestAccDataSourceVSphereComputeCluster_basic(t *testing.T) {
-	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -27,11 +26,11 @@ func TestAccDataSourceVSphereComputeCluster_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(
 						"data.vsphere_compute_cluster.compute_cluster_data", "id",
-						"vsphere_compute_cluster.compute_cluster", "id",
+						"data.vsphere_compute_cluster.rootcompute_cluster1", "id",
 					),
 					resource.TestCheckResourceAttrPair(
 						"data.vsphere_compute_cluster.compute_cluster_data", "resource_pool_id",
-						"vsphere_compute_cluster.compute_cluster", "resource_pool_id",
+						"data.vsphere_compute_cluster.rootcompute_cluster1", "resource_pool_id",
 					),
 				),
 			},
@@ -40,12 +39,10 @@ func TestAccDataSourceVSphereComputeCluster_basic(t *testing.T) {
 }
 
 func TestAccDataSourceVSphereComputeCluster_absolutePathNoDatacenter(t *testing.T) {
-	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
 			testAccPreCheck(t)
-			testAccResourceVSphereComputeClusterPreCheck(t)
 		},
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
@@ -72,10 +69,10 @@ func testAccDataSourceVSphereComputeClusterConfigBasic() string {
 
 data "vsphere_compute_cluster" "compute_cluster_data" {
   name          = "%s"
-  datacenter_id = vsphere_compute_cluster.compute_cluster.datacenter_id
+  datacenter_id = data.vsphere_compute_cluster.rootcompute_cluster1.datacenter_id
 }
 `,
-		testhelper.CombineConfigs(testhelper.ConfigDataRootDC1(), testhelper.ConfigDataRootPortGroup1()),
+		testhelper.CombineConfigs(testhelper.ConfigDataRootDC1(), testhelper.ConfigDataRootComputeCluster1()),
 		os.Getenv("TF_VAR_VSPHERE_CLUSTER"),
 	)
 }
@@ -93,6 +90,6 @@ data "vsphere_compute_cluster" "compute_cluster_data" {
   name          = "/${data.vsphere_datacenter.rootdc1.name}/host/${vsphere_compute_cluster.compute_cluster.name}"
 }
 `,
-		testhelper.CombineConfigs(testhelper.ConfigDataRootDC1(), testhelper.ConfigDataRootPortGroup1()),
+		testhelper.CombineConfigs(testhelper.ConfigDataRootDC1(), testhelper.ConfigDataRootComputeCluster1()),
 	)
 }

--- a/vsphere/data_source_vsphere_datacenter_test.go
+++ b/vsphere/data_source_vsphere_datacenter_test.go
@@ -38,12 +38,10 @@ func TestAccDataSourceVSphereDatacenter_basic(t *testing.T) {
 }
 
 func TestAccDataSourceVSphereDatacenter_defaultDatacenter(t *testing.T) {
-	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
 			testAccPreCheck(t)
-			testAccDataSourceVSphereDatacenterPreCheck(t)
 		},
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
@@ -61,19 +59,11 @@ func TestAccDataSourceVSphereDatacenter_defaultDatacenter(t *testing.T) {
 	})
 }
 
-func testAccDataSourceVSphereDatacenterPreCheck(t *testing.T) {
-	if os.Getenv("TF_VAR_VSPHERE_DATACENTER") == "" {
-		t.Skip("set TF_VAR_VSPHERE_DATACENTER to run vsphere_datacenter acceptance tests")
-	}
-}
-
 func TestAccDataSourceVSphereDatacenter_getVirtualMachines(t *testing.T) {
-	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
 			testAccPreCheck(t)
-			testAccDataSourceVSphereDatacenterPreCheck(t)
 		},
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{

--- a/vsphere/data_source_vsphere_datastore_cluster_test.go
+++ b/vsphere/data_source_vsphere_datastore_cluster_test.go
@@ -6,7 +6,6 @@ package vsphere
 
 import (
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -14,12 +13,10 @@ import (
 )
 
 func TestAccDataSourceVSphereDatastoreCluster_basic(t *testing.T) {
-	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
 			testAccPreCheck(t)
-			testAccResourceVSphereDatastoreClusterPreCheck(t)
 		},
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
@@ -37,12 +34,10 @@ func TestAccDataSourceVSphereDatastoreCluster_basic(t *testing.T) {
 }
 
 func TestAccDataSourceVSphereDatastoreCluster_absolutePathNoDatacenter(t *testing.T) {
-	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
 			testAccPreCheck(t)
-			testAccResourceVSphereDatastoreClusterPreCheck(t)
 		},
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
@@ -59,12 +54,10 @@ func TestAccDataSourceVSphereDatastoreCluster_absolutePathNoDatacenter(t *testin
 	})
 }
 func TestAccDataSourceVSphereDatastoreCluster_getDatastores(t *testing.T) {
-	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
 			testAccPreCheck(t)
-			testAccResourceVSphereDatastoreClusterPreCheck(t)
 		},
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
@@ -88,6 +81,7 @@ func testAccDataSourceVSphereDatastoreClusterConfigBasic() string {
 resource "vsphere_datastore_cluster" "datastore_cluster" {
   name          = "testacc-datastore-cluster"
   datacenter_id = data.vsphere_datacenter.rootdc1.id
+  sdrs_io_load_balance_enabled = false
 }
 
 data "vsphere_datastore_cluster" "datastore_cluster_data" {
@@ -95,7 +89,7 @@ data "vsphere_datastore_cluster" "datastore_cluster_data" {
   datacenter_id = vsphere_datastore_cluster.datastore_cluster.datacenter_id
 }
 `,
-		testhelper.CombineConfigs(testhelper.ConfigDataRootDC1(), testhelper.ConfigDataRootPortGroup1()),
+		testhelper.CombineConfigs(testhelper.ConfigDataRootDC1()),
 	)
 }
 
@@ -106,20 +100,24 @@ func testAccDataSourceVSphereDatastoreClusterConfigAbsolutePath() string {
 resource "vsphere_datastore_cluster" "datastore_cluster" {
   name          = "testacc-datastore-cluster"
   datacenter_id = data.vsphere_datacenter.rootdc1.id
+  sdrs_io_load_balance_enabled = false
 }
 
 data "vsphere_datastore_cluster" "datastore_cluster_data" {
   name = "/${data.vsphere_datacenter.rootdc1.name}/datastore/${vsphere_datastore_cluster.datastore_cluster.name}"
 }
-`, testhelper.CombineConfigs(testhelper.ConfigDataRootDC1(), testhelper.ConfigDataRootPortGroup1()),
+`, testhelper.CombineConfigs(testhelper.ConfigDataRootDC1()),
 	)
 }
 
 func testAccDataSourceVSphereDatastoreClusterGetDatastores() string {
 	return fmt.Sprintf(`
+%s
+
 resource "vsphere_datastore_cluster" "datastore_cluster" {
-  name          = "%s"
-  datacenter_id = "%s"
+  name          = "testacc-datastore-cluster"
+  datacenter_id = data.vsphere_datacenter.rootdc1.id
+  sdrs_io_load_balance_enabled = false
 }
 
 data "vsphere_datastore_cluster" "datastore_cluster_data" {
@@ -130,6 +128,6 @@ data "vsphere_datastore_cluster" "datastore_cluster_data" {
 output "found_datastores" {
   value = length(data.vsphere_datastore_cluster.datastore_cluster_data.datastores) >= 1 ? "true" : "false"
 }
-`, os.Getenv("TF_VAR_VSPHERE_DATASTORE_CLUSTER_NAME"), os.Getenv("TF_VAR_VSPHERE_DATACENTER_ID"),
+`, testhelper.CombineConfigs(testhelper.ConfigDataRootDC1()),
 	)
 }

--- a/vsphere/data_source_vsphere_distributed_virtual_switch_test.go
+++ b/vsphere/data_source_vsphere_distributed_virtual_switch_test.go
@@ -49,7 +49,6 @@ func TestAccDataSourceVSphereDistributedVirtualSwitch_basic(t *testing.T) {
 }
 
 func TestAccDataSourceVSphereDistributedVirtualSwitch_absolutePathNoDatacenterSpecified(t *testing.T) {
-	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -68,12 +67,12 @@ func TestAccDataSourceVSphereDistributedVirtualSwitch_absolutePathNoDatacenterSp
 					resource.TestCheckResourceAttr(
 						"data.vsphere_distributed_virtual_switch.dvs-data",
 						"uplinks.0",
-						testhelper.HostNic0,
+						testhelper.HostNic1,
 					),
 					resource.TestCheckResourceAttr(
 						"data.vsphere_distributed_virtual_switch.dvs-data",
 						"uplinks.1",
-						testhelper.HostNic1,
+						testhelper.HostNic2,
 					),
 					resource.TestCheckResourceAttrPair(
 						"data.vsphere_distributed_virtual_switch.dvs-data", "id",
@@ -86,7 +85,6 @@ func TestAccDataSourceVSphereDistributedVirtualSwitch_absolutePathNoDatacenterSp
 }
 
 func TestAccDataSourceVSphereDistributedVirtualSwitch_CreatePortgroup(t *testing.T) {
-	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -110,12 +108,12 @@ func TestAccDataSourceVSphereDistributedVirtualSwitch_CreatePortgroup(t *testing
 					resource.TestCheckResourceAttr(
 						"vsphere_distributed_port_group.pg",
 						"active_uplinks.0",
-						testhelper.HostNic0,
+						testhelper.HostNic1,
 					),
 					resource.TestCheckResourceAttr(
 						"vsphere_distributed_port_group.pg",
 						"standby_uplinks.0",
-						testhelper.HostNic1,
+						testhelper.HostNic2,
 					),
 				),
 			},
@@ -168,8 +166,8 @@ resource "vsphere_distributed_port_group" "pg" {
 }
 `,
 		testhelper.CombineConfigs(testhelper.ConfigDataRootDC1(), testhelper.ConfigDataRootPortGroup1()),
-		testhelper.HostNic0,
 		testhelper.HostNic1,
+		testhelper.HostNic2,
 	)
 }
 
@@ -187,7 +185,7 @@ data "vsphere_distributed_virtual_switch" "dvs-data" {
   name = "/${data.vsphere_datacenter.rootdc1.name}/network/${vsphere_distributed_virtual_switch.dvs.name}"
 }
 `, testhelper.CombineConfigs(testhelper.ConfigDataRootDC1(), testhelper.ConfigDataRootPortGroup1()),
-		testhelper.HostNic0,
 		testhelper.HostNic1,
+		testhelper.HostNic2,
 	)
 }

--- a/vsphere/data_source_vsphere_dynamic_test.go
+++ b/vsphere/data_source_vsphere_dynamic_test.go
@@ -40,7 +40,6 @@ func TestAccDataSourceVSphereDynamic_regexAndTag(t *testing.T) {
 
 func TestAccDataSourceVSphereDynamic_multiTag(t *testing.T) {
 	t.Cleanup(RunSweepers)
-	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
@@ -64,7 +63,6 @@ func TestAccDataSourceVSphereDynamic_multiTag(t *testing.T) {
 }
 
 func TestAccDataSourceVSphereDynamic_multiResult(t *testing.T) {
-	testAccSkipUnstable(t)
 	t.Cleanup(RunSweepers)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
@@ -85,7 +83,6 @@ func TestAccDataSourceVSphereDynamic_multiResult(t *testing.T) {
 
 func TestAccDataSourceVSphereDynamic_typeFilter(t *testing.T) {
 	t.Cleanup(RunSweepers)
-	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)

--- a/vsphere/data_source_vsphere_guest_os_customization_test.go
+++ b/vsphere/data_source_vsphere_guest_os_customization_test.go
@@ -14,12 +14,10 @@ import (
 
 func TestAccDataSourceVSphereGOSC_basic(t *testing.T) {
 	goscName := acctest.RandomWithPrefix("lin")
-	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
 			testAccPreCheck(t)
-			testAccDataSourceVSphereHostPreCheck(t)
 		},
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{

--- a/vsphere/data_source_vsphere_host_test.go
+++ b/vsphere/data_source_vsphere_host_test.go
@@ -37,12 +37,10 @@ func TestAccDataSourceVSphereHost_basic(t *testing.T) {
 }
 
 func TestAccDataSourceVSphereHost_defaultHost(t *testing.T) {
-	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
 			testAccPreCheck(t)
-			testAccDataSourceVSphereHostPreCheck(t)
 			testAccSkipIfNotEsxi(t)
 		},
 		Providers: testAccProviders,
@@ -61,19 +59,7 @@ func TestAccDataSourceVSphereHost_defaultHost(t *testing.T) {
 	})
 }
 
-func testAccDataSourceVSphereHostPreCheck(t *testing.T) {
-	if os.Getenv("TF_VAR_VSPHERE_DATACENTER") == "" {
-		t.Skip("set TF_VAR_VSPHERE_DATACENTER to run vsphere_host acceptance tests")
-	}
-	if os.Getenv("TF_VAR_VSPHERE_ESXI1") == "" {
-		t.Skip("set TF_VAR_VSPHERE_ESXI1 to run vsphere_host acceptance tests")
-	}
-}
-
 func testAccDataSourceVSphereHostExpectedRegexp() *regexp.Regexp {
-	if os.Getenv("TF_VAR_VSPHERE_TEST_ESXI") != "" {
-		return regexp.MustCompile("^ha-host$")
-	}
 	return regexp.MustCompile("^host-")
 }
 

--- a/vsphere/data_source_vsphere_host_thumbprint_test.go
+++ b/vsphere/data_source_vsphere_host_thumbprint_test.go
@@ -36,6 +36,6 @@ data "vsphere_host_thumbprint" "thumb" {
   address  = "%s"
   insecure = true
 }`,
-		os.Getenv("TF_VAR_VSPHERE_ESXI1"),
+		os.Getenv("TF_VAR_VSPHERE_ESXI4"),
 	)
 }

--- a/vsphere/data_source_vsphere_network_test.go
+++ b/vsphere/data_source_vsphere_network_test.go
@@ -6,7 +6,6 @@ package vsphere
 
 import (
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -18,7 +17,6 @@ func TestAccDataSourceVSphereNetwork_dvsPortgroup(t *testing.T) {
 		PreCheck: func() {
 			RunSweepers()
 			testAccPreCheck(t)
-			testAccDataSourceVSphereNetworkPreCheck(t)
 			testAccSkipIfEsxi(t)
 		},
 		Providers: testAccProviders,
@@ -38,12 +36,10 @@ func TestAccDataSourceVSphereNetwork_dvsPortgroup(t *testing.T) {
 }
 
 func TestAccDataSourceVSphereNetwork_withTimeout(t *testing.T) {
-	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
 			testAccPreCheck(t)
-			testAccDataSourceVSphereNetworkPreCheck(t)
 			testAccSkipIfEsxi(t)
 		},
 		Providers: testAccProviders,
@@ -63,12 +59,10 @@ func TestAccDataSourceVSphereNetwork_withTimeout(t *testing.T) {
 }
 
 func TestAccDataSourceVSphereNetwork_absolutePathNoDatacenter(t *testing.T) {
-	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
 			testAccPreCheck(t)
-			testAccDataSourceVSphereNetworkPreCheck(t)
 			testAccSkipIfEsxi(t)
 		},
 		Providers: testAccProviders,
@@ -88,12 +82,10 @@ func TestAccDataSourceVSphereNetwork_absolutePathNoDatacenter(t *testing.T) {
 }
 
 func TestAccDataSourceVSphereNetwork_hostPortgroups(t *testing.T) {
-	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
 			testAccPreCheck(t)
-			testAccDataSourceVSphereNetworkPreCheck(t)
 		},
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
@@ -105,12 +97,6 @@ func TestAccDataSourceVSphereNetwork_hostPortgroups(t *testing.T) {
 			},
 		},
 	})
-}
-
-func testAccDataSourceVSphereNetworkPreCheck(t *testing.T) {
-	if os.Getenv("TF_VAR_VSPHERE_PG_NAME") == "" {
-		t.Skip("set TF_VAR_VSPHERE_PG_NAME to run vsphere_network acceptance tests")
-	}
 }
 
 func testAccDataSourceVSphereNetworkConfigDVSPortgroup(withTimeout bool) string {

--- a/vsphere/data_source_vsphere_role_test.go
+++ b/vsphere/data_source_vsphere_role_test.go
@@ -56,7 +56,6 @@ func TestAccDataSourceVSphereRole_basic(t *testing.T) {
 }
 
 func TestAccDataSourceVSphereRole_systemRoleData(t *testing.T) {
-	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)

--- a/vsphere/data_source_vsphere_tag_test.go
+++ b/vsphere/data_source_vsphere_tag_test.go
@@ -12,7 +12,6 @@ import (
 )
 
 func TestAccDataSourceVSphereTag_basic(t *testing.T) {
-	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()

--- a/vsphere/data_source_vsphere_vapp_container_test.go
+++ b/vsphere/data_source_vsphere_vapp_container_test.go
@@ -6,7 +6,6 @@ package vsphere
 
 import (
 	"fmt"
-	"os"
 	"regexp"
 	"testing"
 
@@ -15,12 +14,10 @@ import (
 )
 
 func TestAccDataSourceVSphereVAppContainer_basic(t *testing.T) {
-	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
 			testAccPreCheck(t)
-			testAccDataSourceVSphereVAppContainerPreCheck(t)
 			testAccSkipIfEsxi(t)
 		},
 		Providers: testAccProviders,
@@ -37,12 +34,10 @@ func TestAccDataSourceVSphereVAppContainer_basic(t *testing.T) {
 }
 
 func TestAccDataSourceVSphereVAppContainer_path(t *testing.T) {
-	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
 			testAccPreCheck(t)
-			testAccDataSourceVSphereVAppContainerPreCheck(t)
 			testAccSkipIfEsxi(t)
 		},
 		Providers: testAccProviders,
@@ -56,15 +51,6 @@ func TestAccDataSourceVSphereVAppContainer_path(t *testing.T) {
 			},
 		},
 	})
-}
-
-func testAccDataSourceVSphereVAppContainerPreCheck(t *testing.T) {
-	if os.Getenv("TF_VAR_VSPHERE_DATACENTER") == "" {
-		t.Skip("set TF_VAR_VSPHERE_DATACENTER to run vsphere_vapp_container acceptance tests")
-	}
-	if os.Getenv("TF_VAR_VSPHERE_CLUSTER") == "" {
-		t.Skip("set TF_VAR_VSPHERE_CLUSTER to run vsphere_vapp_container acceptance tests")
-	}
 }
 
 func testAccDataSourceVSphereVAppContainerConfig() string {

--- a/vsphere/data_source_vsphere_virtual_machine_test.go
+++ b/vsphere/data_source_vsphere_virtual_machine_test.go
@@ -6,7 +6,6 @@ package vsphere
 
 import (
 	"fmt"
-	"os"
 	"regexp"
 	"testing"
 
@@ -15,12 +14,10 @@ import (
 )
 
 func TestAccDataSourceVSphereVirtualMachine_basic(t *testing.T) {
-	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
 			testAccPreCheck(t)
-			testAccDataSourceVSphereVirtualMachinePreCheck(t)
 		},
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
@@ -28,33 +25,33 @@ func TestAccDataSourceVSphereVirtualMachine_basic(t *testing.T) {
 				Config: testAccDataSourceVSphereVirtualMachineConfig(),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestMatchResourceAttr(
-						"data.vsphere_virtual_machine.template",
+						"data.vsphere_virtual_machine.vm",
 						"id",
 						regexp.MustCompile("^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$")),
-					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.template", "guest_id"),
-					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.template", "scsi_type"),
-					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.template", "memory"),
-					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.template", "memory_reservation_locked_to_max"),
-					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.template", "num_cpus"),
-					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.template", "num_cores_per_socket"),
-					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.template", "firmware"),
-					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.template", "hardware_version"),
-					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.template", "disks.#"),
-					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.template", "disks.0.size"),
-					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.template", "disks.0.eagerly_scrub"),
-					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.template", "disks.0.thin_provisioned"),
-					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.template", "disks.0.unit_number"),
-					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.template", "disks.0.label"),
-					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.template", "network_interface_types.#"),
-					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.template", "network_interfaces.#"),
-					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.template", "network_interfaces.0.adapter_type"),
-					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.template", "network_interfaces.0.bandwidth_limit"),
-					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.template", "network_interfaces.0.bandwidth_reservation"),
-					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.template", "network_interfaces.0.bandwidth_share_level"),
-					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.template", "network_interfaces.0.bandwidth_share_count"),
-					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.template", "network_interfaces.0.mac_address"),
-					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.template", "network_interfaces.0.network_id"),
-					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.template", "instance_uuid"),
+					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.vm", "guest_id"),
+					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.vm", "scsi_type"),
+					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.vm", "memory"),
+					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.vm", "memory_reservation_locked_to_max"),
+					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.vm", "num_cpus"),
+					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.vm", "num_cores_per_socket"),
+					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.vm", "firmware"),
+					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.vm", "hardware_version"),
+					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.vm", "disks.#"),
+					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.vm", "disks.0.size"),
+					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.vm", "disks.0.eagerly_scrub"),
+					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.vm", "disks.0.thin_provisioned"),
+					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.vm", "disks.0.unit_number"),
+					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.vm", "disks.0.label"),
+					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.vm", "network_interface_types.#"),
+					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.vm", "network_interfaces.#"),
+					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.vm", "network_interfaces.0.adapter_type"),
+					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.vm", "network_interfaces.0.bandwidth_limit"),
+					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.vm", "network_interfaces.0.bandwidth_reservation"),
+					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.vm", "network_interfaces.0.bandwidth_share_level"),
+					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.vm", "network_interfaces.0.bandwidth_share_count"),
+					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.vm", "network_interfaces.0.mac_address"),
+					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.vm", "network_interfaces.0.network_id"),
+					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.vm", "instance_uuid"),
 				),
 			},
 		},
@@ -62,12 +59,10 @@ func TestAccDataSourceVSphereVirtualMachine_basic(t *testing.T) {
 }
 
 func TestAccDataSourceVSphereVirtualMachine_noDatacenterAndAbsolutePath(t *testing.T) {
-	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
 			testAccPreCheck(t)
-			testAccDataSourceVSphereVirtualMachinePreCheck(t)
 		},
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
@@ -75,32 +70,32 @@ func TestAccDataSourceVSphereVirtualMachine_noDatacenterAndAbsolutePath(t *testi
 				Config: testAccDataSourceVSphereVirtualMachineConfigAbsolutePath(),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestMatchResourceAttr(
-						"data.vsphere_virtual_machine.template",
+						"data.vsphere_virtual_machine.vm",
 						"id",
 						regexp.MustCompile("^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$")),
-					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.template", "guest_id"),
-					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.template", "scsi_type"),
-					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.template", "memory"),
-					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.template", "num_cpus"),
-					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.template", "num_cores_per_socket"),
-					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.template", "firmware"),
-					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.template", "hardware_version"),
-					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.template", "disks.#"),
-					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.template", "disks.0.size"),
-					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.template", "disks.0.eagerly_scrub"),
-					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.template", "disks.0.thin_provisioned"),
-					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.template", "disks.0.unit_number"),
-					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.template", "disks.0.label"),
-					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.template", "network_interface_types.#"),
-					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.template", "network_interfaces.#"),
-					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.template", "network_interfaces.0.adapter_type"),
-					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.template", "network_interfaces.0.bandwidth_limit"),
-					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.template", "network_interfaces.0.bandwidth_reservation"),
-					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.template", "network_interfaces.0.bandwidth_share_level"),
-					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.template", "network_interfaces.0.bandwidth_share_count"),
-					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.template", "network_interfaces.0.mac_address"),
-					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.template", "network_interfaces.0.network_id"),
-					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.template", "instance_uuid"),
+					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.vm", "guest_id"),
+					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.vm", "scsi_type"),
+					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.vm", "memory"),
+					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.vm", "num_cpus"),
+					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.vm", "num_cores_per_socket"),
+					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.vm", "firmware"),
+					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.vm", "hardware_version"),
+					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.vm", "disks.#"),
+					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.vm", "disks.0.size"),
+					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.vm", "disks.0.eagerly_scrub"),
+					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.vm", "disks.0.thin_provisioned"),
+					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.vm", "disks.0.unit_number"),
+					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.vm", "disks.0.label"),
+					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.vm", "network_interface_types.#"),
+					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.vm", "network_interfaces.#"),
+					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.vm", "network_interfaces.0.adapter_type"),
+					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.vm", "network_interfaces.0.bandwidth_limit"),
+					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.vm", "network_interfaces.0.bandwidth_reservation"),
+					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.vm", "network_interfaces.0.bandwidth_share_level"),
+					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.vm", "network_interfaces.0.bandwidth_share_count"),
+					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.vm", "network_interfaces.0.mac_address"),
+					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.vm", "network_interfaces.0.network_id"),
+					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.vm", "instance_uuid"),
 				),
 			},
 		},
@@ -108,12 +103,10 @@ func TestAccDataSourceVSphereVirtualMachine_noDatacenterAndAbsolutePath(t *testi
 }
 
 func TestAccDataSourceVSphereVirtualMachine_uuid(t *testing.T) {
-	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
 			testAccPreCheck(t)
-			testAccDataSourceVSphereVirtualMachinePreCheck(t)
 		},
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
@@ -121,33 +114,33 @@ func TestAccDataSourceVSphereVirtualMachine_uuid(t *testing.T) {
 				Config: testAccDataSourceVSphereVirtualMachineConfigUUID(),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestMatchResourceAttr(
-						"data.vsphere_virtual_machine.uuid",
+						"data.vsphere_virtual_machine.vm",
 						"id",
 						regexp.MustCompile("^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$")),
-					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.uuid", "guest_id"),
-					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.uuid", "scsi_type"),
-					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.uuid", "memory"),
-					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.uuid", "num_cpus"),
-					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.uuid", "num_cores_per_socket"),
-					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.uuid", "firmware"),
-					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.uuid", "hardware_version"),
-					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.uuid", "disks.#"),
-					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.uuid", "disks.0.size"),
-					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.uuid", "disks.0.eagerly_scrub"),
-					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.uuid", "disks.0.thin_provisioned"),
-					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.uuid", "disks.0.unit_number"),
-					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.uuid", "disks.0.label"),
-					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.uuid", "network_interface_types.#"),
-					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.uuid", "network_interfaces.#"),
-					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.uuid", "network_interfaces.0.adapter_type"),
-					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.uuid", "network_interfaces.0.bandwidth_limit"),
-					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.uuid", "network_interfaces.0.bandwidth_reservation"),
-					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.uuid", "network_interfaces.0.bandwidth_share_level"),
-					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.uuid", "network_interfaces.0.bandwidth_share_count"),
-					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.uuid", "network_interfaces.0.mac_address"),
-					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.uuid", "network_interfaces.0.network_id"),
-					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.uuid", "uuid"),
-					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.uuid", "instance_uuid"),
+					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.vm", "guest_id"),
+					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.vm", "scsi_type"),
+					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.vm", "memory"),
+					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.vm", "num_cpus"),
+					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.vm", "num_cores_per_socket"),
+					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.vm", "firmware"),
+					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.vm", "hardware_version"),
+					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.vm", "disks.#"),
+					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.vm", "disks.0.size"),
+					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.vm", "disks.0.eagerly_scrub"),
+					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.vm", "disks.0.thin_provisioned"),
+					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.vm", "disks.0.unit_number"),
+					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.vm", "disks.0.label"),
+					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.vm", "network_interface_types.#"),
+					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.vm", "network_interfaces.#"),
+					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.vm", "network_interfaces.0.adapter_type"),
+					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.vm", "network_interfaces.0.bandwidth_limit"),
+					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.vm", "network_interfaces.0.bandwidth_reservation"),
+					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.vm", "network_interfaces.0.bandwidth_share_level"),
+					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.vm", "network_interfaces.0.bandwidth_share_count"),
+					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.vm", "network_interfaces.0.mac_address"),
+					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.vm", "network_interfaces.0.network_id"),
+					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.vm", "uuid"),
+					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.vm", "instance_uuid"),
 				),
 			},
 		},
@@ -155,12 +148,10 @@ func TestAccDataSourceVSphereVirtualMachine_uuid(t *testing.T) {
 }
 
 func TestAccDataSourceVSphereVirtualMachine_moid(t *testing.T) {
-	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
 			testAccPreCheck(t)
-			testAccDataSourceVSphereVirtualMachinePreCheck(t)
 		},
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
@@ -168,33 +159,33 @@ func TestAccDataSourceVSphereVirtualMachine_moid(t *testing.T) {
 				Config: testAccDataSourceVSphereVirtualMachineConfigMOID(),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestMatchResourceAttr(
-						"data.vsphere_virtual_machine.moid",
+						"data.vsphere_virtual_machine.vm",
 						"id",
 						regexp.MustCompile("^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$")),
-					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.moid", "guest_id"),
-					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.moid", "scsi_type"),
-					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.moid", "memory"),
-					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.moid", "num_cpus"),
-					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.moid", "num_cores_per_socket"),
-					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.moid", "firmware"),
-					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.moid", "hardware_version"),
-					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.moid", "disks.#"),
-					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.moid", "disks.0.size"),
-					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.moid", "disks.0.eagerly_scrub"),
-					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.moid", "disks.0.thin_provisioned"),
-					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.moid", "disks.0.unit_number"),
-					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.moid", "disks.0.label"),
-					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.moid", "network_interface_types.#"),
-					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.moid", "network_interfaces.#"),
-					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.moid", "network_interfaces.0.adapter_type"),
-					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.moid", "network_interfaces.0.bandwidth_limit"),
-					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.moid", "network_interfaces.0.bandwidth_reservation"),
-					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.moid", "network_interfaces.0.bandwidth_share_level"),
-					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.moid", "network_interfaces.0.bandwidth_share_count"),
-					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.moid", "network_interfaces.0.mac_address"),
-					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.moid", "network_interfaces.0.network_id"),
-					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.moid", "instance_uuid"),
-					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.moid", "moid"),
+					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.vm", "guest_id"),
+					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.vm", "scsi_type"),
+					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.vm", "memory"),
+					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.vm", "num_cpus"),
+					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.vm", "num_cores_per_socket"),
+					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.vm", "firmware"),
+					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.vm", "hardware_version"),
+					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.vm", "disks.#"),
+					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.vm", "disks.0.size"),
+					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.vm", "disks.0.eagerly_scrub"),
+					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.vm", "disks.0.thin_provisioned"),
+					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.vm", "disks.0.unit_number"),
+					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.vm", "disks.0.label"),
+					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.vm", "network_interface_types.#"),
+					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.vm", "network_interfaces.#"),
+					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.vm", "network_interfaces.0.adapter_type"),
+					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.vm", "network_interfaces.0.bandwidth_limit"),
+					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.vm", "network_interfaces.0.bandwidth_reservation"),
+					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.vm", "network_interfaces.0.bandwidth_share_level"),
+					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.vm", "network_interfaces.0.bandwidth_share_count"),
+					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.vm", "network_interfaces.0.mac_address"),
+					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.vm", "network_interfaces.0.network_id"),
+					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.vm", "instance_uuid"),
+					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.vm", "moid"),
 				),
 			},
 		},
@@ -202,76 +193,55 @@ func TestAccDataSourceVSphereVirtualMachine_moid(t *testing.T) {
 }
 
 func TestAccDataSourceVSphereVirtualMachine_nameAndFolder(t *testing.T) {
-	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
 			testAccPreCheck(t)
-			testAccDataSourceVSphereVirtualMachinePreCheck(t)
 		},
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{{
 			Config: testAccDataSourceVirtualMachineFolder(),
 			Check: resource.ComposeTestCheckFunc(
 				resource.TestMatchResourceAttr(
-					"data.vsphere_virtual_machine.vm1",
+					"data.vsphere_virtual_machine.vm",
 					"id",
 					regexp.MustCompile("^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$")),
-				resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.vm1", "guest_id"),
-				resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.vm1", "scsi_type"),
-				resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.vm1", "memory"),
-				resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.vm1", "num_cpus"),
-				resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.vm1", "num_cores_per_socket"),
-				resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.vm1", "firmware"),
-				resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.vm1", "hardware_version"),
-				resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.vm1", "disks.#"),
-				resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.vm1", "disks.0.size"),
-				resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.vm1", "disks.0.eagerly_scrub"),
-				resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.vm1", "disks.0.thin_provisioned"),
-				resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.vm1", "disks.0.unit_number"),
-				resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.vm1", "disks.0.label"),
-				resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.vm1", "network_interface_types.#"),
-				resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.vm1", "network_interfaces.#"),
-				resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.vm1", "network_interfaces.0.adapter_type"),
-				resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.vm1", "network_interfaces.0.bandwidth_limit"),
-				resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.vm1", "network_interfaces.0.bandwidth_reservation"),
-				resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.vm1", "network_interfaces.0.bandwidth_share_level"),
-				resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.vm1", "network_interfaces.0.bandwidth_share_count"),
-				resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.vm1", "network_interfaces.0.mac_address"),
-				resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.vm1", "network_interfaces.0.network_id"),
-				resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.vm1", "instance_uuid")),
+				resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.vm", "guest_id"),
+				resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.vm", "scsi_type"),
+				resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.vm", "memory"),
+				resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.vm", "num_cpus"),
+				resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.vm", "num_cores_per_socket"),
+				resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.vm", "firmware"),
+				resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.vm", "hardware_version"),
+				resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.vm", "disks.#"),
+				resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.vm", "disks.0.size"),
+				resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.vm", "disks.0.eagerly_scrub"),
+				resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.vm", "disks.0.thin_provisioned"),
+				resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.vm", "disks.0.unit_number"),
+				resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.vm", "disks.0.label"),
+				resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.vm", "network_interface_types.#"),
+				resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.vm", "network_interfaces.#"),
+				resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.vm", "network_interfaces.0.adapter_type"),
+				resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.vm", "network_interfaces.0.bandwidth_limit"),
+				resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.vm", "network_interfaces.0.bandwidth_reservation"),
+				resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.vm", "network_interfaces.0.bandwidth_share_level"),
+				resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.vm", "network_interfaces.0.bandwidth_share_count"),
+				resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.vm", "network_interfaces.0.mac_address"),
+				resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.vm", "network_interfaces.0.network_id"),
+				resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.vm", "instance_uuid")),
 		}},
 	})
-}
-
-func testAccDataSourceVSphereVirtualMachinePreCheck(t *testing.T) {
-	if os.Getenv("TF_VAR_VSPHERE_DATACENTER") == "" {
-		t.Skip("set TF_VAR_VSPHERE_DATACENTER to run vsphere_virtual_machine data source acceptance tests")
-	}
-	if os.Getenv("TF_VAR_VSPHERE_TEMPLATE") == "" {
-		t.Skip("set TF_VAR_VSPHERE_TEMPLATE to run vsphere_virtual_machine data source acceptance tests")
-	}
 }
 
 func testAccDataSourceVSphereVirtualMachineConfigUUID() string {
 	return fmt.Sprintf(`
 %s
 
-variable "template" {
-  default = "%s"
-}
-
-data "vsphere_virtual_machine" "template" {
-  name          = var.template
-  datacenter_id = data.vsphere_datacenter.rootdc1.id
-}
-
-data "vsphere_virtual_machine" "uuid" {
-  uuid = data.vsphere_virtual_machine.template.uuid
+data "vsphere_virtual_machine" "vm" {
+  uuid = vsphere_virtual_machine.srcvm.uuid
 }
 `,
-		testhelper.CombineConfigs(testhelper.ConfigDataRootDC1(), testhelper.ConfigDataRootPortGroup1()),
-		os.Getenv("TF_VAR_VSPHERE_TEMPLATE"),
+		testAccDataSourceVSphereVirtualMachineConfigBase(),
 	)
 }
 
@@ -279,21 +249,11 @@ func testAccDataSourceVSphereVirtualMachineConfigMOID() string {
 	return fmt.Sprintf(`
 %s
 
-variable "template" {
-  default = "%s"
-}
-
-data "vsphere_virtual_machine" "template" {
-  name          = var.template
-  datacenter_id = data.vsphere_datacenter.rootdc1.id
-}
-
-data "vsphere_virtual_machine" "moid" {
-  moid = data.vsphere_virtual_machine.template.moid
+data "vsphere_virtual_machine" "vm" {
+  moid = vsphere_virtual_machine.srcvm.moid
 }
 `,
-		testhelper.CombineConfigs(testhelper.ConfigDataRootDC1(), testhelper.ConfigDataRootPortGroup1()),
-		os.Getenv("TF_VAR_VSPHERE_TEMPLATE"),
+		testAccDataSourceVSphereVirtualMachineConfigBase(),
 	)
 }
 
@@ -301,17 +261,12 @@ func testAccDataSourceVSphereVirtualMachineConfig() string {
 	return fmt.Sprintf(`
 %s
 
-variable "template" {
-  default = "%s"
-}
-
-data "vsphere_virtual_machine" "template" {
-  name          = var.template
+data "vsphere_virtual_machine" "vm" {
+  name          = vsphere_virtual_machine.srcvm.name
   datacenter_id = data.vsphere_datacenter.rootdc1.id
 }
 `,
-		testhelper.CombineConfigs(testhelper.ConfigDataRootDC1(), testhelper.ConfigDataRootPortGroup1()),
-		os.Getenv("TF_VAR_VSPHERE_TEMPLATE"),
+		testAccDataSourceVSphereVirtualMachineConfigBase(),
 	)
 }
 
@@ -319,34 +274,65 @@ func testAccDataSourceVSphereVirtualMachineConfigAbsolutePath() string {
 	return fmt.Sprintf(`
 %s
 
-variable "template" {
-  default = "%s"
-}
-
-data "vsphere_virtual_machine" "template" {
-  name = "/${data.vsphere_datacenter.rootdc1.name}/vm/${var.template}"
+data "vsphere_virtual_machine" "vm" {
+  name = "/${data.vsphere_datacenter.rootdc1.name}/vm/${vsphere_virtual_machine.srcvm.name}"
 }
 `,
-		testhelper.CombineConfigs(testhelper.ConfigDataRootDC1(), testhelper.ConfigDataRootPortGroup1()),
-		os.Getenv("TF_VAR_VSPHERE_TEMPLATE"),
+		testAccDataSourceVSphereVirtualMachineConfigBase(),
 	)
 }
 
 func testAccDataSourceVirtualMachineFolder() string {
 	return fmt.Sprintf(`
-	%s
+%s
 
 resource "vsphere_folder" "new_vm_folder" {
   path          = "new-vm-folder"
   datacenter_id = data.vsphere_datacenter.rootdc1.id
   type          = "vm"
-
 }
 
-resource "vsphere_virtual_machine" "vm" {
-  name             = "foo"
+resource "vsphere_virtual_machine" "srcvm" {
+  name             = "acc-test-vm"
   resource_pool_id = data.vsphere_compute_cluster.rootcompute_cluster1.resource_pool_id
+  datastore_id     = data.vsphere_datastore.rootds1.id
   folder           = vsphere_folder.new_vm_folder.path
+  num_cpus         = 1
+  memory           = 1024
+  guest_id         = "otherLinux64Guest"
+  network_interface {
+    network_id = data.vsphere_network.network1.id
+  }
+  disk {
+    label = "disk0"
+    size  = 1
+    io_reservation = 1
+  }
+  wait_for_guest_ip_timeout  = 0
+  wait_for_guest_net_timeout = 0
+}
+
+data vsphere_virtual_machine "vm" {
+  name          = vsphere_virtual_machine.srcvm.name
+  datacenter_id = data.vsphere_datacenter.rootdc1.id
+  folder        = vsphere_folder.new_vm_folder.path
+}
+`,
+		testhelper.CombineConfigs(
+			testhelper.ConfigDataRootDC1(),
+			testhelper.ConfigDataRootDS1(),
+			testhelper.ConfigDataRootComputeCluster1(),
+			testhelper.ConfigDataRootPortGroup1()),
+	)
+}
+
+func testAccDataSourceVSphereVirtualMachineConfigBase() string {
+	return fmt.Sprintf(`
+%s
+
+resource "vsphere_virtual_machine" "srcvm" {
+  name             = "acc-test-vm"
+  resource_pool_id = data.vsphere_compute_cluster.rootcompute_cluster1.resource_pool_id
   datastore_id     = data.vsphere_datastore.rootds1.id
   num_cpus         = 1
   memory           = 1024
@@ -356,26 +342,17 @@ resource "vsphere_virtual_machine" "vm" {
   }
   disk {
     label = "disk0"
-    size  = 10
+    size  = 1
+    io_reservation = 1
   }
   wait_for_guest_ip_timeout  = 0
   wait_for_guest_net_timeout = 0
 }
-
-data vsphere_virtual_machine "vm1" {
-  name          = vsphere_virtual_machine.vm.name
-  datacenter_id = data.vsphere_datacenter.rootdc1.id
-  folder        = vsphere_folder.new_vm_folder.path
-}
-
-
-
-
-`, testhelper.CombineConfigs(
-		testhelper.ConfigDataRootDC1(),
-		testhelper.ConfigDataRootPortGroup1(),
-		testhelper.ConfigDataRootComputeCluster1(),
-		testhelper.ConfigDataRootDS1(),
-	))
-
+`,
+		testhelper.CombineConfigs(
+			testhelper.ConfigDataRootDC1(),
+			testhelper.ConfigDataRootDS1(),
+			testhelper.ConfigDataRootComputeCluster1(),
+			testhelper.ConfigDataRootPortGroup1()),
+	)
 }

--- a/vsphere/data_source_vsphere_vmfs_disks_test.go
+++ b/vsphere/data_source_vsphere_vmfs_disks_test.go
@@ -15,12 +15,10 @@ import (
 )
 
 func TestAccDataSourceVSphereVmfsDisks_basic(t *testing.T) {
-	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
 			testAccPreCheck(t)
-			testAccDataSourceVSphereVmfsDisksPreCheck(t)
 		},
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
@@ -32,12 +30,6 @@ func TestAccDataSourceVSphereVmfsDisks_basic(t *testing.T) {
 			},
 		},
 	})
-}
-
-func testAccDataSourceVSphereVmfsDisksPreCheck(t *testing.T) {
-	if os.Getenv("TF_VAR_VSPHERE_ESXI1") == "" {
-		t.Skip("set TF_VAR_VSPHERE_ESXI1 to run vsphere_vmfs_disks acceptance tests")
-	}
 }
 
 // testCheckOutputBool checks an output in the Terraform configuration
@@ -80,6 +72,6 @@ output "found" {
 }
 `,
 		testhelper.CombineConfigs(testhelper.ConfigDataRootDC1(), testhelper.ConfigDataRootPortGroup1()),
-		os.Getenv("TF_VAR_VSPHERE_ESXI1"),
+		os.Getenv("TF_VAR_VSPHERE_ESXI3"),
 	)
 }

--- a/vsphere/internal/virtualdevice/virtual_machine_network_interface_subresource.go
+++ b/vsphere/internal/virtualdevice/virtual_machine_network_interface_subresource.go
@@ -1194,12 +1194,6 @@ func (r *NetworkInterfaceSubresource) blockBandwidthSettingsSriov() error {
 func (r *NetworkInterfaceSubresource) ValidateDiff() error {
 	log.Printf("[DEBUG] %s: Beginning diff validation", r)
 
-	if r.Get("adapter_type") != networkInterfaceSubresourceTypeSriov {
-		if err := r.restrictResourceAllocationSettings(); err != nil {
-			return err
-		}
-	}
-
 	// Ensure physical adapter is set on all (and only on) SR-IOV NICs
 	if r.Get("adapter_type").(string) == networkInterfaceSubresourceTypeSriov {
 		if len(r.Get("physical_function").(string)) == 0 {
@@ -1218,26 +1212,6 @@ func (r *NetworkInterfaceSubresource) ValidateDiff() error {
 	}
 
 	log.Printf("[DEBUG] %s: Diff validation complete", r)
-	return nil
-}
-
-func (r *NetworkInterfaceSubresource) restrictResourceAllocationSettings() error {
-	rs := NetworkInterfaceSubresourceSchema()
-	keys := []string{
-		"bandwidth_limit",
-		"bandwidth_reservation",
-		"bandwidth_share_level",
-		"bandwidth_share_count",
-	}
-	for _, key := range keys {
-		expected := rs[key].Default
-		if expected == nil {
-			expected = rs[key].ZeroValue()
-		}
-		if r.Get(key) != expected {
-			return fmt.Errorf("%s requires vSphere 6.0 or higher", key)
-		}
-	}
 	return nil
 }
 

--- a/vsphere/resource_vsphere_resource_pool.go
+++ b/vsphere/resource_vsphere_resource_pool.go
@@ -336,7 +336,7 @@ func expandResourcePoolConfigSpec(d *schema.ResourceData, version viapi.VSphereV
 
 func expandResourcePoolCPUAllocation(d *schema.ResourceData) types.ResourceAllocationInfo {
 	return types.ResourceAllocationInfo{
-		Reservation:           structure.GetInt64Ptr(d, "cpu_reservation"),
+		Reservation:           structure.GetInt64PtrEmptyZero(d, "cpu_reservation"),
 		ExpandableReservation: structure.GetBoolPtr(d, "cpu_expandable"),
 		Limit:                 structure.GetInt64Ptr(d, "cpu_limit"),
 		Shares: &types.SharesInfo{
@@ -348,7 +348,7 @@ func expandResourcePoolCPUAllocation(d *schema.ResourceData) types.ResourceAlloc
 
 func expandResourcePoolMemoryAllocation(d *schema.ResourceData) types.ResourceAllocationInfo {
 	return types.ResourceAllocationInfo{
-		Reservation:           structure.GetInt64Ptr(d, "memory_reservation"),
+		Reservation:           structure.GetInt64PtrEmptyZero(d, "memory_reservation"),
 		ExpandableReservation: structure.GetBoolPtr(d, "memory_expandable"),
 		Limit:                 structure.GetInt64Ptr(d, "memory_limit"),
 		Shares: &types.SharesInfo{


### PR DESCRIPTION
### Summary

Rework data source tests so that they work on the default testbed and mark as enabled

### Type

- [ ] `fix`: Bug Fix
- [ ] `feat`: Feature or Enhancement
- [ ] `docs`: Documentation
- [X] `refactor`: Refactoring
- [ ] `chore`: Build, Dependencies, Workflows, etc.
- [ ] `other`: Other (Please describe.)

### Breaking Changes?

- [ ] Yes, there are breaking changes.
- [X] No, there are no breaking changes.

### Tests

- [ ] Tests have been added or updated.
- [x] Tests have been completed.

<details>

<summary>Output:</summary>

📦 github.com/vmware/terraform-provider-vsphere/vsphere
  ✅ TestAccDataSourceVSphereComputeClusterHostGroup_basic (56.36s)
  ✅ TestAccDataSourceVSphereComputeCluster_absolutePathNoDatacenter (1m11.89s)
  ✅ TestAccDataSourceVSphereComputeCluster_basic (50.31s)
  ✅ TestAccDataSourceVSphereContentLibrary_basic (59.16s)
  ✅ TestAccDataSourceVSphereCustomAttribute_basic (45.3s)
  ✅ TestAccDataSourceVSphereDatacenter_basic (44.35s)
  ✅ TestAccDataSourceVSphereDatacenter_defaultDatacenter (44.65s)
  ✅ TestAccDataSourceVSphereDatacenter_getVirtualMachines (44.42s)
  ✅ TestAccDataSourceVSphereDatastoreCluster_absolutePathNoDatacenter (54.81s)
  ✅ TestAccDataSourceVSphereDatastoreCluster_basic (56.2s)
  ✅ TestAccDataSourceVSphereDatastoreCluster_getDatastores (55.09s)
  ✅ TestAccDataSourceVSphereDatastoreStats_basic (1m14.37s)
  ✅ TestAccDataSourceVSphereDatastore_basic (49.04s)
  ✅ TestAccDataSourceVSphereDistributedVirtualSwitch_CreatePortgroup (1m3.06s)
  ✅ TestAccDataSourceVSphereDistributedVirtualSwitch_absolutePathNoDatacenterSpecified (1m0.95s)
  ✅ TestAccDataSourceVSphereDistributedVirtualSwitch_basic (1m1.45s)
  ✅ TestAccDataSourceVSphereDynamic_multiResult (1m9.23s)
  ✅ TestAccDataSourceVSphereDynamic_multiTag (1m29.35s)
  ✅ TestAccDataSourceVSphereDynamic_regexAndTag (1m28.09s)
  ✅ TestAccDataSourceVSphereDynamic_typeFilter (1m28.33s)
  ✅ TestAccDataSourceVSphereFolder_basic (54.06s)
  ✅ TestAccDataSourceVSphereGOSC_basic (44.69s)
  ✅ TestAccDataSourceVSphereHostThumbprint_basic (9.88s)
  ✅ TestAccDataSourceVSphereHost_basic (48.66s)
  ✅ TestAccDataSourceVSphereNetwork_absolutePathNoDatacenter (1m0.87s)
  ✅ TestAccDataSourceVSphereNetwork_dvsPortgroup (1m3.25s)
  ✅ TestAccDataSourceVSphereNetwork_hostPortgroups (50.88s)
  ✅ TestAccDataSourceVSphereNetwork_withTimeout (1m2.01s)
  ✅ TestAccDataSourceVSphereResourcePool_basic (58.72s)
  ✅ TestAccDataSourceVSphereResourcePool_noDatacenterAndAbsolutePath (58.1s)
  ✅ TestAccDataSourceVSphereResourcePool_withParentId (59.43s)
  ✅ TestAccDataSourceVSphereRole_basic (14.37s)
  ✅ TestAccDataSourceVSphereRole_systemRoleData (9.56s)
  ✅ TestAccDataSourceVSphereTagCategory_basic (47.72s)
  ✅ TestAccDataSourceVSphereTag_basic (48.83s)
  ✅ TestAccDataSourceVSphereVAppContainer_basic (57.29s)
  ✅ TestAccDataSourceVSphereVAppContainer_path (57.32s)
  ✅ TestAccDataSourceVSphereVirtualMachine_basic (1m15.35s)
  ✅ TestAccDataSourceVSphereVirtualMachine_moid (1m12.08s)
  ✅ TestAccDataSourceVSphereVirtualMachine_nameAndFolder (1m20.39s)
  ✅ TestAccDataSourceVSphereVirtualMachine_noDatacenterAndAbsolutePath (1m14.05s)
  ✅ TestAccDataSourceVSphereVirtualMachine_uuid (1m18.75s)
  ✅ TestAccDataSourceVSphereVmfsDisks_basic (52.62s)

</details>

### Documentation

- [X] Documentation has been added or updated.

### Issue References

https://github.com/vmware/terraform-provider-vsphere/issues/2508
### Release Note


### Additional Information

