### PR TITLE
refactor: enable more acceptance tests

### DIFF
--- a/vsphere/host_network_policy_structure.go
+++ b/vsphere/host_network_policy_structure.go
@@ -110,7 +110,9 @@ func schemaHostNetworkPolicy() map[string]*schema.Schema {
 // expandHostNicFailureCriteria reads certain ResourceData keys and returns a
 // HostNicFailureCriteria.
 func expandHostNicFailureCriteria(d *schema.ResourceData) *types.HostNicFailureCriteria {
-	obj := &types.HostNicFailureCriteria{}
+	obj := &types.HostNicFailureCriteria{
+		CheckBeacon: structure.BoolPtr(false),
+	}
 
 	if v, ok := d.GetOk("check_beacon"); ok {
 		obj.CheckBeacon = structure.BoolPtr(v.(bool))
@@ -166,7 +168,9 @@ func flattenHostNicOrderPolicy(d *schema.ResourceData, obj *types.HostNicOrderPo
 // HostNicTeamingPolicy.
 func expandHostNicTeamingPolicy(d *schema.ResourceData) *types.HostNicTeamingPolicy {
 	obj := &types.HostNicTeamingPolicy{
-		Policy: d.Get("teaming_policy").(string),
+		Policy:         d.Get("teaming_policy").(string),
+		RollingOrder:   structure.BoolPtr(false),
+		NotifySwitches: structure.BoolPtr(false),
 	}
 	if v, ok := d.GetOk("failback"); ok {
 		obj.RollingOrder = structure.BoolPtr(!v.(bool))
@@ -189,7 +193,7 @@ func expandHostNicTeamingPolicy(d *schema.ResourceData) *types.HostNicTeamingPol
 func flattenHostNicTeamingPolicy(d *schema.ResourceData, obj *types.HostNicTeamingPolicy) error {
 	if obj.RollingOrder != nil {
 		v := *obj.RollingOrder
-		_ = d.Set("failback", !v)
+		_ = d.Set("failback", v)
 	}
 	if obj.NotifySwitches != nil {
 		_ = d.Set("notify_switches", obj.NotifySwitches)
@@ -205,7 +209,11 @@ func flattenHostNicTeamingPolicy(d *schema.ResourceData, obj *types.HostNicTeami
 // expandHostNetworkSecurityPolicy reads certain ResourceData keys and returns
 // a HostNetworkSecurityPolicy.
 func expandHostNetworkSecurityPolicy(d *schema.ResourceData) *types.HostNetworkSecurityPolicy {
-	obj := &types.HostNetworkSecurityPolicy{}
+	obj := &types.HostNetworkSecurityPolicy{
+		AllowPromiscuous: structure.BoolPtr(false),
+		ForgedTransmits:  structure.BoolPtr(false),
+		MacChanges:       structure.BoolPtr(false),
+	}
 	if v, ok := d.GetOk("allow_promiscuous"); ok {
 		obj.AllowPromiscuous = structure.BoolPtr(v.(bool))
 	}
@@ -240,6 +248,7 @@ func expandHostNetworkTrafficShapingPolicy(d *schema.ResourceData) *types.HostNe
 		AverageBandwidth: int64(d.Get("shaping_average_bandwidth").(int)),
 		BurstSize:        int64(d.Get("shaping_burst_size").(int)),
 		PeakBandwidth:    int64(d.Get("shaping_peak_bandwidth").(int)),
+		Enabled:          structure.BoolPtr(false),
 	}
 	if v, ok := d.GetOk("shaping_enabled"); ok {
 		obj.Enabled = structure.BoolPtr(v.(bool))

--- a/vsphere/resource_vsphere_compute_cluster_host_group_test.go
+++ b/vsphere/resource_vsphere_compute_cluster_host_group_test.go
@@ -23,12 +23,10 @@ import (
 )
 
 func TestAccResourceVSphereComputeClusterHostGroup_basic(t *testing.T) {
-	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
 			testAccPreCheck(t)
-			testAccResourceVSphereComputeClusterHostGroupPreCheck(t)
 		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccResourceVSphereComputeClusterHostGroupExists(false),
@@ -80,12 +78,10 @@ func TestAccResourceVSphereComputeClusterHostGroup_basic(t *testing.T) {
 }
 
 func TestAccResourceVSphereComputeClusterHostGroup_update(t *testing.T) {
-	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
 			testAccPreCheck(t)
-			testAccResourceVSphereComputeClusterHostGroupPreCheck(t)
 		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccResourceVSphereComputeClusterHostGroupExists(false),
@@ -106,18 +102,6 @@ func TestAccResourceVSphereComputeClusterHostGroup_update(t *testing.T) {
 			},
 		},
 	})
-}
-
-func testAccResourceVSphereComputeClusterHostGroupPreCheck(t *testing.T) {
-	if os.Getenv("TF_VAR_VSPHERE_DATACENTER") == "" {
-		t.Skip("set TF_VAR_VSPHERE_DATACENTER to run vsphere_compute_cluster_host_group acceptance tests")
-	}
-	if os.Getenv("TF_VAR_VSPHERE_ESXI1") == "" {
-		t.Skip("set TF_VAR_VSPHERE_ESXI1 to run vsphere_compute_cluster_host_group acceptance tests")
-	}
-	if os.Getenv("TF_VAR_VSPHERE_ESXI2") == "" {
-		t.Skip("set TF_VAR_VSPHERE_ESXI2 to run vsphere_compute_cluster_host_group acceptance tests")
-	}
 }
 
 func testAccResourceVSphereComputeClusterHostGroupExists(expected bool) resource.TestCheckFunc {

--- a/vsphere/resource_vsphere_compute_cluster_vm_affinity_rule_test.go
+++ b/vsphere/resource_vsphere_compute_cluster_vm_affinity_rule_test.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"os"
 	"reflect"
 	"sort"
 	"testing"
@@ -24,12 +23,10 @@ import (
 )
 
 func TestAccResourceVSphereComputeClusterVMAffinityRule_basic(t *testing.T) {
-	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
 			testAccPreCheck(t)
-			testAccResourceVSphereComputeClusterVMAffinityRulePreCheck(t)
 		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccResourceVSphereComputeClusterVMAffinityRuleExists(false),
@@ -86,12 +83,10 @@ func TestAccResourceVSphereComputeClusterVMAffinityRule_basic(t *testing.T) {
 }
 
 func TestAccResourceVSphereComputeClusterVMAffinityRule_updateEnabled(t *testing.T) {
-	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
 			testAccPreCheck(t)
-			testAccResourceVSphereComputeClusterVMAffinityRulePreCheck(t)
 		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccResourceVSphereComputeClusterVMAffinityRuleExists(false),
@@ -125,12 +120,10 @@ func TestAccResourceVSphereComputeClusterVMAffinityRule_updateEnabled(t *testing
 }
 
 func TestAccResourceVSphereComputeClusterVMAffinityRule_updateCount(t *testing.T) {
-	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
 			testAccPreCheck(t)
-			testAccResourceVSphereComputeClusterVMAffinityRulePreCheck(t)
 		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccResourceVSphereComputeClusterVMAffinityRuleExists(false),
@@ -161,21 +154,6 @@ func TestAccResourceVSphereComputeClusterVMAffinityRule_updateCount(t *testing.T
 			},
 		},
 	})
-}
-
-func testAccResourceVSphereComputeClusterVMAffinityRulePreCheck(t *testing.T) {
-	if os.Getenv("TF_VAR_VSPHERE_DATACENTER") == "" {
-		t.Skip("set TF_VAR_VSPHERE_DATACENTER to run vsphere_compute_cluster_vm_affinity_rule acceptance tests")
-	}
-	if os.Getenv("TF_VAR_VSPHERE_NFS_DS_NAME") == "" {
-		t.Skip("set TF_VAR_VSPHERE_NFS_DS_NAME to run vsphere_compute_cluster_vm_affinity_rule acceptance tests")
-	}
-	if os.Getenv("TF_VAR_VSPHERE_CLUSTER") == "" {
-		t.Skip("set TF_VAR_VSPHERE_CLUSTER to run vsphere_compute_cluster_vm_affinity_rule acceptance tests")
-	}
-	if os.Getenv("TF_VAR_VSPHERE_PG_NAME") == "" {
-		t.Skip("set TF_VAR_VSPHERE_PG_NAME to run vsphere_compute_cluster_vm_affinity_rule acceptance tests")
-	}
 }
 
 func testAccResourceVSphereComputeClusterVMAffinityRuleExists(expected bool) resource.TestCheckFunc {
@@ -323,13 +301,13 @@ resource "vsphere_virtual_machine" "vm" {
   count            = var.vm_count
   name             = "terraform-test-${count.index}"
   resource_pool_id = data.vsphere_compute_cluster.rootcompute_cluster1.resource_pool_id
-  datastore_id     = vsphere_nas_datastore.ds1.id
+  datastore_id     = data.vsphere_datastore.rootds1.id
 
   num_cpus = 2
   memory   = 2048
   guest_id = "other3xLinuxGuest"
 
-  wait_for_guest_net_timeout = -1
+  wait_for_guest_net_timeout = 0
 
   network_interface {
     network_id = data.vsphere_network.network1.id
@@ -337,7 +315,8 @@ resource "vsphere_virtual_machine" "vm" {
 
   disk {
     label = "disk0"
-    size  = 20
+    size  = 1
+    io_reservation = 1
   }
 }
 
@@ -351,7 +330,7 @@ resource "vsphere_compute_cluster_vm_affinity_rule" "cluster_vm_affinity_rule" {
 		testhelper.ConfigDataRootDC1(),
 		testhelper.ConfigDataRootHost1(),
 		testhelper.ConfigDataRootHost2(),
-		testhelper.ConfigResDS1(),
+		testhelper.ConfigDataRootDS1(),
 		testhelper.ConfigDataRootComputeCluster1(),
 		testhelper.ConfigResResourcePool1(),
 		testhelper.ConfigDataRootPortGroup1()),

--- a/vsphere/resource_vsphere_compute_cluster_vm_anti_affinity_rule_test.go
+++ b/vsphere/resource_vsphere_compute_cluster_vm_anti_affinity_rule_test.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"os"
 	"reflect"
 	"sort"
 	"testing"
@@ -24,12 +23,10 @@ import (
 )
 
 func TestAccResourceVSphereComputeClusterVMAntiAffinityRule_basic(t *testing.T) {
-	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
 			testAccPreCheck(t)
-			testAccResourceVSphereComputeClusterVMAntiAffinityRulePreCheck(t)
 		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccResourceVSphereComputeClusterVMAntiAffinityRuleExists(false),
@@ -86,12 +83,10 @@ func TestAccResourceVSphereComputeClusterVMAntiAffinityRule_basic(t *testing.T) 
 }
 
 func TestAccResourceVSphereComputeClusterVMAntiAffinityRule_updateEnabled(t *testing.T) {
-	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
 			testAccPreCheck(t)
-			testAccResourceVSphereComputeClusterVMAntiAffinityRulePreCheck(t)
 		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccResourceVSphereComputeClusterVMAntiAffinityRuleExists(false),
@@ -125,12 +120,10 @@ func TestAccResourceVSphereComputeClusterVMAntiAffinityRule_updateEnabled(t *tes
 }
 
 func TestAccResourceVSphereComputeClusterVMAntiAffinityRule_updateCount(t *testing.T) {
-	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
 			testAccPreCheck(t)
-			testAccResourceVSphereComputeClusterVMAntiAffinityRulePreCheck(t)
 		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccResourceVSphereComputeClusterVMAntiAffinityRuleExists(false),
@@ -161,21 +154,6 @@ func TestAccResourceVSphereComputeClusterVMAntiAffinityRule_updateCount(t *testi
 			},
 		},
 	})
-}
-
-func testAccResourceVSphereComputeClusterVMAntiAffinityRulePreCheck(t *testing.T) {
-	if os.Getenv("TF_VAR_VSPHERE_DATACENTER") == "" {
-		t.Skip("set TF_VAR_VSPHERE_DATACENTER to run vsphere_compute_cluster_vm_anti_affinity_rule acceptance tests")
-	}
-	if os.Getenv("TF_VAR_VSPHERE_NFS_DS_NAME") == "" {
-		t.Skip("set TF_VAR_VSPHERE_NFS_DS_NAME to run vsphere_compute_cluster_vm_anti_affinity_rule acceptance tests")
-	}
-	if os.Getenv("TF_VAR_VSPHERE_CLUSTER") == "" {
-		t.Skip("set TF_VAR_VSPHERE_CLUSTER to run vsphere_compute_cluster_vm_anti_affinity_rule acceptance tests")
-	}
-	if os.Getenv("TF_VAR_VSPHERE_PG_NAME") == "" {
-		t.Skip("set TF_VAR_VSPHERE_PG_NAME to run vsphere_compute_cluster_vm_anti_affinity_rule acceptance tests")
-	}
 }
 
 func testAccResourceVSphereComputeClusterVMAntiAffinityRuleExists(expected bool) resource.TestCheckFunc {
@@ -323,13 +301,13 @@ resource "vsphere_virtual_machine" "vm" {
   count            = var.vm_count
   name             = "terraform-test-${count.index}"
   resource_pool_id = data.vsphere_compute_cluster.rootcompute_cluster1.resource_pool_id
-  datastore_id     = vsphere_nas_datastore.ds1.id
+  datastore_id     = data.vsphere_datastore.rootds1.id
 
   num_cpus = 2
   memory   = 2048
   guest_id = "other3xLinuxGuest"
 
-  wait_for_guest_net_timeout = -1
+  wait_for_guest_net_timeout = 0
 
   network_interface {
     network_id = data.vsphere_network.network1.id
@@ -337,7 +315,8 @@ resource "vsphere_virtual_machine" "vm" {
 
   disk {
     label = "disk0"
-    size  = 20
+    size  = 1
+    io_reservation = 1
   }
 }
 
@@ -351,7 +330,7 @@ resource "vsphere_compute_cluster_vm_anti_affinity_rule" "cluster_vm_anti_affini
 		testhelper.ConfigDataRootDC1(),
 		testhelper.ConfigDataRootHost1(),
 		testhelper.ConfigDataRootHost2(),
-		testhelper.ConfigResDS1(),
+		testhelper.ConfigDataRootDS1(),
 		testhelper.ConfigDataRootComputeCluster1(),
 		testhelper.ConfigResResourcePool1(),
 		testhelper.ConfigDataRootPortGroup1()),

--- a/vsphere/resource_vsphere_compute_cluster_vm_group_test.go
+++ b/vsphere/resource_vsphere_compute_cluster_vm_group_test.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"os"
 	"reflect"
 	"sort"
 	"testing"
@@ -24,12 +23,10 @@ import (
 )
 
 func TestAccResourceVSphereComputeClusterVMGroup_basic(t *testing.T) {
-	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
 			testAccPreCheck(t)
-			testAccResourceVSphereComputeClusterVMGroupPreCheck(t)
 		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccResourceVSphereComputeClusterVMGroupExists(false),
@@ -81,12 +78,10 @@ func TestAccResourceVSphereComputeClusterVMGroup_basic(t *testing.T) {
 }
 
 func TestAccResourceVSphereComputeClusterVMGroup_update(t *testing.T) {
-	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
 			testAccPreCheck(t)
-			testAccResourceVSphereComputeClusterVMGroupPreCheck(t)
 		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccResourceVSphereComputeClusterVMGroupExists(false),
@@ -107,21 +102,6 @@ func TestAccResourceVSphereComputeClusterVMGroup_update(t *testing.T) {
 			},
 		},
 	})
-}
-
-func testAccResourceVSphereComputeClusterVMGroupPreCheck(t *testing.T) {
-	if os.Getenv("TF_VAR_VSPHERE_DATACENTER") == "" {
-		t.Skip("set TF_VAR_VSPHERE_DATACENTER to run vsphere_compute_cluster_vm_group acceptance tests")
-	}
-	if os.Getenv("TF_VAR_VSPHERE_NFS_DS_NAME") == "" {
-		t.Skip("set TF_VAR_VSPHERE_NFS_DS_NAME to run vsphere_compute_cluster_vm_group acceptance tests")
-	}
-	if os.Getenv("TF_VAR_VSPHERE_CLUSTER") == "" {
-		t.Skip("set TF_VAR_VSPHERE_CLUSTER to run vsphere_compute_cluster_vm_group acceptance tests")
-	}
-	if os.Getenv("TF_VAR_VSPHERE_PG_NAME") == "" {
-		t.Skip("set TF_VAR_VSPHERE_PG_NAME to run vsphere_compute_cluster_vm_group acceptance tests")
-	}
 }
 
 func testAccResourceVSphereComputeClusterVMGroupExists(expected bool) resource.TestCheckFunc {
@@ -235,13 +215,13 @@ resource "vsphere_virtual_machine" "vm" {
   count            = var.vm_count
   name             = "terraform-test-${count.index}"
   resource_pool_id = data.vsphere_compute_cluster.rootcompute_cluster1.resource_pool_id
-  datastore_id     = vsphere_nas_datastore.ds1.id
+  datastore_id     = data.vsphere_datastore.rootds1.id
 
   num_cpus = 2
   memory   = 2048
   guest_id = "other3xLinuxGuest"
 
-  wait_for_guest_net_timeout = -1
+  wait_for_guest_net_timeout = 0
 
   network_interface {
     network_id = data.vsphere_network.network1.id
@@ -249,7 +229,8 @@ resource "vsphere_virtual_machine" "vm" {
 
   disk {
     label = "disk0"
-    size  = 20
+    size  = 1
+    io_reservation = 1 
   }
 }
 
@@ -262,7 +243,7 @@ resource "vsphere_compute_cluster_vm_group" "cluster_vm_group" {
 		testhelper.ConfigDataRootDC1(),
 		testhelper.ConfigDataRootHost1(),
 		testhelper.ConfigDataRootHost2(),
-		testhelper.ConfigResDS1(),
+		testhelper.ConfigDataRootDS1(),
 		testhelper.ConfigDataRootComputeCluster1(),
 		testhelper.ConfigResResourcePool1(),
 		testhelper.ConfigDataRootPortGroup1()),

--- a/vsphere/resource_vsphere_custom_attribute_test.go
+++ b/vsphere/resource_vsphere_custom_attribute_test.go
@@ -14,7 +14,6 @@ import (
 )
 
 func TestAccResourceVSphereCustomAttribute_basic(t *testing.T) {
-	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -54,7 +53,6 @@ func TestAccResourceVSphereCustomAttribute_basic(t *testing.T) {
 	})
 }
 func TestAccResourceVSphereCustomAttribute_withType(t *testing.T) {
-	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -75,7 +73,6 @@ func TestAccResourceVSphereCustomAttribute_withType(t *testing.T) {
 	})
 }
 func TestAccResourceVSphereCustomAttribute_rename(t *testing.T) {
-	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -102,7 +99,6 @@ func TestAccResourceVSphereCustomAttribute_rename(t *testing.T) {
 }
 
 func TestAccResourceVSphereCustomAttribute_changeType(t *testing.T) {
-	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()

--- a/vsphere/resource_vsphere_datacenter_test.go
+++ b/vsphere/resource_vsphere_datacenter_test.go
@@ -163,7 +163,6 @@ func TestAccResourceVSphereDatacenter_createOnSubfolder(t *testing.T) {
 	dcFolder := "dc-folder"
 	name := "testDC"
 
-	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -190,7 +189,6 @@ func TestAccResourceVSphereDatacenter_createOnSubfolder(t *testing.T) {
 }
 
 func TestAccResourceVSphereDatacenter_singleTag(t *testing.T) {
-	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -214,7 +212,6 @@ func TestAccResourceVSphereDatacenter_singleTag(t *testing.T) {
 }
 
 func TestAccResourceVSphereDatacenter_modifyTags(t *testing.T) {
-	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()

--- a/vsphere/resource_vsphere_datastore_cluster_test.go
+++ b/vsphere/resource_vsphere_datastore_cluster_test.go
@@ -27,12 +27,10 @@ const (
 )
 
 func TestAccResourceVSphereDatastoreCluster_basic(t *testing.T) {
-	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
 			testAccPreCheck(t)
-			testAccResourceVSphereDatastoreClusterPreCheck(t)
 		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccResourceVSphereDatastoreClusterCheckExists(false),
@@ -45,10 +43,17 @@ func TestAccResourceVSphereDatastoreCluster_basic(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:            "vsphere_datastore_cluster.datastore_cluster",
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"datacenter_id", "sdrs_free_space_threshold"},
+				ResourceName:      "vsphere_datastore_cluster.datastore_cluster",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"datacenter_id",
+					"sdrs_free_space_threshold",
+					"sdrs_io_latency_threshold",
+					"sdrs_io_load_imbalance_threshold",
+					"sdrs_io_reservable_percent_threshold",
+					"sdrs_io_reservable_threshold_mode",
+				},
 				ImportStateIdFunc: func(s *terraform.State) (string, error) {
 					pod, err := testGetDatastoreCluster(s, "datastore_cluster")
 					if err != nil {
@@ -89,12 +94,10 @@ func TestAccResourceVSphereDatastoreCluster_sdrsEnabled(t *testing.T) {
 }
 
 func TestAccResourceVSphereDatastoreCluster_rename(t *testing.T) {
-	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
 			testAccPreCheck(t)
-			testAccResourceVSphereDatastoreClusterPreCheck(t)
 		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccResourceVSphereDatastoreClusterCheckExists(false),
@@ -118,12 +121,10 @@ func TestAccResourceVSphereDatastoreCluster_rename(t *testing.T) {
 }
 
 func TestAccResourceVSphereDatastoreCluster_inFolder(t *testing.T) {
-	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
 			testAccPreCheck(t)
-			testAccResourceVSphereDatastoreClusterPreCheck(t)
 		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccResourceVSphereDatastoreClusterCheckExists(false),
@@ -140,12 +141,10 @@ func TestAccResourceVSphereDatastoreCluster_inFolder(t *testing.T) {
 }
 
 func TestAccResourceVSphereDatastoreCluster_moveToFolder(t *testing.T) {
-	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
 			testAccPreCheck(t)
-			testAccResourceVSphereDatastoreClusterPreCheck(t)
 		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccResourceVSphereDatastoreClusterCheckExists(false),
@@ -712,6 +711,7 @@ func testAccResourceVSphereDatastoreClusterConfigBasic() string {
 resource "vsphere_datastore_cluster" "datastore_cluster" {
   name          = "testacc-datastore-cluster"
   datacenter_id = data.vsphere_datacenter.rootdc1.id
+  sdrs_io_load_balance_enabled = false
 }
 `,
 		testhelper.CombineConfigs(testhelper.ConfigDataRootDC1(), testhelper.ConfigDataRootPortGroup1()),
@@ -739,6 +739,7 @@ func testAccResourceVSphereDatastoreClusterConfigWithName(name string) string {
 resource "vsphere_datastore_cluster" "datastore_cluster" {
   name          = "%s"
   datacenter_id = data.vsphere_datacenter.rootdc1.id
+  sdrs_io_load_balance_enabled = false
 }
 `,
 		testhelper.CombineConfigs(testhelper.ConfigDataRootDC1(), testhelper.ConfigDataRootPortGroup1()),
@@ -764,6 +765,7 @@ resource "vsphere_datastore_cluster" "datastore_cluster" {
   name          = "testacc-datastore-cluster"
   datacenter_id = data.vsphere_datacenter.rootdc1.id
   folder        = vsphere_folder.datastore_cluster_folder.path
+  sdrs_io_load_balance_enabled = false
 }
 `,
 		testhelper.CombineConfigs(testhelper.ConfigDataRootDC1(), testhelper.ConfigDataRootPortGroup1()),

--- a/vsphere/resource_vsphere_distributed_port_group_test.go
+++ b/vsphere/resource_vsphere_distributed_port_group_test.go
@@ -94,12 +94,10 @@ func TestAccResourceVSphereDistributedPortGroup_inheritPolicyDiffCheckVlanRangeT
 }
 
 func TestAccResourceVSphereDistributedPortGroup_overrideVlan(t *testing.T) {
-	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
 			testAccPreCheck(t)
-			testAccResourceVSphereDistributedPortGroupPreCheck()
 		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccResourceVSphereDistributedPortGroupExists(false),

--- a/vsphere/resource_vsphere_distributed_virtual_switch_pvlan_mapping_test.go
+++ b/vsphere/resource_vsphere_distributed_virtual_switch_pvlan_mapping_test.go
@@ -17,12 +17,10 @@ import (
 )
 
 func TestAccResourceVSphereDistributedVirtualSwitchPvlanMapping_basic(t *testing.T) {
-	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
 			testAccPreCheck(t)
-			testAccResourceVSphereDistributedVirtualSwitchPreCheck(t)
 		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccResourceVSphereDistributedVirtualSwitchPvlanMappingExists(false),
@@ -60,7 +58,7 @@ resource "vsphere_distributed_virtual_switch" "dvs" {
   }
 }
 `, testhelper.CombineConfigs(testhelper.ConfigDataRootDC1(), testhelper.ConfigDataRootHost2()),
-		testhelper.HostNic0,
+		testhelper.HostNic1,
 	)
 }
 
@@ -81,19 +79,19 @@ func testAccResourceVSphereDistributedVirtualSwitchPvlanMappingExists(expected b
 			return fmt.Errorf("could not find pvlan mapping resource: %s", err)
 		}
 
-		primaryVlanIDInt64, err := strconv.ParseInt(mappingToSearchFor.resourceAttributes["primaryVlanID"], 10, 32)
+		primaryVlanIDInt64, err := strconv.ParseInt(mappingToSearchFor.resourceAttributes["primary_vlan_id"], 10, 32)
 		if err != nil {
 			return err
 		}
 		primaryVlanID := int32(primaryVlanIDInt64)
 
-		secondaryVlanIDInt64, err := strconv.ParseInt(mappingToSearchFor.resourceAttributes["secondaryVlanID"], 10, 32)
+		secondaryVlanIDInt64, err := strconv.ParseInt(mappingToSearchFor.resourceAttributes["secondary_vlan_id"], 10, 32)
 		if err != nil {
 			return err
 		}
 		secondaryVlanID := int32(secondaryVlanIDInt64)
 
-		pvlanType := mappingToSearchFor.resourceAttributes["pvlanType"]
+		pvlanType := mappingToSearchFor.resourceAttributes["pvlan_type"]
 
 		for _, mapping := range props.Config.(*types.VMwareDVSConfigInfo).PvlanConfig {
 			if mapping.PrimaryVlanId == primaryVlanID && mapping.SecondaryVlanId == secondaryVlanID && mapping.PvlanType == pvlanType {

--- a/vsphere/resource_vsphere_distributed_virtual_switch_test.go
+++ b/vsphere/resource_vsphere_distributed_virtual_switch_test.go
@@ -21,8 +21,8 @@ import (
 )
 
 const (
-	testAccResourceVSphereDistributedVirtualSwitchUpperVersion = "7.0.0"
-	testAccResourceVSphereDistributedVirtualSwitchLowerVersion = "6.6.0"
+	testAccResourceVSphereDistributedVirtualSwitchUpperVersion = "8.0.0"
+	testAccResourceVSphereDistributedVirtualSwitchLowerVersion = "7.0.0"
 )
 
 func TestAccResourceVSphereDistributedVirtualSwitch_basic(t *testing.T) {
@@ -62,12 +62,10 @@ func TestAccResourceVSphereDistributedVirtualSwitch_basic(t *testing.T) {
 }
 
 func TestAccResourceVSphereDistributedVirtualSwitch_noHosts(t *testing.T) {
-	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
 			testAccPreCheck(t)
-			testAccResourceVSphereDistributedVirtualSwitchPreCheck(t)
 		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccResourceVSphereDistributedVirtualSwitchExists(false),
@@ -83,12 +81,10 @@ func TestAccResourceVSphereDistributedVirtualSwitch_noHosts(t *testing.T) {
 }
 
 func TestAccResourceVSphereDistributedVirtualSwitch_removeNIC(t *testing.T) {
-	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
 			testAccPreCheck(t)
-			testAccResourceVSphereDistributedVirtualSwitchPreCheck(t)
 		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccResourceVSphereDistributedVirtualSwitchExists(false),
@@ -164,12 +160,10 @@ func TestAccResourceVSphereDistributedVirtualSwitch_basicToStandbyWithFailover(t
 }
 
 func TestAccResourceVSphereDistributedVirtualSwitch_upgradeVersion(t *testing.T) {
-	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
 			testAccPreCheck(t)
-			testAccResourceVSphereDistributedVirtualSwitchPreCheck(t)
 		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccResourceVSphereDistributedVirtualSwitchExists(false),
@@ -193,12 +187,10 @@ func TestAccResourceVSphereDistributedVirtualSwitch_upgradeVersion(t *testing.T)
 }
 
 func TestAccResourceVSphereDistributedVirtualSwitch_networkResourceControl(t *testing.T) {
-	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
 			testAccPreCheck(t)
-			testAccResourceVSphereDistributedVirtualSwitchPreCheck(t)
 		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccResourceVSphereDistributedVirtualSwitchExists(false),
@@ -704,7 +696,7 @@ resource "vsphere_distributed_virtual_switch" "dvs" {
 			testhelper.ConfigDataRootDC1(),
 			testhelper.ConfigDataRootPortGroup1(),
 			testhelper.ConfigDataRootHost1()),
-		testhelper.HostNic0,
+		testhelper.HostNic1,
 		version,
 	)
 }
@@ -740,7 +732,7 @@ resource "vsphere_distributed_virtual_switch" "dvs" {
 			testhelper.ConfigDataRootHost1(),
 			testhelper.ConfigDataRootHost2(),
 		),
-		testhelper.HostNic0,
+		testhelper.HostNic1,
 	)
 }
 
@@ -778,7 +770,7 @@ resource "vsphere_distributed_virtual_switch" "dvs" {
 			testhelper.ConfigDataRootPortGroup1(),
 			testhelper.ConfigDataRootHost1(),
 			testhelper.ConfigDataRootHost2()),
-		testhelper.HostNic0,
+		testhelper.HostNic1,
 	)
 }
 

--- a/vsphere/resource_vsphere_dpm_host_override_test.go
+++ b/vsphere/resource_vsphere_dpm_host_override_test.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"os"
 	"reflect"
 	"testing"
 
@@ -22,12 +21,10 @@ import (
 )
 
 func TestAccResourceVSphereDPMHostOverride_basic(t *testing.T) {
-	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
 			testAccPreCheck(t)
-			testAccResourceVSphereDPMHostOverridePreCheck(t)
 		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccResourceVSphereDPMHostOverrideExists(false),
@@ -74,12 +71,10 @@ func TestAccResourceVSphereDPMHostOverride_basic(t *testing.T) {
 }
 
 func TestAccResourceVSphereDPMHostOverride_overrides(t *testing.T) {
-	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
 			testAccPreCheck(t)
-			testAccResourceVSphereDPMHostOverridePreCheck(t)
 		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccResourceVSphereDPMHostOverrideExists(false),
@@ -96,12 +91,10 @@ func TestAccResourceVSphereDPMHostOverride_overrides(t *testing.T) {
 }
 
 func TestAccResourceVSphereDPMHostOverride_update(t *testing.T) {
-	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
 			testAccPreCheck(t)
-			testAccResourceVSphereDPMHostOverridePreCheck(t)
 		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccResourceVSphereDPMHostOverrideExists(false),
@@ -122,18 +115,6 @@ func TestAccResourceVSphereDPMHostOverride_update(t *testing.T) {
 			},
 		},
 	})
-}
-
-func testAccResourceVSphereDPMHostOverridePreCheck(t *testing.T) {
-	if os.Getenv("TF_VAR_VSPHERE_DATACENTER") == "" {
-		t.Skip("set TF_VAR_VSPHERE_DATACENTER to run vsphere_compute_cluster acceptance tests")
-	}
-	if os.Getenv("TF_VAR_VSPHERE_ESXI1") == "" {
-		t.Skip("set TF_VAR_VSPHERE_ESXI1 to run vsphere_compute_cluster acceptance tests")
-	}
-	if os.Getenv("TF_VAR_VSPHERE_ESXI2") == "" {
-		t.Skip("set TF_VAR_VSPHERE_ESXI2 to run vsphere_compute_cluster acceptance tests")
-	}
 }
 
 func testAccResourceVSphereDPMHostOverrideExists(expected bool) resource.TestCheckFunc {

--- a/vsphere/resource_vsphere_drs_vm_override_test.go
+++ b/vsphere/resource_vsphere_drs_vm_override_test.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"os"
 	"reflect"
 	"testing"
 
@@ -23,12 +22,10 @@ import (
 )
 
 func TestAccResourceVSphereDRSVMOverride_drs(t *testing.T) {
-	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
 			testAccPreCheck(t)
-			testAccResourceVSphereDRSVMOverridePreCheck(t)
 		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccResourceVSphereDRSVMOverrideExists(false),
@@ -75,12 +72,10 @@ func TestAccResourceVSphereDRSVMOverride_drs(t *testing.T) {
 }
 
 func TestAccResourceVSphereDRSVMOverride_automationLevel(t *testing.T) {
-	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
 			testAccPreCheck(t)
-			testAccResourceVSphereDRSVMOverridePreCheck(t)
 		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccResourceVSphereDRSVMOverrideExists(false),
@@ -97,12 +92,10 @@ func TestAccResourceVSphereDRSVMOverride_automationLevel(t *testing.T) {
 }
 
 func TestAccResourceVSphereDRSVMOverride_update(t *testing.T) {
-	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
 			testAccPreCheck(t)
-			testAccResourceVSphereDRSVMOverridePreCheck(t)
 		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccResourceVSphereDRSVMOverrideExists(false),
@@ -123,21 +116,6 @@ func TestAccResourceVSphereDRSVMOverride_update(t *testing.T) {
 			},
 		},
 	})
-}
-
-func testAccResourceVSphereDRSVMOverridePreCheck(t *testing.T) {
-	if os.Getenv("TF_VAR_VSPHERE_DATACENTER") == "" {
-		t.Skip("set TF_VAR_VSPHERE_DATACENTER to run vsphere_drs_vm_override acceptance tests")
-	}
-	if os.Getenv("TF_VAR_VSPHERE_NFS_DS_NAME") == "" {
-		t.Skip("set TF_VAR_VSPHERE_NFS_DS_NAME to run vsphere_drs_vm_override acceptance tests")
-	}
-	if os.Getenv("TF_VAR_VSPHERE_CLUSTER") == "" {
-		t.Skip("set TF_VAR_VSPHERE_CLUSTER to run vsphere_drs_vm_override acceptance tests")
-	}
-	if os.Getenv("TF_VAR_VSPHERE_PG_NAME") == "" {
-		t.Skip("set TF_VAR_VSPHERE_PG_NAME to run vsphere_drs_vm_override acceptance tests")
-	}
 }
 
 func testAccResourceVSphereDRSVMOverrideExists(expected bool) resource.TestCheckFunc {
@@ -206,13 +184,13 @@ func testAccResourceVSphereDRSVMOverrideConfigOverrideDRSEnabled() string {
 resource "vsphere_virtual_machine" "vm" {
   name             = "testacc-test"
   resource_pool_id = data.vsphere_compute_cluster.rootcompute_cluster1.resource_pool_id
-  datastore_id     = vsphere_nas_datastore.ds1.id
+  datastore_id     = data.vsphere_datastore.rootds1.id
 
   num_cpus = 2
   memory   = 2048
   guest_id = "other3xLinuxGuest"
 
-  wait_for_guest_net_timeout = -1
+  wait_for_guest_net_timeout = 0
 
   network_interface {
     network_id = data.vsphere_network.network1.id
@@ -220,7 +198,8 @@ resource "vsphere_virtual_machine" "vm" {
 
   disk {
     label = "disk0"
-    size  = 20
+    size  = 1
+    io_reservation = 1
   }
 }
 
@@ -232,7 +211,7 @@ resource "vsphere_drs_vm_override" "drs_vm_override" {
 `, testhelper.CombineConfigs(testhelper.ConfigDataRootDC1(),
 		testhelper.ConfigDataRootHost1(),
 		testhelper.ConfigDataRootHost2(),
-		testhelper.ConfigResDS1(),
+		testhelper.ConfigDataRootDS1(),
 		testhelper.ConfigDataRootComputeCluster1(),
 		testhelper.ConfigResResourcePool1(),
 		testhelper.ConfigDataRootPortGroup1()),
@@ -246,13 +225,13 @@ func testAccResourceVSphereDRSVMOverrideConfigOverrideAutomationLevel() string {
 resource "vsphere_virtual_machine" "vm" {
   name             = "testacc-test"
   resource_pool_id = data.vsphere_compute_cluster.rootcompute_cluster1.resource_pool_id
-  datastore_id     = vsphere_nas_datastore.ds1.id
+  datastore_id     = data.vsphere_datastore.rootds1.id
 
   num_cpus = 2
   memory   = 2048
   guest_id = "other3xLinuxGuest"
 
-  wait_for_guest_net_timeout = -1
+  wait_for_guest_net_timeout = 0
 
   network_interface {
     network_id = data.vsphere_network.network1.id
@@ -260,7 +239,8 @@ resource "vsphere_virtual_machine" "vm" {
 
   disk {
     label = "disk0"
-    size  = 20
+    size  = 2
+    io_reservation = 1
   }
 }
 
@@ -270,6 +250,6 @@ resource "vsphere_drs_vm_override" "drs_vm_override" {
   drs_enabled          = true
   drs_automation_level = "fullyAutomated"
 }
-`, testhelper.CombineConfigs(testhelper.ConfigDataRootDC1(), testhelper.ConfigDataRootHost1(), testhelper.ConfigDataRootHost2(), testhelper.ConfigResDS1(), testhelper.ConfigDataRootComputeCluster1(), testhelper.ConfigResResourcePool1(), testhelper.ConfigDataRootPortGroup1()),
+`, testhelper.CombineConfigs(testhelper.ConfigDataRootDC1(), testhelper.ConfigDataRootHost1(), testhelper.ConfigDataRootHost2(), testhelper.ConfigDataRootDS1(), testhelper.ConfigDataRootComputeCluster1(), testhelper.ConfigResResourcePool1(), testhelper.ConfigDataRootPortGroup1()),
 	)
 }

--- a/vsphere/resource_vsphere_entity_permissions_test.go
+++ b/vsphere/resource_vsphere_entity_permissions_test.go
@@ -7,7 +7,6 @@ package vsphere
 import (
 	"errors"
 	"fmt"
-	"os"
 	"strings"
 	"testing"
 
@@ -19,7 +18,6 @@ import (
 const EntityPermissionResource = "entity_permission1"
 
 func TestAccResourcevsphereEntityPermissions_basic(t *testing.T) {
-	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
@@ -61,18 +59,13 @@ func testAccResourceVsphereEntityPermissionsConfigBasic() string {
 	return fmt.Sprintf(`
 %s
 
-data "vsphere_virtual_machine" "vm" {
-  datacenter_id = data.vsphere_datacenter.rootdc1.id
-  name          = "%s"
-}
-
 data "vsphere_role" "role1" {
   label = "Administrator"
 }
 
 resource vsphere_entity_permissions "%s" {
-  entity_id   = data.vsphere_virtual_machine.vm.id
-  entity_type = "VirtualMachine"
+  entity_id   = data.vsphere_datacenter.rootdc1.id
+  entity_type = "Datacenter"
   permissions {
     user_or_group = "%s"
     propagate     = true
@@ -81,7 +74,6 @@ resource vsphere_entity_permissions "%s" {
   }
 }
 `, testhelper.ConfigDataRootDC1(),
-		os.Getenv("TF_VAR_VSPHERE_VM_V1_PATH"),
 		EntityPermissionResource,
 		"root",
 	)

--- a/vsphere/resource_vsphere_file_test.go
+++ b/vsphere/resource_vsphere_file_test.go
@@ -18,7 +18,6 @@ import (
 
 // TestAccResourceVSphereFile_basic verifies the basic functionality of the resource.
 func TestAccResourceVSphereFile_basic(t *testing.T) {
-	testAccSkipUnstable(t)
 	testFileData := []byte("test file data")
 	testFile := "/tmp/tf_test.txt"
 	err := os.WriteFile(testFile, testFileData, 0600)
@@ -38,7 +37,6 @@ func TestAccResourceVSphereFile_basic(t *testing.T) {
 		PreCheck: func() {
 			RunSweepers()
 			testAccPreCheck(t)
-			testAccCheckEnvVariables(t, []string{"TF_VAR_VSPHERE_DATACENTER", "TF_VAR_VSPHERE_NFS_DS_NAME"})
 		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckVSphereFileDestroy,
@@ -65,7 +63,6 @@ func TestAccResourceVSphereFile_basic(t *testing.T) {
 // TestAccResourceVSphereFile_uploadWithCreateDirectories verifies uploading files with nested directories.
 // creation.
 func TestAccResourceVSphereFile_uploadWithCreateDirectories(t *testing.T) {
-	testAccSkipUnstable(t)
 	testFileData := []byte("test file data")
 	testFile := "/tmp/tf_test.txt"
 	err := os.WriteFile(testFile, testFileData, 0600)
@@ -88,7 +85,6 @@ func TestAccResourceVSphereFile_uploadWithCreateDirectories(t *testing.T) {
 		PreCheck: func() {
 			RunSweepers()
 			testAccPreCheck(t)
-			testAccCheckEnvVariables(t, []string{"TF_VAR_VSPHERE_DATACENTER", "TF_VAR_VSPHERE_NFS_DS_NAME"})
 		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckVSphereFileDestroy,

--- a/vsphere/resource_vsphere_folder_test.go
+++ b/vsphere/resource_vsphere_folder_test.go
@@ -24,7 +24,6 @@ const testAccResourceVSphereFolderConfigExpectedParentName = "terraform-test-par
 const testAccResourceVSphereFolderConfigOOBName = "terraform-test-oob"
 
 func TestAccResourceVSphereFolder_vmFolder(t *testing.T) {
-	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -70,7 +69,6 @@ func TestAccResourceVSphereFolder_vmFolder(t *testing.T) {
 }
 
 func TestAccResourceVSphereFolder_datastoreFolder(t *testing.T) {
-	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -95,7 +93,6 @@ func TestAccResourceVSphereFolder_datastoreFolder(t *testing.T) {
 }
 
 func TestAccResourceVSphereFolder_networkFolder(t *testing.T) {
-	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -120,7 +117,6 @@ func TestAccResourceVSphereFolder_networkFolder(t *testing.T) {
 }
 
 func TestAccResourceVSphereFolder_hostFolder(t *testing.T) {
-	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -205,7 +201,6 @@ func TestAccResourceVSphereFolder_rename(t *testing.T) {
 }
 
 func TestAccResourceVSphereFolder_subfolder(t *testing.T) {
-	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -231,7 +226,6 @@ func TestAccResourceVSphereFolder_subfolder(t *testing.T) {
 }
 
 func TestAccResourceVSphereFolder_moveToSubfolder(t *testing.T) {
-	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -715,7 +709,7 @@ resource "vsphere_folder" "parent" {
 }
 
 resource "vsphere_folder" "folder" {
-  path          = vsphere_folder.parent.path + "/" + var.folder_name
+  path          = "${vsphere_folder.parent.path}/${var.folder_name}"
   type          = var.folder_type
   datacenter_id = data.vsphere_datacenter.rootdc1.id
 }

--- a/vsphere/resource_vsphere_guest_os_customization_test.go
+++ b/vsphere/resource_vsphere_guest_os_customization_test.go
@@ -17,7 +17,6 @@ import (
 func TestAccResourceVSpherGOSC_windows_basic(t *testing.T) {
 	goscName := acctest.RandomWithPrefix("win")
 	goscResourceName := acctest.RandomWithPrefix("gosc")
-	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -57,7 +56,6 @@ func TestAccResourceVSpherGOSC_windows_workGroup(t *testing.T) {
 func TestAccResourceVSpherGOSC_linux(t *testing.T) {
 	goscName := acctest.RandomWithPrefix("lin")
 	goscResourceName := acctest.RandomWithPrefix("gosc")
-	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -77,7 +75,6 @@ func TestAccResourceVSpherGOSC_linux(t *testing.T) {
 func TestAccResourceVSpherGOSC_sysprep(t *testing.T) {
 	goscName := acctest.RandomWithPrefix("lin")
 	goscResourceName := acctest.RandomWithPrefix("gosc")
-	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()

--- a/vsphere/resource_vsphere_ha_vm_override_test.go
+++ b/vsphere/resource_vsphere_ha_vm_override_test.go
@@ -23,12 +23,10 @@ import (
 )
 
 func TestAccResourceVSphereHAVMOverride_basic(t *testing.T) {
-	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
 			testAccPreCheck(t)
-			testAccResourceVSphereHAVMOverridePreCheck(t)
 		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccResourceVSphereHAVMOverrideExists(false),
@@ -398,13 +396,13 @@ func testAccResourceVSphereHAVMOverrideConfigOverrideDefaults() string {
 resource "vsphere_virtual_machine" "vm" {
   name             = "testacc-test"
   resource_pool_id = data.vsphere_compute_cluster.rootcompute_cluster1.resource_pool_id
-  datastore_id     = vsphere_nas_datastore.ds1.id
+  datastore_id     = data.vsphere_datastore.rootds1.id
 
   num_cpus = 2
   memory   = 2048
   guest_id = "other3xLinuxGuest"
 
-  wait_for_guest_net_timeout = -1
+  wait_for_guest_net_timeout = 0
 
   network_interface {
     network_id = data.vsphere_network.network1.id
@@ -412,7 +410,8 @@ resource "vsphere_virtual_machine" "vm" {
 
   disk {
     label = "disk0"
-    size  = 20
+    size  = 2
+    io_reservation = 1
   }
 }
 
@@ -424,7 +423,7 @@ resource "vsphere_ha_vm_override" "ha_vm_override" {
 		testhelper.ConfigDataRootDC1(),
 		testhelper.ConfigDataRootHost1(),
 		testhelper.ConfigDataRootHost2(),
-		testhelper.ConfigResDS1(),
+		testhelper.ConfigDataRootDS1(),
 		testhelper.ConfigDataRootComputeCluster1(),
 		testhelper.ConfigResResourcePool1(),
 		testhelper.ConfigDataRootPortGroup1()),

--- a/vsphere/resource_vsphere_host_port_group_test.go
+++ b/vsphere/resource_vsphere_host_port_group_test.go
@@ -35,12 +35,10 @@ func TestAccResourceVSphereHostPortGroup_basic(t *testing.T) {
 }
 
 func TestAccResourceVSphereHostPortGroup_complexWithOverrides(t *testing.T) {
-	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
 			testAccPreCheck(t)
-			testAccResourceVSphereHostPortGroupPreCheck(t)
 		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccResourceVSphereHostPortGroupExists(false),
@@ -50,8 +48,8 @@ func TestAccResourceVSphereHostPortGroup_complexWithOverrides(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccResourceVSphereHostPortGroupExists(true),
 					testAccResourceVSphereHostPortGroupCheckVlan(1000),
-					testAccResourceVSphereHostPortGroupCheckEffectiveActive([]string{testhelper.HostNic0}),
-					testAccResourceVSphereHostPortGroupCheckEffectiveStandby([]string{testhelper.HostNic1}),
+					testAccResourceVSphereHostPortGroupCheckEffectiveActive([]string{testhelper.HostNic1}),
+					testAccResourceVSphereHostPortGroupCheckEffectiveStandby([]string{testhelper.HostNic2}),
 					testAccResourceVSphereHostPortGroupCheckEffectivePromisc(true),
 				),
 			},
@@ -60,12 +58,10 @@ func TestAccResourceVSphereHostPortGroup_complexWithOverrides(t *testing.T) {
 }
 
 func TestAccResourceVSphereHostPortGroup_basicToComplex(t *testing.T) {
-	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
 			testAccPreCheck(t)
-			testAccResourceVSphereHostPortGroupPreCheck(t)
 		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccResourceVSphereHostPortGroupExists(false),
@@ -81,19 +77,13 @@ func TestAccResourceVSphereHostPortGroup_basicToComplex(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccResourceVSphereHostPortGroupExists(true),
 					testAccResourceVSphereHostPortGroupCheckVlan(1000),
-					testAccResourceVSphereHostPortGroupCheckEffectiveActive([]string{testhelper.HostNic0}),
-					testAccResourceVSphereHostPortGroupCheckEffectiveStandby([]string{testhelper.HostNic1}),
+					testAccResourceVSphereHostPortGroupCheckEffectiveActive([]string{testhelper.HostNic1}),
+					testAccResourceVSphereHostPortGroupCheckEffectiveStandby([]string{testhelper.HostNic2}),
 					testAccResourceVSphereHostPortGroupCheckEffectivePromisc(true),
 				),
 			},
 		},
 	})
-}
-
-func testAccResourceVSphereHostPortGroupPreCheck(t *testing.T) {
-	if os.Getenv("TF_VAR_VSPHERE_NFS_DS_NAME") == "" {
-		t.Skip("set TF_VAR_VSPHERE_ESXI_HOST to run vsphere_host_port_group acceptance tests")
-	}
 }
 
 func testAccResourceVSphereHostPortGroupExists(expected bool) resource.TestCheckFunc {
@@ -209,11 +199,11 @@ resource "vsphere_host_port_group" "pg" {
 
 func testAccResourceVSphereHostPortGroupConfigWithOverrides() string {
 	return fmt.Sprintf(`
-variable "host_nic0" {
+variable "host_nic1" {
   default = "%s"
 }
 
-variable "host_nic1" {
+variable "host_nic2" {
   default = "%s"
 }
 
@@ -228,9 +218,9 @@ resource "vsphere_host_virtual_switch" "switch" {
   name           = "vSwitchTerraformTest2"
   host_system_id = data.vsphere_host.esxi_host.id
 
-  network_adapters  = [var.host_nic0, var.host_nic1]
-  active_nics       = [var.host_nic0]
-  standby_nics      = [var.host_nic1]
+  network_adapters  = [var.host_nic1, var.host_nic2]
+  active_nics       = [var.host_nic1]
+  standby_nics      = [var.host_nic2]
   allow_promiscuous = false
 }
 
@@ -240,12 +230,12 @@ resource "vsphere_host_port_group" "pg" {
   virtual_switch_name = vsphere_host_virtual_switch.switch.name
 
   vlan_id           = 1000
-  active_nics       = [var.host_nic0]
-  standby_nics      = [var.host_nic1]
+  active_nics       = [var.host_nic1]
+  standby_nics      = [var.host_nic2]
   allow_promiscuous = true
 }
-`, testhelper.HostNic0,
-		testhelper.HostNic1,
+`, testhelper.HostNic1,
+		testhelper.HostNic2,
 		testhelper.CombineConfigs(testhelper.ConfigDataRootDC1(), testhelper.ConfigDataRootPortGroup1()),
-		os.Getenv("TF_VAR_VSPHERE_ESXI1"))
+		os.Getenv("TF_VAR_VSPHERE_ESXI3"))
 }

--- a/vsphere/resource_vsphere_host_test.go
+++ b/vsphere/resource_vsphere_host_test.go
@@ -61,6 +61,7 @@ func TestAccResourceVSphereHost_basic(t *testing.T) {
 }
 
 func TestAccResourceVSphereHost_rootFolder(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()

--- a/vsphere/resource_vsphere_host_virtual_switch.go
+++ b/vsphere/resource_vsphere_host_virtual_switch.go
@@ -37,7 +37,6 @@ func resourceVSphereHostVirtualSwitch() *schema.Resource {
 	s["teaming_policy"].Default = hostNetworkPolicyNicTeamingPolicyModeLoadbalanceSrcID
 	s["check_beacon"].Default = false
 	s["notify_switches"].Default = true
-	s["failback"].Default = true
 
 	s["allow_promiscuous"].Default = false
 	s["allow_forged_transmits"].Default = true

--- a/vsphere/resource_vsphere_resource_pool_test.go
+++ b/vsphere/resource_vsphere_resource_pool_test.go
@@ -211,12 +211,10 @@ func TestAccResourceVSphereResourcePool_esxiHost(t *testing.T) {
 }
 
 func TestAccResourceVSphereResourcePool_updateParent(t *testing.T) {
-	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
 			testAccPreCheck(t)
-			testAccResourceVSphereResourcePoolPreCheck(t)
 		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccResourceVSphereResourcePoolCheckExists(false),

--- a/vsphere/resource_vsphere_role_test.go
+++ b/vsphere/resource_vsphere_role_test.go
@@ -51,7 +51,6 @@ func TestAccResourceVsphereRole_createRole(t *testing.T) {
 
 func TestAccResourceVsphereRole_addPrivileges(t *testing.T) {
 	roleName := "terraform_role" + acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
-	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
@@ -85,7 +84,6 @@ func TestAccResourceVsphereRole_addPrivileges(t *testing.T) {
 
 func TestAccResourceVsphereRole_removePrivileges(t *testing.T) {
 	roleName := "terraform_role" + acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
-	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)

--- a/vsphere/resource_vsphere_tag_category_test.go
+++ b/vsphere/resource_vsphere_tag_category_test.go
@@ -18,7 +18,6 @@ import (
 )
 
 func TestAccResourceVSphereTagCategory_basic(t *testing.T) {
-	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
@@ -59,7 +58,6 @@ func TestAccResourceVSphereTagCategory_basic(t *testing.T) {
 }
 
 func TestAccResourceVSphereTagCategory_addType(t *testing.T) {
-	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()

--- a/vsphere/resource_vsphere_vapp_container_test.go
+++ b/vsphere/resource_vsphere_vapp_container_test.go
@@ -23,12 +23,10 @@ const (
 )
 
 func TestAccResourceVSphereVAppContainer_basic(t *testing.T) {
-	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
 			testAccPreCheck(t)
-			testAccResourceVSphereVAppContainerPreCheck(t)
 		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccResourceVSphereVAppContainerCheckExists(false),
@@ -40,12 +38,12 @@ func TestAccResourceVSphereVAppContainer_basic(t *testing.T) {
 					testAccResourceVSphereVAppContainerCheckFolder("parent_folder"),
 					testAccResourceVSphereVAppContainerCheckExists(true),
 					testAccResourceVSphereVAppContainerCheckCPUReservation(10),
-					testAccResourceVSphereVAppContainerCheckCPUExpandable(false),
+					testAccResourceVSphereVAppContainerCheckCPUExpandable(true),
 					testAccResourceVSphereVAppContainerCheckCPULimit(20),
 					testAccResourceVSphereVAppContainerCheckCPUShareLevel("custom"),
 					testAccResourceVSphereVAppContainerCheckCPUShares(10),
 					testAccResourceVSphereVAppContainerCheckCPUReservation(10),
-					testAccResourceVSphereVAppContainerCheckCPUExpandable(false),
+					testAccResourceVSphereVAppContainerCheckCPUExpandable(true),
 					testAccResourceVSphereVAppContainerCheckCPULimit(20),
 					testAccResourceVSphereVAppContainerCheckMemoryShareLevel("custom"),
 					testAccResourceVSphereVAppContainerCheckMemoryShares(10),
@@ -451,16 +449,16 @@ resource "vsphere_vapp_container" "vapp_container" {
   cpu_share_level         = "custom"
   cpu_shares              = 10
   cpu_reservation         = 10
-  cpu_expandable          = false
+  cpu_expandable          = true
   cpu_limit               = 20
   memory_share_level      = "custom"
   memory_shares           = 10
   memory_reservation      = 10
-  memory_expandable       = false
+  memory_expandable       = true
   memory_limit            = 20
 }
 `,
-		testhelper.CombineConfigs(testhelper.ConfigDataRootDC1(), testhelper.ConfigDataRootHost1(), testhelper.ConfigDataRootHost2(), testhelper.ConfigResDS1(), testhelper.ConfigDataRootComputeCluster1(), testhelper.ConfigResResourcePool1(), testhelper.ConfigDataRootPortGroup1()),
+		testhelper.CombineConfigs(testhelper.ConfigDataRootDC1(), testhelper.ConfigDataRootHost1(), testhelper.ConfigDataRootHost2(), testhelper.ConfigDataRootDS1(), testhelper.ConfigDataRootComputeCluster1(), testhelper.ConfigResResourcePool1(), testhelper.ConfigDataRootPortGroup1()),
 	)
 }
 

--- a/vsphere/resource_vsphere_vapp_entity_test.go
+++ b/vsphere/resource_vsphere_vapp_entity_test.go
@@ -17,12 +17,10 @@ import (
 )
 
 func TestAccResourceVSphereVAppEntity_basic(t *testing.T) {
-	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
 			testAccPreCheck(t)
-			testAccResourceVSphereVAppEntityPreCheck(t)
 		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccResourceVSphereVAppEntityCheckExists("vapp_entity", false),
@@ -348,17 +346,18 @@ resource "vsphere_vapp_entity" "vapp_entity" {
 resource "vsphere_virtual_machine" "vm" {
   name             = "terraform-virtual-machine-test"
   resource_pool_id = vsphere_vapp_container.vapp_container.id
-  datastore_id     = vsphere_nas_datastore.ds1.id
+  datastore_id     = data.vsphere_datastore.rootds1.id
 
   num_cpus                   = 2
   memory                     = 2048
   guest_id                   = "other3xLinuxGuest"
-  wait_for_guest_net_timeout = -1
+  wait_for_guest_net_timeout = 0
 
 
   disk {
     label = "disk0"
-    size  = "1"
+    size  = 1
+    io_reservation = 1
   }
 
   network_interface {
@@ -369,7 +368,7 @@ resource "vsphere_virtual_machine" "vm" {
 		testhelper.ConfigDataRootDC1(),
 		testhelper.ConfigDataRootHost1(),
 		testhelper.ConfigDataRootHost2(),
-		testhelper.ConfigResDS1(),
+		testhelper.ConfigDataRootDS1(),
 		testhelper.ConfigDataRootComputeCluster1(),
 		testhelper.ConfigResResourcePool1(),
 		testhelper.ConfigDataRootPortGroup1()),

--- a/vsphere/resource_vsphere_virtual_disk_test.go
+++ b/vsphere/resource_vsphere_virtual_disk_test.go
@@ -7,7 +7,6 @@ package vsphere
 import (
 	"context"
 	"fmt"
-	"os"
 	"strings"
 	"testing"
 
@@ -47,7 +46,6 @@ func TestAccResourceVSphereVirtualDisk_extend(t *testing.T) {
 		PreCheck: func() {
 			RunSweepers()
 			testAccPreCheck(t)
-			testAccResourceVSphereVirtualDiskPreCheck(t)
 		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccVSphereVirtualDiskExists("vsphere_virtual_disk.foo", false),
@@ -78,7 +76,6 @@ func TestAccResourceVSphereVirtualDisk_multi(t *testing.T) {
 		PreCheck: func() {
 			RunSweepers()
 			testAccPreCheck(t)
-			testAccResourceVSphereVirtualDiskPreCheck(t)
 		},
 		Providers: testAccProviders,
 		CheckDestroy: resource.ComposeTestCheckFunc(
@@ -107,7 +104,6 @@ func TestAccResourceVSphereVirtualDisk_multiWithParent(t *testing.T) {
 		PreCheck: func() {
 			RunSweepers()
 			testAccPreCheck(t)
-			testAccResourceVSphereVirtualDiskPreCheck(t)
 		},
 		Providers: testAccProviders,
 		CheckDestroy: resource.ComposeTestCheckFunc(
@@ -136,7 +132,6 @@ func TestAccResourceVSphereVirtualDisk_withParent(t *testing.T) {
 		PreCheck: func() {
 			RunSweepers()
 			testAccPreCheck(t)
-			testAccResourceVSphereVirtualDiskPreCheck(t)
 		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccVSphereVirtualDiskExists("vsphere_virtual_disk.foo", false),
@@ -149,15 +144,6 @@ func TestAccResourceVSphereVirtualDisk_withParent(t *testing.T) {
 			},
 		},
 	})
-}
-
-func testAccResourceVSphereVirtualDiskPreCheck(t *testing.T) {
-	if os.Getenv("TF_VAR_VSPHERE_DATACENTER") == "" {
-		t.Skip("set TF_VAR_VSPHERE_DATACENTER to run vsphere_virtual_disk acceptance tests")
-	}
-	if os.Getenv("TF_VAR_VSPHERE_NFS_DS_NAME") == "" {
-		t.Skip("set TF_VAR_VSPHERE_NFS_DS_NAME to run vsphere_virtual_disk acceptance tests")
-	}
 }
 
 func testAccVSphereVirtualDiskExists(name string, expected bool) resource.TestCheckFunc {

--- a/vsphere/resource_vsphere_virtual_machine_test.go
+++ b/vsphere/resource_vsphere_virtual_machine_test.go
@@ -81,21 +81,19 @@ func TestAccResourceVSphereVirtualMachine_basic(t *testing.T) {
 }
 
 func TestAccResourceVSphereVirtualMachine_hardwareVersionBare(t *testing.T) {
-	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
 			testAccPreCheck(t)
-			testAccResourceVSphereVirtualMachinePreCheck(t)
 		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccResourceVSphereVirtualMachineCheckExists(false),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccResourceVSphereVirtualMachineConfigBareHardwareVersion(15),
+				Config: testAccResourceVSphereVirtualMachineConfigBareHardwareVersion(20),
 				Check: resource.ComposeTestCheckFunc(
 					testAccResourceVSphereVirtualMachineCheckExists(true),
-					resource.TestMatchResourceAttr("vsphere_virtual_machine.vm", "hardware_version", regexp.MustCompile("^15$")),
+					resource.TestMatchResourceAttr("vsphere_virtual_machine.vm", "hardware_version", regexp.MustCompile("^20$")),
 				),
 			},
 		},
@@ -103,28 +101,26 @@ func TestAccResourceVSphereVirtualMachine_hardwareVersionBare(t *testing.T) {
 }
 
 func TestAccResourceVSphereVirtualMachine_hardwareVersionUpgrade(t *testing.T) {
-	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
 			testAccPreCheck(t)
-			testAccResourceVSphereVirtualMachinePreCheck(t)
 		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccResourceVSphereVirtualMachineCheckExists(false),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccResourceVSphereVirtualMachineConfigBareHardwareVersion(14),
+				Config: testAccResourceVSphereVirtualMachineConfigBareHardwareVersion(20),
 				Check: resource.ComposeTestCheckFunc(
 					testAccResourceVSphereVirtualMachineCheckExists(true),
-					resource.TestMatchResourceAttr("vsphere_virtual_machine.vm", "hardware_version", regexp.MustCompile("^14$")),
+					resource.TestMatchResourceAttr("vsphere_virtual_machine.vm", "hardware_version", regexp.MustCompile("^20$")),
 				),
 			},
 			{
-				Config: testAccResourceVSphereVirtualMachineConfigBareHardwareVersion(15),
+				Config: testAccResourceVSphereVirtualMachineConfigBareHardwareVersion(21),
 				Check: resource.ComposeTestCheckFunc(
 					testAccResourceVSphereVirtualMachineCheckExists(true),
-					resource.TestMatchResourceAttr("vsphere_virtual_machine.vm", "hardware_version", regexp.MustCompile("^15$")),
+					resource.TestMatchResourceAttr("vsphere_virtual_machine.vm", "hardware_version", regexp.MustCompile("^21$")),
 				),
 			},
 		},
@@ -181,21 +177,19 @@ func TestAccResourceVSphereVirtualMachine_hardwareVersionDowngrade(t *testing.T)
 }
 
 func TestAccResourceVSphereVirtualMachine_hardwareVersionClone(t *testing.T) {
-	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
 			testAccPreCheck(t)
-			testAccResourceVSphereVirtualMachinePreCheck(t)
 		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccResourceVSphereVirtualMachineCheckExists(false),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccResourceVSphereVirtualMachineConfigHardwareVersionClone(15),
+				Config: testAccResourceVSphereVirtualMachineConfigHardwareVersionClone(20),
 				Check: resource.ComposeTestCheckFunc(
 					testAccResourceVSphereVirtualMachineCheckExists(true),
-					resource.TestMatchResourceAttr("vsphere_virtual_machine.vm", "hardware_version", regexp.MustCompile("^15$")),
+					resource.TestMatchResourceAttr("vsphere_virtual_machine.vm", "hardware_version", regexp.MustCompile("^20$")),
 				),
 			},
 		},
@@ -225,12 +219,10 @@ func TestAccResourceVSphereVirtualMachineContentLibrary_basic(t *testing.T) {
 }
 
 func TestAccResourceVSphereVirtualMachine_ignoreValidationOnComputedValue(t *testing.T) {
-	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
 			testAccPreCheck(t)
-			testAccResourceVSphereVirtualMachinePreCheck(t)
 		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccResourceVSphereVirtualMachineCheckExists(false),
@@ -250,7 +242,6 @@ func TestAccResourceVSphereVirtualMachine_highLatencySensitivity(t *testing.T) {
 		PreCheck: func() {
 			RunSweepers()
 			testAccPreCheck(t)
-			testAccResourceVSphereVirtualMachinePreCheck(t)
 		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccResourceVSphereVirtualMachineCheckExists(false),
@@ -291,12 +282,10 @@ func TestAccResourceVSphereVirtualMachine_ESXiOnly(t *testing.T) {
 func TestAccResourceVSphereVirtualMachine_shutdownOK(t *testing.T) {
 	var state *terraform.State
 
-	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
 			testAccPreCheck(t)
-			testAccResourceVSphereVirtualMachinePreCheck(t)
 		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccResourceVSphereVirtualMachineCheckExists(false),
@@ -324,12 +313,10 @@ func TestAccResourceVSphereVirtualMachine_shutdownOK(t *testing.T) {
 func TestAccResourceVSphereVirtualMachine_reCreateOnDeletion(t *testing.T) {
 	var state *terraform.State
 
-	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
 			testAccPreCheck(t)
-			testAccResourceVSphereVirtualMachinePreCheck(t)
 		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccResourceVSphereVirtualMachineCheckExists(false),
@@ -361,12 +348,10 @@ func TestAccResourceVSphereVirtualMachine_reCreateOnDeletion(t *testing.T) {
 }
 
 func TestAccResourceVSphereVirtualMachine_multiDevice(t *testing.T) {
-	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
 			testAccPreCheck(t)
-			testAccResourceVSphereVirtualMachinePreCheck(t)
 		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccResourceVSphereVirtualMachineCheckExists(false),
@@ -375,7 +360,7 @@ func TestAccResourceVSphereVirtualMachine_multiDevice(t *testing.T) {
 				Config: testAccResourceVSphereVirtualMachineConfigMultiDevice(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccResourceVSphereVirtualMachineCheckExists(true),
-					testAccResourceVSphereVirtualMachineCheckMultiDevice([]bool{true, true, true}, []bool{true, true, true}),
+					testAccResourceVSphereVirtualMachineCheckMultiDevice([]bool{true, true, true}),
 				),
 			},
 		},
@@ -383,12 +368,10 @@ func TestAccResourceVSphereVirtualMachine_multiDevice(t *testing.T) {
 }
 
 func TestAccResourceVSphereVirtualMachine_addDevices(t *testing.T) {
-	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
 			testAccPreCheck(t)
-			testAccResourceVSphereVirtualMachinePreCheck(t)
 		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccResourceVSphereVirtualMachineCheckExists(false),
@@ -403,7 +386,7 @@ func TestAccResourceVSphereVirtualMachine_addDevices(t *testing.T) {
 				Config: testAccResourceVSphereVirtualMachineConfigMultiDevice(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccResourceVSphereVirtualMachineCheckExists(true),
-					testAccResourceVSphereVirtualMachineCheckMultiDevice([]bool{true, true, true}, []bool{true, true, true}),
+					testAccResourceVSphereVirtualMachineCheckMultiDevice([]bool{true, true, true}),
 				),
 			},
 		},
@@ -412,12 +395,10 @@ func TestAccResourceVSphereVirtualMachine_addDevices(t *testing.T) {
 
 func TestAccResourceVSphereVirtualMachine_removeMiddleDevices(t *testing.T) {
 	var state *terraform.State
-	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
 			testAccPreCheck(t)
-			testAccResourceVSphereVirtualMachinePreCheck(t)
 		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccResourceVSphereVirtualMachineCheckExists(false),
@@ -427,7 +408,7 @@ func TestAccResourceVSphereVirtualMachine_removeMiddleDevices(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					copyStatePtr(&state),
 					testAccResourceVSphereVirtualMachineCheckExists(true),
-					testAccResourceVSphereVirtualMachineCheckMultiDevice([]bool{true, true, true}, []bool{true, true, true}),
+					testAccResourceVSphereVirtualMachineCheckMultiDevice([]bool{true, true, true}),
 				),
 			},
 			{
@@ -444,7 +425,7 @@ func TestAccResourceVSphereVirtualMachine_removeMiddleDevices(t *testing.T) {
 				Config: testAccResourceVSphereVirtualMachineConfigRemoveMiddle(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccResourceVSphereVirtualMachineCheckExists(true),
-					testAccResourceVSphereVirtualMachineCheckMultiDevice([]bool{true, false, true}, []bool{true, false, true}),
+					testAccResourceVSphereVirtualMachineCheckMultiDevice([]bool{true, false, true}),
 				),
 			},
 		},
@@ -452,12 +433,10 @@ func TestAccResourceVSphereVirtualMachine_removeMiddleDevices(t *testing.T) {
 }
 
 func TestAccResourceVSphereVirtualMachine_removeMiddleDevicesChangeDiskUnit(t *testing.T) {
-	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
 			testAccPreCheck(t)
-			testAccResourceVSphereVirtualMachinePreCheck(t)
 		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccResourceVSphereVirtualMachineCheckExists(false),
@@ -466,14 +445,14 @@ func TestAccResourceVSphereVirtualMachine_removeMiddleDevicesChangeDiskUnit(t *t
 				Config: testAccResourceVSphereVirtualMachineConfigMultiDevice(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccResourceVSphereVirtualMachineCheckExists(true),
-					testAccResourceVSphereVirtualMachineCheckMultiDevice([]bool{true, true, true}, []bool{true, true, true}),
+					testAccResourceVSphereVirtualMachineCheckMultiDevice([]bool{true, true, true}),
 				),
 			},
 			{
 				Config: testAccResourceVSphereVirtualMachineConfigRemoveMiddleChangeUnit(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccResourceVSphereVirtualMachineCheckExists(true),
-					testAccResourceVSphereVirtualMachineCheckMultiDevice([]bool{true, false, true}, []bool{true, false, true}),
+					testAccResourceVSphereVirtualMachineCheckMultiDevice([]bool{true, false, true}),
 				),
 			},
 		},
@@ -481,12 +460,10 @@ func TestAccResourceVSphereVirtualMachine_removeMiddleDevicesChangeDiskUnit(t *t
 }
 
 func TestAccResourceVSphereVirtualMachine_highDiskUnitNumbers(t *testing.T) {
-	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
 			testAccPreCheck(t)
-			testAccResourceVSphereVirtualMachinePreCheck(t)
 		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccResourceVSphereVirtualMachineCheckExists(false),
@@ -527,12 +504,10 @@ func TestAccResourceVSphereVirtualMachine_highDiskUnitInsufficientBus(t *testing
 }
 
 func TestAccResourceVSphereVirtualMachine_highDiskUnitsToRegularSingleController(t *testing.T) {
-	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
 			testAccPreCheck(t)
-			testAccResourceVSphereVirtualMachinePreCheck(t)
 		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccResourceVSphereVirtualMachineCheckExists(false),
@@ -560,12 +535,10 @@ func TestAccResourceVSphereVirtualMachine_highDiskUnitsToRegularSingleController
 }
 
 func TestAccResourceVSphereVirtualMachine_scsiBusSharing(t *testing.T) {
-	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
 			testAccPreCheck(t)
-			testAccResourceVSphereVirtualMachinePreCheck(t)
 		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccResourceVSphereVirtualMachineCheckExists(false),
@@ -582,12 +555,10 @@ func TestAccResourceVSphereVirtualMachine_scsiBusSharing(t *testing.T) {
 }
 
 func TestAccResourceVSphereVirtualMachine_scsiBusSharingUpdate(t *testing.T) {
-	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
 			testAccPreCheck(t)
-			testAccResourceVSphereVirtualMachinePreCheck(t)
 		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccResourceVSphereVirtualMachineCheckExists(false),
@@ -901,12 +872,10 @@ func TestAccResourceVSphereVirtualMachine_cdromConflictingParameters(t *testing.
 }
 
 func TestAccResourceVSphereVirtualMachine_maximumNumberOfNICs(t *testing.T) {
-	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
 			testAccPreCheck(t)
-			testAccResourceVSphereVirtualMachinePreCheck(t)
 		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccResourceVSphereVirtualMachineCheckExists(false),
@@ -1260,12 +1229,10 @@ func TestAccResourceVSphereVirtualMachine_inFolder(t *testing.T) {
 }
 
 func TestAccResourceVSphereVirtualMachine_moveToFolder(t *testing.T) {
-	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()
 			testAccPreCheck(t)
-			testAccResourceVSphereVirtualMachinePreCheck(t)
 		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccResourceVSphereVirtualMachineCheckExists(false),
@@ -2245,7 +2212,7 @@ func TestAccResourceVSphereVirtualMachine_storageVMotionPinDatastore(t *testing.
 				Config: testAccResourceVSphereVirtualMachineConfigBase(),
 			},
 			{
-				Config: testAccResourceVSphereVirtualMachineConfigStorageVMotionPinDatastore("vsphere_nas_datastore.ds1.id"),
+				Config: testAccResourceVSphereVirtualMachineConfigStorageVMotionPinDatastore("data.vsphere_datastore.rootds1.id"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccResourceVSphereVirtualMachineCheckExists(true),
 					testAccResourceVSphereVirtualMachineCheckVmxDatastore(testhelper.NfsDsName2),
@@ -2333,7 +2300,7 @@ func TestAccResourceVSphereVirtualMachine_storageVMotionLinkedClones(t *testing.
 				),
 			},
 			{
-				Config: testAccResourceVSphereVirtualMachineConfigStorageVMotionLinkedClone("vsphere_nas_datastore.ds1.id"),
+				Config: testAccResourceVSphereVirtualMachineConfigStorageVMotionLinkedClone("data.vsphere_datastore.rootds1.id"),
 				Check: resource.ComposeTestCheckFunc(
 					copyStatePtr(&state),
 					testAccResourceVSphereVirtualMachineCheckExists(true),
@@ -3185,10 +3152,10 @@ func testAccResourceVSphereVirtualMachineCheckTags(tagResName string) resource.T
 
 // testAccResourceVSphereVirtualMachineCheckMultiDevice is a check for proper
 // parameters on the vsphere_virtual_machine multi-device test. This is a very
-// specific check that checks for the specific disk and network devices. The
+// specific check that checks for the specific disk devices. The
 // configuration that this test asserts should be in the
 // testAccResourceVSphereVirtualMachineConfigMultiDevice resource.
-func testAccResourceVSphereVirtualMachineCheckMultiDevice(expectedD, expectedN []bool) resource.TestCheckFunc {
+func testAccResourceVSphereVirtualMachineCheckMultiDevice(expectedD []bool) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		props, err := testGetVirtualMachineProperties(s, "vm")
 		if err != nil {
@@ -3196,13 +3163,9 @@ func testAccResourceVSphereVirtualMachineCheckMultiDevice(expectedD, expectedN [
 		}
 
 		actualD := make([]bool, 3)
-		actualN := make([]bool, 3)
-		expectedDisk0Size := structure.GiBToByte(20)
-		expectedDisk1Size := structure.GiBToByte(10)
-		expectedDisk2Size := structure.GiBToByte(5)
-		expectedNet0Level := types.SharesLevelNormal
-		expectedNet1Level := types.SharesLevelHigh
-		expectedNet2Level := types.SharesLevelLow
+		expectedDisk0Size := structure.GiBToByte(1)
+		expectedDisk1Size := structure.GiBToByte(2)
+		expectedDisk2Size := structure.GiBToByte(3)
 
 		for _, dev := range props.Config.Hardware.Device {
 			if disk, ok := dev.(*types.VirtualDisk); ok {
@@ -3215,27 +3178,11 @@ func testAccResourceVSphereVirtualMachineCheckMultiDevice(expectedD, expectedN [
 					actualD[2] = true
 				}
 			}
-			if bvec, ok := dev.(types.BaseVirtualEthernetCard); ok {
-				card := bvec.GetVirtualEthernetCard()
-				switch card.ResourceAllocation.Share.Level {
-				case expectedNet0Level:
-					actualN[0] = true
-				case expectedNet1Level:
-					actualN[1] = true
-				case expectedNet2Level:
-					actualN[2] = true
-				}
-			}
 		}
 
 		for n, actual := range actualD {
 			if actual != expectedD[n] {
 				return fmt.Errorf("expected disk at index %d to be %t, got %t", n, expectedD[n], actual)
-			}
-		}
-		for n, actual := range actualN {
-			if actual != expectedN[n] {
-				return fmt.Errorf("expected network interface at index %d to be %t, got %t", n, expectedN[n], actual)
 			}
 		}
 
@@ -3742,7 +3689,7 @@ func testAccResourceVSphereVirtualMachineConfigComputedValue() string {
 resource "vsphere_virtual_machine" "vm" {
   name             = "testacc-test"
   resource_pool_id = vsphere_resource_pool.pool1.id
-  datastore_id     = vsphere_nas_datastore.ds1.id
+  datastore_id     = data.vsphere_datastore.rootds1.id
 
   num_cpus = 2
   memory   = 2048
@@ -3754,7 +3701,8 @@ resource "vsphere_virtual_machine" "vm" {
 
   disk {
     label = "disk0"
-    size  = 20
+    size  = 1
+    io_reservation = 1
   }
 }
 `,
@@ -3766,56 +3714,69 @@ resource "vsphere_virtual_machine" "vm" {
 func testAccResourceVSphereVirtualMachineConfigHardwareVersionClone(hw int) string {
 	return fmt.Sprintf(`
 
-
 %s  // Mix and match config
-
-data "vsphere_virtual_machine" "template" {
-  name          = "%s"
-  datacenter_id = data.vsphere_datacenter.rootdc1.id
-}
 
 variable "linked_clone" {
   default = "%s"
 }
 
-resource "vsphere_virtual_machine" "vm" {
-  name             = "testacc-test"
+resource "vsphere_virtual_machine" "template" {
+  name             = "testacc-test-template"
   resource_pool_id = vsphere_resource_pool.pool1.id
-  datastore_id     = vsphere_nas_datastore.ds1.id
+  datastore_id     = data.vsphere_datastore.rootds1.id
 
   num_cpus         = 2
   memory           = 2048
-  guest_id         = data.vsphere_virtual_machine.template.guest_id
+  guest_id         = "other3xLinuxGuest"
   hardware_version = %d
 
-  wait_for_guest_net_timeout = -1
+  wait_for_guest_net_timeout = 0
 
   network_interface {
     network_id = data.vsphere_network.network1.id
-    adapter_type = data.vsphere_virtual_machine.template.network_interface_types[0]
   }
 
   disk {
     label            = "disk0"
-    size             = data.vsphere_virtual_machine.template.disks.0.size
-    eagerly_scrub    = data.vsphere_virtual_machine.template.disks.0.eagerly_scrub
-    thin_provisioned = data.vsphere_virtual_machine.template.disks.0.thin_provisioned
+    size             = 1
+    io_reservation   = 1
+  }
+}
+
+resource "vsphere_virtual_machine" "vm" {
+  name             = "testacc-test"
+  resource_pool_id = vsphere_resource_pool.pool1.id
+  datastore_id     = data.vsphere_datastore.rootds1.id
+
+  num_cpus         = 2
+  memory           = 2048
+  guest_id         = vsphere_virtual_machine.template.guest_id
+  hardware_version = %d
+
+  wait_for_guest_net_timeout = 0
+
+  network_interface {
+    network_id = data.vsphere_network.network1.id
+  }
+
+  disk {
+    label            = "disk0"
+    size             = vsphere_virtual_machine.template.disk.0.size
+    io_reservation   = 1
+    eagerly_scrub    = vsphere_virtual_machine.template.disk.0.eagerly_scrub
+    thin_provisioned = vsphere_virtual_machine.template.disk.0.thin_provisioned
   }
 
   clone {
-    template_uuid = data.vsphere_virtual_machine.template.id
+    template_uuid = vsphere_virtual_machine.template.id
     linked_clone  = var.linked_clone != "" ? "true" : "false"
-  }
-
-  cdrom {
-    client_device = true
   }
 }
 `,
 
 		testAccResourceVSphereVirtualMachineConfigBase(),
-		os.Getenv("TF_VAR_VSPHERE_TEMPLATE"),
 		os.Getenv("TF_VAR_VSPHERE_USE_LINKED_CLONE"),
+		hw,
 		hw,
 	)
 }
@@ -3829,14 +3790,14 @@ func testAccResourceVSphereVirtualMachineConfigBareHardwareVersion(hw int) strin
 resource "vsphere_virtual_machine" "vm" {
   name             = "testacc-test"
   resource_pool_id = vsphere_resource_pool.pool1.id
-  datastore_id     = vsphere_nas_datastore.ds1.id
+  datastore_id     = data.vsphere_datastore.rootds1.id
 
   num_cpus         = 2
   memory           = 2048
   guest_id         = "other3xLinuxGuest"
   hardware_version = %d
 
-  wait_for_guest_net_timeout = -1
+  wait_for_guest_net_timeout = 0
 
   network_interface {
     network_id = data.vsphere_network.network1.id
@@ -3844,7 +3805,8 @@ resource "vsphere_virtual_machine" "vm" {
 
   disk {
     label = "disk0"
-    size  = 20
+    size  = 1
+    io_reservation = 1
   }
 }
 `,
@@ -3912,7 +3874,7 @@ resource "vsphere_virtual_machine" "vm" {
 
   disk {
     label = "disk0"
-    size  = 20
+    size  = 1
     io_reservation = 1
   }
 }
@@ -3931,12 +3893,12 @@ func testAccResourceVSphereVirtualMachineConfigSharedSCSIBus() string {
 resource "vsphere_virtual_machine" "vm" {
   name             = "testacc-test"
   resource_pool_id = vsphere_resource_pool.pool1.id
-  datastore_id     = vsphere_nas_datastore.ds1.id
+  datastore_id     = data.vsphere_datastore.rootds1.id
 
   num_cpus                   = 2
   memory                     = 2048
   guest_id                   = "other3xLinuxGuest"
-  wait_for_guest_net_timeout = -1
+  wait_for_guest_net_timeout = 0
 
   scsi_bus_sharing = "physicalSharing"
 
@@ -3946,7 +3908,8 @@ resource "vsphere_virtual_machine" "vm" {
 
   disk {
     label = "disk0"
-    size  = 20
+    size  = 1
+    io_reservation = 1
   }
 }
 `,
@@ -3973,7 +3936,7 @@ variable "linked_clone" {
 resource "vsphere_virtual_machine" "vm" {
   name             = "testacc-test"
   resource_pool_id = vsphere_resource_pool.pool1.id
-  datastore_id     = vsphere_nas_datastore.ds1.id
+  datastore_id     = data.vsphere_datastore.rootds1.id
 
   num_cpus = 2
   memory   = 2048
@@ -4039,7 +4002,7 @@ data "vsphere_resource_pool" "pool" {}
 resource "vsphere_virtual_machine" "vm" {
   name             = "testacc-test"
   resource_pool_id = vsphere_resource_pool.pool1.id
-  datastore_id     = vsphere_nas_datastore.ds1.id
+  datastore_id     = data.vsphere_datastore.rootds1.id
 
   num_cpus = 2
   memory   = 2048
@@ -4051,7 +4014,7 @@ resource "vsphere_virtual_machine" "vm" {
 
   disk {
     label = "disk0"
-    size  = 20
+    size  = 1
   }
 }
 `,
@@ -4069,7 +4032,7 @@ func testAccResourceVSphereVirtualMachineConfigMultiDevice() string {
 resource "vsphere_virtual_machine" "vm" {
   name             = "testacc-test"
   resource_pool_id = vsphere_resource_pool.pool1.id
-  datastore_id     = vsphere_nas_datastore.ds1.id
+  datastore_id     = data.vsphere_datastore.rootds1.id
 
   num_cpus = 2
   memory   = 2048
@@ -4079,34 +4042,26 @@ resource "vsphere_virtual_machine" "vm" {
 
   network_interface {
     network_id            = data.vsphere_network.network1.id
-    bandwidth_share_level = "normal"
-  }
-
-  network_interface {
-    network_id            = data.vsphere_network.network1.id
-    bandwidth_share_level = "high"
-  }
-
-  network_interface {
-    network_id            = data.vsphere_network.network1.id
-    bandwidth_share_level = "low"
   }
 
   disk {
     label = "disk0"
-    size  = 20
+    size  = 1
+    io_reservation = 1
   }
 
   disk {
     label       = "disk1"
     unit_number = 1
-    size        = 10
+    size        = 2
+    io_reservation = 1
   }
 
   disk {
     label       = "disk2"
     unit_number = 2
-    size        = 5
+    size        = 3
+    io_reservation = 1
   }
 }
 `,
@@ -4124,7 +4079,7 @@ func testAccResourceVSphereVirtualMachineConfigMultiHighBusInsufficientBus() str
 resource "vsphere_virtual_machine" "vm" {
   name             = "testacc-test"
   resource_pool_id = vsphere_resource_pool.pool1.id
-  datastore_id     = vsphere_nas_datastore.ds1.id
+  datastore_id     = data.vsphere_datastore.rootds1.id
 
   scsi_controller_count = 1
 
@@ -4149,7 +4104,7 @@ resource "vsphere_virtual_machine" "vm" {
 
   disk {
     label = "disk0"
-    size  = 20
+    size  = 1
   }
 
   disk {
@@ -4179,7 +4134,7 @@ func testAccResourceVSphereVirtualMachineConfigMultiHighBus() string {
 resource "vsphere_virtual_machine" "vm" {
   name             = "testacc-test"
   resource_pool_id = vsphere_resource_pool.pool1.id
-  datastore_id     = vsphere_nas_datastore.ds1.id
+  datastore_id     = data.vsphere_datastore.rootds1.id
 
   scsi_controller_count = 3
 
@@ -4191,52 +4146,47 @@ resource "vsphere_virtual_machine" "vm" {
 
   network_interface {
     network_id            = data.vsphere_network.network1.id
-    bandwidth_share_level = "normal"
-  }
-
-  network_interface {
-    network_id            = data.vsphere_network.network1.id
-    bandwidth_share_level = "high"
-  }
-
-  network_interface {
-    network_id            = data.vsphere_network.network1.id
-    bandwidth_share_level = "low"
   }
 
   disk {
     label = "disk0"
-    size  = 20
+    size  = 1
+    io_reservation = 1
   }
 
   disk {
     label       = "disk1"
     unit_number = 1
-    size        = 10
+    size        = 2
+    io_reservation = 1
   }
 
   disk {
     label       = "disk2"
     unit_number = 15
-    size        = 5
+    size        = 3
+    io_reservation = 1
   }
 
   disk {
     label       = "disk3"
     unit_number = 16
     size        = 5
+    io_reservation = 1
   }
 
   disk {
     label       = "disk4"
     unit_number = 30
     size        = 5
+    io_reservation = 1
   }
 
   disk {
     label       = "disk5"
     unit_number = 31
     size        = 5
+    io_reservation = 1
   }
 }
 `,
@@ -4254,7 +4204,7 @@ func testAccResourceVSphereVirtualMachineConfigRemoveMiddle() string {
 resource "vsphere_virtual_machine" "vm" {
   name             = "testacc-test"
   resource_pool_id = vsphere_resource_pool.pool1.id
-  datastore_id     = vsphere_nas_datastore.ds1.id
+  datastore_id     = data.vsphere_datastore.rootds1.id
 
   num_cpus = 2
   memory   = 2048
@@ -4264,23 +4214,19 @@ resource "vsphere_virtual_machine" "vm" {
 
   network_interface {
     network_id            = data.vsphere_network.network1.id
-    bandwidth_share_level = "normal"
-  }
-
-  network_interface {
-    network_id            = data.vsphere_network.network1.id
-    bandwidth_share_level = "low"
   }
 
   disk {
     label = "disk0"
-    size  = 20
+    size  = 1
+    io_reservation = 1
   }
 
   disk {
     label       = "disk2"
     unit_number = 2
-    size        = 5
+    size        = 3
+    io_reservation = 1
   }
 }
 `,
@@ -4298,7 +4244,7 @@ func testAccResourceVSphereVirtualMachineConfigRemoveMiddleChangeUnit() string {
 resource "vsphere_virtual_machine" "vm" {
   name             = "testacc-test"
   resource_pool_id = vsphere_resource_pool.pool1.id
-  datastore_id     = vsphere_nas_datastore.ds1.id
+  datastore_id     = data.vsphere_datastore.rootds1.id
 
   num_cpus = 2
   memory   = 2048
@@ -4308,23 +4254,18 @@ resource "vsphere_virtual_machine" "vm" {
 
   network_interface {
     network_id            = data.vsphere_network.network1.id
-    bandwidth_share_level = "normal"
   }
-
-  network_interface {
-    network_id            = data.vsphere_network.network1.id
-    bandwidth_share_level = "low"
-  }
-
   disk {
     label = "disk0"
-    size  = 20
+    size  = 1
+    io_reservation = 1
   }
 
   disk {
     label       = "disk2"
     unit_number = 1
-    size        = 5
+    size        = 3
+    io_reservation = 1
   }
 }
 `,
@@ -4351,7 +4292,7 @@ variable "linked_clone" {
 resource "vsphere_virtual_machine" "vm" {
   name             = "testacc-test"
   resource_pool_id = vsphere_resource_pool.pool1.id
-  datastore_id     = vsphere_nas_datastore.ds1.id
+  datastore_id     = data.vsphere_datastore.rootds1.id
 
   num_cpus = 2
   memory   = 2048
@@ -4408,7 +4349,7 @@ variable "linked_clone" {
 resource "vsphere_virtual_machine" "vm" {
   name             = "testacc-test"
   resource_pool_id = vsphere_resource_pool.pool1.id
-  datastore_id     = vsphere_nas_datastore.ds1.id
+  datastore_id     = data.vsphere_datastore.rootds1.id
 
   num_cpus = 2
   memory   = 2048
@@ -4469,7 +4410,7 @@ variable "linked_clone" {
 resource "vsphere_virtual_machine" "vm" {
   name             = "testacc-test"
   resource_pool_id = vsphere_resource_pool.pool1.id
-  datastore_id     = vsphere_nas_datastore.ds1.id
+  datastore_id     = data.vsphere_datastore.rootds1.id
 
   num_cpus = 2
   memory   = 2048
@@ -4514,7 +4455,7 @@ func testAccResourceVSphereVirtualMachineConfigClientCdrom() string {
 resource "vsphere_virtual_machine" "vm" {
   name             = "testacc-test"
   resource_pool_id = vsphere_resource_pool.pool1.id
-  datastore_id     = vsphere_nas_datastore.ds1.id
+  datastore_id     = data.vsphere_datastore.rootds1.id
 
   num_cpus = 2
   memory   = 2048
@@ -4528,7 +4469,7 @@ resource "vsphere_virtual_machine" "vm" {
 
   disk {
     label = "disk0"
-    size  = 20
+    size  = 1
   }
 
   cdrom {
@@ -4550,7 +4491,7 @@ func testAccResourceVSphereVirtualMachineConfigNoCdromParameters() string {
 resource "vsphere_virtual_machine" "vm" {
   name             = "testacc-test"
   resource_pool_id = vsphere_resource_pool.pool1.id
-  datastore_id     = vsphere_nas_datastore.ds1.id
+  datastore_id     = data.vsphere_datastore.rootds1.id
 
   num_cpus = 2
   memory   = 2048
@@ -4564,7 +4505,7 @@ resource "vsphere_virtual_machine" "vm" {
 
   disk {
     label = "disk0"
-    size  = 20
+    size  = 1
   }
 
   cdrom {}
@@ -4597,7 +4538,7 @@ data "vsphere_datastore" "iso_datastore" {
 resource "vsphere_virtual_machine" "vm" {
   name             = "testacc-test"
   resource_pool_id = vsphere_resource_pool.pool1.id
-  datastore_id     = vsphere_nas_datastore.ds1.id
+  datastore_id     = data.vsphere_datastore.rootds1.id
 
   num_cpus = 2
   memory   = 2048
@@ -4611,7 +4552,7 @@ resource "vsphere_virtual_machine" "vm" {
 
   disk {
     label = "disk0"
-    size  = 20
+    size  = 1
   }
 
   cdrom {
@@ -4649,7 +4590,7 @@ data "vsphere_datastore" "iso_datastore" {
 resource "vsphere_virtual_machine" "vm" {
   name             = "testacc-test"
   resource_pool_id = vsphere_resource_pool.pool1.id
-  datastore_id     = vsphere_nas_datastore.ds1.id
+  datastore_id     = data.vsphere_datastore.rootds1.id
 
   num_cpus = 2
   memory   = 2048
@@ -4663,7 +4604,7 @@ resource "vsphere_virtual_machine" "vm" {
 
   disk {
     label = "disk0"
-    size  = 20
+    size  = 1
   }
 
   cdrom {
@@ -4689,7 +4630,7 @@ func testAccResourceVSphereVirtualMachineConfigBeefy() string {
 resource "vsphere_virtual_machine" "vm" {
   name             = "testacc-test"
   resource_pool_id = vsphere_resource_pool.pool1.id
-  datastore_id     = vsphere_nas_datastore.ds1.id
+  datastore_id     = data.vsphere_datastore.rootds1.id
 
   num_cpus = 4
   memory   = 8192
@@ -4703,7 +4644,7 @@ resource "vsphere_virtual_machine" "vm" {
 
   disk {
     label = "disk0"
-    size  = 20
+    size  = 1
   }
 }
 `,
@@ -4721,7 +4662,7 @@ func testAccResourceVSphereVirtualMachineConfigMaxNIC() string {
 resource "vsphere_virtual_machine" "vm" {
   name             = "testacc-test"
   resource_pool_id = vsphere_resource_pool.pool1.id
-  datastore_id     = vsphere_nas_datastore.ds1.id
+  datastore_id     = data.vsphere_datastore.rootds1.id
 
   num_cpus = 2
   memory   = 2048
@@ -4771,14 +4712,8 @@ resource "vsphere_virtual_machine" "vm" {
 
   disk {
     label = "disk0"
-    size  = 20
-  }
-
-  lifecycle {
-    ignore_changes = [
-      ept_rvi_mode,
-      hv_mode
-    ]
+    size  = 1
+    io_reservation = 1
   }
 }
 `,
@@ -4800,7 +4735,7 @@ variable "annotation" {
 resource "vsphere_virtual_machine" "vm" {
   name             = "testacc-test"
   resource_pool_id = vsphere_resource_pool.pool1.id
-  datastore_id     = vsphere_nas_datastore.ds1.id
+  datastore_id     = data.vsphere_datastore.rootds1.id
 
   num_cpus   = 2
   memory     = 2048
@@ -4813,7 +4748,7 @@ resource "vsphere_virtual_machine" "vm" {
 
   disk {
     label = "disk0"
-    size  = 20
+    size  = 1
   }
 }
 `,
@@ -4832,7 +4767,7 @@ func testAccResourceVSphereVirtualMachineConfigGrowDisk(size int) string {
 resource "vsphere_virtual_machine" "vm" {
   name             = "testacc-test"
   resource_pool_id = vsphere_resource_pool.pool1.id
-  datastore_id     = vsphere_nas_datastore.ds1.id
+  datastore_id     = data.vsphere_datastore.rootds1.id
 
   num_cpus = 2
   memory   = 2048
@@ -4865,7 +4800,7 @@ func testAccResourceVSphereVirtualMachineConfigLsiLogicSAS() string {
 resource "vsphere_virtual_machine" "vm" {
   name             = "testacc-test"
   resource_pool_id = vsphere_resource_pool.pool1.id
-  datastore_id     = vsphere_nas_datastore.ds1.id
+  datastore_id     = data.vsphere_datastore.rootds1.id
 
   num_cpus = 2
   memory   = 2048
@@ -4881,7 +4816,7 @@ resource "vsphere_virtual_machine" "vm" {
 
   disk {
     label = "disk0"
-    size  = 20
+    size  = 1
   }
 }
 `,
@@ -4899,7 +4834,7 @@ func testAccResourceVSphereVirtualMachineConfigExtraConfig(k, v string) string {
 resource "vsphere_virtual_machine" "vm" {
   name             = "testacc-test"
   resource_pool_id = vsphere_resource_pool.pool1.id
-  datastore_id     = vsphere_nas_datastore.ds1.id
+  datastore_id     = data.vsphere_datastore.rootds1.id
 
   num_cpus = 2
   memory   = 2048
@@ -4918,7 +4853,7 @@ resource "vsphere_virtual_machine" "vm" {
 
   disk {
     label = "disk0"
-    size  = 20
+    size  = 1
   }
 }
 `,
@@ -4950,7 +4885,7 @@ resource "vsphere_virtual_disk" "disk" {
 resource "vsphere_virtual_machine" "vm" {
   name             = "testacc-test"
   resource_pool_id = vsphere_resource_pool.pool1.id
-  datastore_id     = vsphere_nas_datastore.ds1.id
+  datastore_id     = data.vsphere_datastore.rootds1.id
 
   num_cpus = 2
   memory   = 2048
@@ -4964,7 +4899,7 @@ resource "vsphere_virtual_machine" "vm" {
 
   disk {
     label = "disk0"
-    size  = 20
+    size  = 1
   }
 
   disk {
@@ -4998,7 +4933,7 @@ resource "vsphere_folder" "folder" {
 resource "vsphere_virtual_machine" "vm" {
   name             = "testacc-test"
   resource_pool_id = vsphere_resource_pool.pool1.id
-  datastore_id     = vsphere_nas_datastore.ds1.id
+  datastore_id     = data.vsphere_datastore.rootds1.id
   folder           = vsphere_folder.folder.path
 
   num_cpus = 2
@@ -5013,7 +4948,8 @@ resource "vsphere_virtual_machine" "vm" {
 
   disk {
     label = "disk0"
-    size  = 20
+    size  = 1
+    io_reservation = 1
   }
 }
 `,
@@ -5044,7 +4980,7 @@ resource "vsphere_vapp_container" "vapp-container" {
 resource "vsphere_virtual_machine" "vm" {
   name             = "testacc-test"
   resource_pool_id = vsphere_vapp_container.vapp-container.id
-  datastore_id     = vsphere_nas_datastore.ds1.id
+  datastore_id     = data.vsphere_datastore.rootds1.id
 
   num_cpus                   = 2
   memory                     = 2048
@@ -5057,7 +4993,7 @@ resource "vsphere_virtual_machine" "vm" {
 
   disk {
     label = "disk0"
-    size  = 20
+    size  = 1
   }
 }
 `,
@@ -5086,7 +5022,7 @@ resource "vsphere_folder" "folder" {
 resource "vsphere_virtual_machine" "vm" {
   name             = "testacc-test"
   resource_pool_id = vsphere_resource_pool.pool.id
-  datastore_id     = vsphere_nas_datastore.ds1.id
+  datastore_id     = data.vsphere_datastore.rootds1.id
   folder           = vsphere_folder.folder.path
 
   num_cpus                   = 2
@@ -5100,7 +5036,7 @@ resource "vsphere_virtual_machine" "vm" {
 
   disk {
     label = "disk0"
-    size  = 20
+    size  = 1
   }
 }
 `,
@@ -5131,7 +5067,7 @@ resource "vsphere_vapp_container" "vapp-container" {
 resource "vsphere_virtual_machine" "vm" {
   name             = "testacc-test"
   resource_pool_id = vsphere_vapp_container.vapp-container.id
-  datastore_id     = vsphere_nas_datastore.ds1.id
+  datastore_id     = data.vsphere_datastore.rootds1.id
   folder           = vsphere_folder.folder.path
 
   num_cpus                   = 2
@@ -5145,7 +5081,7 @@ resource "vsphere_virtual_machine" "vm" {
 
   disk {
     label = "disk0"
-    size  = 20
+    size  = 1
   }
 }
 `,
@@ -5163,7 +5099,7 @@ func testAccResourceVSphereVirtualMachineConfigVbsEnabledAndVvtdEnabled() string
 resource "vsphere_virtual_machine" "vm" {
   name             = "testacc-test"
   resource_pool_id = vsphere_resource_pool.pool1.id
-  datastore_id     = vsphere_nas_datastore.ds1.id
+  datastore_id     = data.vsphere_datastore.rootds1.id
 
   num_cpus = 2
   memory   = 2048
@@ -5183,7 +5119,7 @@ resource "vsphere_virtual_machine" "vm" {
 
   disk {
     label = "disk0"
-    size  = 20
+    size  = 1
   }
 }
 `,
@@ -5213,7 +5149,7 @@ resource "vsphere_vapp_container" "vapp-container" {
 resource "vsphere_virtual_machine" "vm" {
   name             = "testacc-test"
   resource_pool_id = vsphere_resource_pool.pool1.id
-  datastore_id     = vsphere_nas_datastore.ds1.id
+  datastore_id     = data.vsphere_datastore.rootds1.id
   folder           = vsphere_folder.folder.path
 
   num_cpus                   = 2
@@ -5227,7 +5163,7 @@ resource "vsphere_virtual_machine" "vm" {
 
   disk {
     label = "disk0"
-    size  = 20
+    size  = 1
   }
 }
 `,
@@ -5245,7 +5181,7 @@ func testAccResourceVSphereVirtualMachineConfigStaticMAC() string {
 resource "vsphere_virtual_machine" "vm" {
   name             = "testacc-test"
   resource_pool_id = vsphere_resource_pool.pool1.id
-  datastore_id     = vsphere_nas_datastore.ds1.id
+  datastore_id     = data.vsphere_datastore.rootds1.id
 
   num_cpus = 2
   memory   = 2048
@@ -5261,7 +5197,7 @@ resource "vsphere_virtual_machine" "vm" {
 
   disk {
     label = "disk0"
-    size  = 20
+    size  = 1
   }
 }
 `,
@@ -5294,7 +5230,7 @@ resource "vsphere_tag" "testacc-tag" {
 resource "vsphere_virtual_machine" "vm" {
   name             = "testacc-test"
   resource_pool_id = vsphere_resource_pool.pool1.id
-  datastore_id     = vsphere_nas_datastore.ds1.id
+  datastore_id     = data.vsphere_datastore.rootds1.id
 
   num_cpus = 2
   memory   = 2048
@@ -5308,7 +5244,7 @@ resource "vsphere_virtual_machine" "vm" {
 
   disk {
     label = "disk0"
-    size  = 20
+    size  = 1
   }
 
   tags = [
@@ -5357,7 +5293,7 @@ resource "vsphere_tag" "testacc-tags-alt" {
 resource "vsphere_virtual_machine" "vm" {
   name             = "testacc-test"
   resource_pool_id = vsphere_resource_pool.pool1.id
-  datastore_id     = vsphere_nas_datastore.ds1.id
+  datastore_id     = data.vsphere_datastore.rootds1.id
 
   num_cpus = 2
   memory   = 2048
@@ -5371,7 +5307,7 @@ resource "vsphere_virtual_machine" "vm" {
 
   disk {
     label = "disk0"
-    size  = 20
+    size  = 1
   }
 
   tags = vsphere_tag.testacc-tags-alt.*.id
@@ -5393,7 +5329,7 @@ resource "random_pet" "pet" {}
 resource "vsphere_virtual_machine" "vm" {
   name             = "terraform-test-${random_pet.pet.id}"
   resource_pool_id = vsphere_resource_pool.pool1.id
-  datastore_id     = vsphere_nas_datastore.ds1.id
+  datastore_id     = data.vsphere_datastore.rootds1.id
 
   num_cpus = 2
   memory   = 2048
@@ -5405,7 +5341,7 @@ resource "vsphere_virtual_machine" "vm" {
 
   disk {
     label = "terraform-test-${random_pet.pet.id}.vmdk"
-    size  = 20
+    size  = 1
   }
 }
 `,
@@ -5423,7 +5359,7 @@ func testAccResourceVSphereVirtualMachineVAppPropertiesNonClone() string {
 resource "vsphere_virtual_machine" "vm" {
   name             = "testacc-test"
   resource_pool_id = vsphere_resource_pool.pool1.id
-  datastore_id     = vsphere_nas_datastore.ds1.id
+  datastore_id     = data.vsphere_datastore.rootds1.id
 
   num_cpus = 2
   memory   = 2048
@@ -5437,7 +5373,7 @@ resource "vsphere_virtual_machine" "vm" {
 
   disk {
     label = "disk0"
-    size  = 20
+    size  = 1
   }
 
   vapp {
@@ -5461,7 +5397,7 @@ func testAccResourceVSphereVirtualMachineConfigBadOrphanedLabel() string {
 resource "vsphere_virtual_machine" "vm" {
   name             = "testacc-test"
   resource_pool_id = vsphere_resource_pool.pool1.id
-  datastore_id     = vsphere_nas_datastore.ds1.id
+  datastore_id     = data.vsphere_datastore.rootds1.id
 
   num_cpus = 2
   memory   = 2048
@@ -5473,7 +5409,7 @@ resource "vsphere_virtual_machine" "vm" {
 
   disk {
     label = "orphaned_disk_0"
-    size  = 20
+    size  = 1
   }
 }
 `,
@@ -5505,7 +5441,7 @@ resource "vsphere_resource_pool" "pool" {
 resource "vsphere_virtual_machine" "vm" {
   name             = "testacc-test"
   resource_pool_id = vsphere_resource_pool.pool.id
-  datastore_id     = vsphere_nas_datastore.ds1.id
+  datastore_id     = data.vsphere_datastore.rootds1.id
 
   num_cpus = 2
   memory   = 2048
@@ -5568,7 +5504,7 @@ variable "linked_clone" {
 resource "vsphere_virtual_machine" "vm" {
   name             = "testacc-test"
   resource_pool_id = vsphere_resource_pool.pool1.id
-  datastore_id     = vsphere_nas_datastore.ds1.id
+  datastore_id     = data.vsphere_datastore.rootds1.id
 
   num_cpus = 2
   memory   = 2048
@@ -5623,7 +5559,7 @@ variable "linked_clone" {
 resource "vsphere_virtual_machine" "vm_source" {
   name             = "terraform-test1"
   resource_pool_id = vsphere_resource_pool.pool1.id
-  datastore_id     = vsphere_nas_datastore.ds1.id
+  datastore_id     = data.vsphere_datastore.rootds1.id
 
   num_cpus                   = 2
   memory                     = 2048
@@ -5655,7 +5591,7 @@ resource "vsphere_virtual_machine" "vm_source" {
 resource "vsphere_virtual_machine" "vm" {
   name             = "terraform-test2"
   resource_pool_id = vsphere_resource_pool.pool1.id
-  datastore_id     = vsphere_nas_datastore.ds1.id
+  datastore_id     = data.vsphere_datastore.rootds1.id
 
   num_cpus                   = 2
   memory                     = 2048
@@ -5709,7 +5645,7 @@ variable "linked_clone" {
 resource "vsphere_virtual_machine" "vm" {
   name             = "testacc-test"
   resource_pool_id = vsphere_resource_pool.pool1.id
-  datastore_id     = vsphere_nas_datastore.ds1.id
+  datastore_id     = data.vsphere_datastore.rootds1.id
 
   num_cpus = 2
   memory   = 2048
@@ -5762,7 +5698,7 @@ variable "linked_clone" {
 resource "vsphere_virtual_machine" "vm" {
   name             = "testacc-test"
   resource_pool_id = vsphere_resource_pool.pool1.id
-  datastore_id     = vsphere_nas_datastore.ds1.id
+  datastore_id     = data.vsphere_datastore.rootds1.id
 
   num_cpus = 2
   memory   = 2048
@@ -5810,7 +5746,7 @@ data "vsphere_virtual_machine" "template" {
 resource "vsphere_virtual_machine" "vm" {
   name             = "testacc-test"
   resource_pool_id = vsphere_resource_pool.pool1.id
-  datastore_id     = vsphere_nas_datastore.ds1.id
+  datastore_id     = data.vsphere_datastore.rootds1.id
 
   num_cpus = 4
   memory   = 4096
@@ -5889,7 +5825,7 @@ variable "linked_clone" {
 resource "vsphere_virtual_machine" "vm" {
   name             = "testacc-test"
   resource_pool_id = vsphere_resource_pool.pool1.id
-  datastore_id     = vsphere_nas_datastore.ds1.id
+  datastore_id     = data.vsphere_datastore.rootds1.id
 
   num_cpus = 2
   memory   = 2048
@@ -6048,7 +5984,7 @@ variable "time_zone" {
 resource "vsphere_virtual_machine" "vm" {
   name             = "testacc-test"
   resource_pool_id = vsphere_resource_pool.pool1.id
-  datastore_id     = vsphere_nas_datastore.ds1.id
+  datastore_id     = data.vsphere_datastore.rootds1.id
 
   num_cpus = 2
   memory   = 2048
@@ -6113,7 +6049,7 @@ variable "linked_clone" {
 resource "vsphere_virtual_machine" "vm" {
   name             = "testacc-test"
   resource_pool_id = vsphere_resource_pool.pool1.id
-  datastore_id     = vsphere_nas_datastore.ds1.id
+  datastore_id     = data.vsphere_datastore.rootds1.id
 
   num_cpus = 2
   memory   = 2048
@@ -6320,7 +6256,7 @@ variable "linked_clone" {
 resource "vsphere_virtual_machine" "vm" {
   name             = "testacc-test"
   resource_pool_id = vsphere_resource_pool.pool1.id
-  datastore_id     = vsphere_nas_datastore.ds1.id
+  datastore_id     = data.vsphere_datastore.rootds1.id
 
   num_cpus                  = %d
   memory                    = %d
@@ -6383,7 +6319,7 @@ variable "linked_clone" {
 resource "vsphere_virtual_machine" "vm" {
   name             = "testacc-test"
   resource_pool_id = vsphere_resource_pool.pool1.id
-  datastore_id     = vsphere_nas_datastore.ds1.id
+  datastore_id     = data.vsphere_datastore.rootds1.id
 
   num_cpus = 2
   memory   = 2048
@@ -6454,7 +6390,7 @@ resource "vsphere_virtual_machine" "vm" {
   name             = "testacc-test"
   resource_pool_id = vsphere_resource_pool.pool1.id
   host_system_id   = data.vsphere_host.host.id
-  datastore_id     = vsphere_nas_datastore.ds1.id
+  datastore_id     = data.vsphere_datastore.rootds1.id
 
   num_cpus                   = 2
   memory                     = 2048
@@ -6508,7 +6444,7 @@ resource "vsphere_virtual_machine" "vm" {
   name             = "testacc-test"
   resource_pool_id = vsphere_resource_pool.pool1.id
   host_system_id   = data.vsphere_host.host.id
-  datastore_id     = vsphere_nas_datastore.ds1.id
+  datastore_id     = data.vsphere_datastore.rootds1.id
 
   num_cpus = 2
   memory   = 2048
@@ -7045,7 +6981,7 @@ locals {
 resource "vsphere_virtual_machine" "vm" {
   name             = "testacc-test"
   resource_pool_id = vsphere_resource_pool.pool1.id
-  datastore_id     = vsphere_nas_datastore.ds1.id
+  datastore_id     = data.vsphere_datastore.rootds1.id
   num_cpus         = 2
   memory           = 2048
   guest_id         = data.vsphere_virtual_machine.template.guest_id
@@ -7125,7 +7061,7 @@ locals {
 resource "vsphere_virtual_machine" "vm" {
   name             = "testacc-test"
   resource_pool_id = vsphere_resource_pool.pool1.id
-  datastore_id     = vsphere_nas_datastore.ds1.id
+  datastore_id     = data.vsphere_datastore.rootds1.id
   num_cpus         = 2
   memory           = 2048
   guest_id         = data.vsphere_virtual_machine.template.guest_id
@@ -7176,7 +7112,7 @@ data "vsphere_virtual_machine" "template" {
 resource "vsphere_virtual_machine" "vm" {
   name             = "testacc-test"
   resource_pool_id = vsphere_resource_pool.pool1.id
-  datastore_id     = vsphere_nas_datastore.ds1.id
+  datastore_id     = data.vsphere_datastore.rootds1.id
 
   num_cpus = 2
   memory   = 2048
@@ -7231,7 +7167,7 @@ resource "vsphere_compute_cluster" "compute_cluster" {
 resource "vsphere_virtual_machine" "vm" {
   name             = "testacc-test"
   resource_pool_id = vsphere_compute_cluster.compute_cluster.resource_pool_id
-  datastore_id     = vsphere_nas_datastore.ds1.id
+  datastore_id     = data.vsphere_datastore.rootds1.id
 
   num_cpus = 2
   memory   = 2048
@@ -7245,7 +7181,7 @@ resource "vsphere_virtual_machine" "vm" {
 
   disk {
     label = "disk0"
-    size  = 20
+    size  = 1
   }
 }
 `,
@@ -7312,7 +7248,7 @@ resource "vsphere_compute_cluster" "compute_cluster" {
 resource "vsphere_virtual_machine" "vm" {
   name             = "testacc-test"
   resource_pool_id = vsphere_compute_cluster.compute_cluster.resource_pool_id
-  datastore_id     = vsphere_nas_datastore.ds1.id
+  datastore_id     = data.vsphere_datastore.rootds1.id
 
   num_cpus = 2
   memory   = 2048
@@ -7402,7 +7338,7 @@ resource "vsphere_virtual_machine" "vm" {
     client_device = true
   }
 
-  depends_on = [vsphere_nas_datastore.ds1]
+  depends_on = [data.vsphere_datastore.rootds1]
 }
 `,
 		testAccResourceVSphereVirtualMachineConfigBase(),
@@ -7422,7 +7358,7 @@ func testAccResourceVSphereVirtualMachineConfigHighSensitivity() string {
 resource "vsphere_virtual_machine" "vm" {
   name             = "testacc-test"
   resource_pool_id = vsphere_resource_pool.pool1.id
-  datastore_id     = vsphere_nas_datastore.ds1.id
+  datastore_id     = data.vsphere_datastore.rootds1.id
 
   num_cpus            = 2
   cpu_reservation     = 6192
@@ -7437,7 +7373,7 @@ resource "vsphere_virtual_machine" "vm" {
 
   disk {
     label = "disk0"
-    size  = 20
+    size  = 1
   }
 }
 `,
@@ -7457,14 +7393,14 @@ resource "vsphere_virtual_disk" "d" {
   count      = 2
   size       = 1
   vmdk_path  = "disk-${count.index}.vmdk"
-  datastore  = vsphere_nas_datastore.ds1.name
+  datastore  = data.vsphere_datastore.rootds1.name
   datacenter = data.vsphere_datacenter.rootdc1.name
 }
 
 resource "vsphere_virtual_machine" "vm" {
   name                       = "testacc-test"
   resource_pool_id           = data.vsphere_compute_cluster.rootcompute_cluster1.resource_pool_id
-  datastore_id               = vsphere_nas_datastore.ds1.id
+  datastore_id               = data.vsphere_datastore.rootds1.id
   guest_id                   = "other3xLinuxGuest"
 	wait_for_guest_net_timeout = -1
 
@@ -7476,7 +7412,7 @@ resource "vsphere_virtual_machine" "vm" {
       label        = "disk0"
       path         = vsphere_virtual_disk.d[0].vmdk_path
       unit_number  = 0
-      datastore_id = vsphere_nas_datastore.ds1.id
+      datastore_id = data.vsphere_datastore.rootds1.id
     }
 
     disk {
@@ -7484,7 +7420,7 @@ resource "vsphere_virtual_machine" "vm" {
       label        = "disk1"
       path         = vsphere_virtual_disk.d[1].vmdk_path
       unit_number  = 1
-      datastore_id = vsphere_nas_datastore.ds1.id
+      datastore_id = data.vsphere_datastore.rootds1.id
    }
 }`,
 
@@ -7518,7 +7454,7 @@ resource "vsphere_virtual_machine" "vm" {
   num_cpus = 1
   memory   = 2048
 
-  wait_for_guest_net_timeout = -1
+  wait_for_guest_net_timeout = 0
   guest_id                   = "other3xLinuxGuest"
 
   network_interface {
@@ -7537,6 +7473,7 @@ resource "vsphere_virtual_machine" "vm" {
     label            = "disk0"
     thin_provisioned = true
     size             = 20
+    io_reservation = 1
   }
 }
 
@@ -7557,7 +7494,7 @@ variable "ovf_url" {
 data "vsphere_ovf_vm_template" "ovf" {
   name             = "%s"
   resource_pool_id = vsphere_resource_pool.pool1.id
-  datastore_id     = vsphere_nas_datastore.ds1.id
+  datastore_id     = data.vsphere_datastore.rootds1.id
   host_system_id   = data.vsphere_host.roothost1.id
   remote_ovf_url   = var.ovf_url
 
@@ -7612,7 +7549,7 @@ variable "ova_url" {
 data "vsphere_ovf_vm_template" "ovf" {
   name              = "%s"
   resource_pool_id  = vsphere_resource_pool.pool1.id
-  datastore_id      = vsphere_nas_datastore.ds1.id
+  datastore_id      = data.vsphere_datastore.rootds1.id
   host_system_id    = data.vsphere_host.roothost1.id
   remote_ovf_url    = var.ova_url
 
@@ -7629,7 +7566,7 @@ resource "vsphere_virtual_machine" "vm" {
   memory           = data.vsphere_ovf_vm_template.ovf.memory
   guest_id         = data.vsphere_ovf_vm_template.ovf.guest_id
   resource_pool_id = vsphere_resource_pool.pool1.id
-  datastore_id     = vsphere_nas_datastore.ds1.id
+  datastore_id     = data.vsphere_datastore.rootds1.id
   host_system_id   = data.vsphere_ovf_vm_template.ovf.host_system_id
 
   wait_for_guest_net_timeout = 0
@@ -7798,7 +7735,7 @@ resource "vsphere_virtual_machine" "vm" {
 
   disk {
     label = "disk0"
-    size  = 20
+    size  = 1
   }
 }
 `,
@@ -7818,7 +7755,7 @@ variable "ovf_url" {
 data "vsphere_ovf_vm_template" "ovf" {
   name             = "%s"
   resource_pool_id = data.vsphere_host.roothost1.resource_pool_id
-  datastore_id     = vsphere_nas_datastore.ds1.id
+  datastore_id     = data.vsphere_datastore.rootds1.id
   host_system_id   = data.vsphere_host.roothost1.id
   remote_ovf_url   = var.ovf_url
 

--- a/vsphere/resource_vsphere_virtual_machine_test.go
+++ b/vsphere/resource_vsphere_virtual_machine_test.go
@@ -872,6 +872,7 @@ func TestAccResourceVSphereVirtualMachine_cdromConflictingParameters(t *testing.
 }
 
 func TestAccResourceVSphereVirtualMachine_maximumNumberOfNICs(t *testing.T) {
+	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			RunSweepers()


### PR DESCRIPTION
### Summary

Enabling more acceptance tests. The total number of stable tests is now 129 which accounts for around 1/3 of all tests.

### Type

- [ ] `fix`: Bug Fix
- [ ] `feat`: Feature or Enhancement
- [ ] `docs`: Documentation
- [X] `refactor`: Refactoring
- [ ] `chore`: Build, Dependencies, Workflows, etc.
- [ ] `other`: Other (Please describe.)

### Breaking Changes?

- [ ] Yes, there are breaking changes.
- [X] No, there are no breaking changes.

### Tests

- [X] Tests have been added or updated.
- [X] Tests have been completed.

<details>
<summary>Output:</summary>

📦 github.com/vmware/terraform-provider-vsphere/vsphere
  ✅ TestAccDataSourceVSphereComputeClusterHostGroup_basic (59.11s)
  ✅ TestAccDataSourceVSphereComputeCluster_absolutePathNoDatacenter (1m13.09s)
  ✅ TestAccDataSourceVSphereComputeCluster_basic (50.54s)
  ✅ TestAccDataSourceVSphereContentLibrary_basic (1m0.36s)
  ✅ TestAccDataSourceVSphereCustomAttribute_basic (45.63s)
  ✅ TestAccDataSourceVSphereDatacenter_basic (46.76s)
  ✅ TestAccDataSourceVSphereDatacenter_defaultDatacenter (45.35s)
  ✅ TestAccDataSourceVSphereDatacenter_getVirtualMachines (44.91s)
  ✅ TestAccDataSourceVSphereDatastoreCluster_absolutePathNoDatacenter (1m3.5s)
  ✅ TestAccDataSourceVSphereDatastoreCluster_basic (57.24s)
  ✅ TestAccDataSourceVSphereDatastoreCluster_getDatastores (58.23s)
  ✅ TestAccDataSourceVSphereDatastoreStats_basic (1m15.93s)
  ✅ TestAccDataSourceVSphereDatastore_basic (50.76s)
  ✅ TestAccDataSourceVSphereDistributedVirtualSwitch_CreatePortgroup (1m12.71s)
  ✅ TestAccDataSourceVSphereDistributedVirtualSwitch_absolutePathNoDatacenterSpecified (58.93s)
  ✅ TestAccDataSourceVSphereDistributedVirtualSwitch_basic (1m2.18s)
  ✅ TestAccDataSourceVSphereDynamic_multiResult (1m8.4s)
  ✅ TestAccDataSourceVSphereDynamic_multiTag (1m29.25s)
  ✅ TestAccDataSourceVSphereDynamic_regexAndTag (1m36.97s)
  ✅ TestAccDataSourceVSphereDynamic_typeFilter (1m29.39s)
  ✅ TestAccDataSourceVSphereFolder_basic (54.87s)
  ✅ TestAccDataSourceVSphereGOSC_basic (45.9s)
  ✅ TestAccDataSourceVSphereHostThumbprint_basic (10.32s)
  ✅ TestAccDataSourceVSphereHost_basic (48.93s)
  ✅ TestAccDataSourceVSphereNetwork_absolutePathNoDatacenter (1m2.3s)
  ✅ TestAccDataSourceVSphereNetwork_dvsPortgroup (1m3.96s)
  ✅ TestAccDataSourceVSphereNetwork_hostPortgroups (55.3s)
  ✅ TestAccDataSourceVSphereNetwork_withTimeout (1m4.75s)
  ✅ TestAccDataSourceVSphereResourcePool_basic (1m0.41s)
  ✅ TestAccDataSourceVSphereResourcePool_noDatacenterAndAbsolutePath (58.25s)
  ✅ TestAccDataSourceVSphereResourcePool_withParentId (59.75s)
  ✅ TestAccDataSourceVSphereRole_basic (14.54s)
  ✅ TestAccDataSourceVSphereRole_systemRoleData (9.61s)
  ✅ TestAccDataSourceVSphereTagCategory_basic (49.24s)
  ✅ TestAccDataSourceVSphereTag_basic (50.97s)
  ✅ TestAccDataSourceVSphereVAppContainer_basic (59.43s)
  ✅ TestAccDataSourceVSphereVAppContainer_path (58.6s)
  ✅ TestAccDataSourceVSphereVirtualMachine_basic (1m17.11s)
  ✅ TestAccDataSourceVSphereVirtualMachine_moid (1m19.41s)
  ✅ TestAccDataSourceVSphereVirtualMachine_nameAndFolder (1m25.02s)
  ✅ TestAccDataSourceVSphereVirtualMachine_noDatacenterAndAbsolutePath (1m14.32s)
  ✅ TestAccDataSourceVSphereVirtualMachine_uuid (1m19.06s)
  ✅ TestAccDataSourceVSphereVmfsDisks_basic (53.65s)
  ✅ TestAccResourceVMStoragePolicy_basic (53.91s)
  ✅ TestAccResourceVSpherGOSC_linux (46.56s)
  ✅ TestAccResourceVSpherGOSC_sysprep (46.5s)
  ✅ TestAccResourceVSpherGOSC_windows_basic (46.95s)
  ✅ TestAccResourceVSphereComputeClusterHostGroup_basic (1m5.85s)
  ✅ TestAccResourceVSphereComputeClusterHostGroup_update (1m20.95s)
  ✅ TestAccResourceVSphereComputeClusterVMAffinityRule_basic (1m32.7s)
  ✅ TestAccResourceVSphereComputeClusterVMAffinityRule_updateCount (2m11.56s)
  ✅ TestAccResourceVSphereComputeClusterVMAffinityRule_updateEnabled (1m54.52s)
  ✅ TestAccResourceVSphereComputeClusterVMAntiAffinityRule_basic (1m32.61s)
  ✅ TestAccResourceVSphereComputeClusterVMAntiAffinityRule_updateCount (2m15.89s)
  ✅ TestAccResourceVSphereComputeClusterVMAntiAffinityRule_updateEnabled (1m57.5s)
  ✅ TestAccResourceVSphereComputeClusterVMGroup_basic (1m34.4s)
  ✅ TestAccResourceVSphereComputeClusterVMGroup_update (2m14.84s)
  ✅ TestAccResourceVSphereContentLibrary_basic (1m6.27s)
  ✅ TestAccResourceVSphereCustomAttribute_basic (48.94s)
  ✅ TestAccResourceVSphereCustomAttribute_changeType (56.11s)
  ✅ TestAccResourceVSphereCustomAttribute_rename (55.29s)
  ✅ TestAccResourceVSphereCustomAttribute_withType (46.75s)
  ✅ TestAccResourceVSphereDPMHostOverride_basic (1m7.05s)
  ✅ TestAccResourceVSphereDPMHostOverride_overrides (1m0.73s)
  ✅ TestAccResourceVSphereDPMHostOverride_update (1m20.69s)
  ✅ TestAccResourceVSphereDRSVMOverride_automationLevel (1m19.5s)
  ✅ TestAccResourceVSphereDRSVMOverride_drs (1m28.28s)
  ✅ TestAccResourceVSphereDRSVMOverride_update (2m4.69s)
  ✅ TestAccResourceVSphereDatacenter_createOnRootFolder (31.22s)
  ✅ TestAccResourceVSphereDatacenter_createOnSubfolder (39.28s)
  ✅ TestAccResourceVSphereDatacenter_modifyTags (1m17.05s)
  ✅ TestAccResourceVSphereDatacenter_singleTag (1m4.78s)
  ✅ TestAccResourceVSphereDatastoreCluster_basic (1m8.9s)
  ✅ TestAccResourceVSphereDatastoreCluster_inFolder (1m0.72s)
  ✅ TestAccResourceVSphereDatastoreCluster_moveToFolder (1m20.09s)
  ✅ TestAccResourceVSphereDatastoreCluster_rename (1m15.46s)
  ✅ TestAccResourceVSphereDistributedPortGroup_basic (1m5.53s)
  ✅ TestAccResourceVSphereDistributedPortGroup_overrideVlan (1m1.65s)
  ✅ TestAccResourceVSphereDistributedVirtualSwitchPvlanMapping_basic (1m6.91s)
  ✅ TestAccResourceVSphereDistributedVirtualSwitch_basic (1m10.21s)
  ✅ TestAccResourceVSphereDistributedVirtualSwitch_networkResourceControl (1m5.42s)
  ✅ TestAccResourceVSphereDistributedVirtualSwitch_noHosts (57.37s)
  ✅ TestAccResourceVSphereDistributedVirtualSwitch_removeNIC (1m27.71s)
  ✅ TestAccResourceVSphereDistributedVirtualSwitch_upgradeVersion (1m27.44s)
  ✅ TestAccResourceVSphereFile_basic (57.48s)
  ✅ TestAccResourceVSphereFile_uploadWithCreateDirectories (1m16.84s)
  ✅ TestAccResourceVSphereFolder_datacenterFolder (1m2.74s)
  ✅ TestAccResourceVSphereFolder_datastoreFolder (57.78s)
  ✅ TestAccResourceVSphereFolder_hostFolder (57.41s)
  ✅ TestAccResourceVSphereFolder_moveToSubfolder (1m24.12s)
  ✅ TestAccResourceVSphereFolder_networkFolder (57.24s)
  ✅ TestAccResourceVSphereFolder_subfolder (1m3.03s)
  ✅ TestAccResourceVSphereFolder_vmFolder (1m2.12s)
  ✅ TestAccResourceVSphereHAVMOverride_basic (1m31.55s)
  ✅ TestAccResourceVSphereHostNtpService (0s)
  ✅ TestAccResourceVSphereHostPortGroup_basic (1m0.72s)
  ✅ TestAccResourceVSphereHostPortGroup_basicToComplex (1m26.43s)
  ✅ TestAccResourceVSphereHostPortGroup_complexWithOverrides (1m3.62s)
  ✅ TestAccResourceVSphereHostVirtualSwitch_basic (1m4.43s)
  ✅ TestAccResourceVSphereResourcePool_basic (1m6.13s)
  ✅ TestAccResourceVSphereResourcePool_updateParent (1m21.59s)
  ✅ TestAccResourceVSphereTagCategory_addType (58.96s)
  ✅ TestAccResourceVSphereTagCategory_basic (51.43s)
  ✅ TestAccResourceVSphereTag_basic (54.07s)
  ✅ TestAccResourceVSphereVAppContainer_basic (1m15.41s)
  ✅ TestAccResourceVSphereVAppEntity_basic (1m43.19s)
  ✅ TestAccResourceVSphereVNic_dvs_default (6m30.76s)
  ✅ TestAccResourceVSphereVirtualDisk_basic (1m12.14s)
  ✅ TestAccResourceVSphereVirtualMachine_addDevices (2m43.72s)
  ✅ TestAccResourceVSphereVirtualMachine_basic (1m31.16s)
  ✅ TestAccResourceVSphereVirtualMachine_hardwareVersionBare (1m19.07s)
  ✅ TestAccResourceVSphereVirtualMachine_hardwareVersionClone (2m37.84s)
  ✅ TestAccResourceVSphereVirtualMachine_hardwareVersionUpgrade (2m21.18s)
  ✅ TestAccResourceVSphereVirtualMachine_highDiskUnitNumbers (1m33.37s)
  ✅ TestAccResourceVSphereVirtualMachine_highDiskUnitsToRegularSingleController (2m26.2s)
  ✅ TestAccResourceVSphereVirtualMachine_ignoreValidationOnComputedValue (45.16s)
  ✅ TestAccResourceVSphereVirtualMachine_moveToFolder (2m0.35s)
  ✅ TestAccResourceVSphereVirtualMachine_multiDevice (1m28.19s)
  ✅ TestAccResourceVSphereVirtualMachine_reCreateOnDeletion (2m2.86s)
  ✅ TestAccResourceVSphereVirtualMachine_removeMiddleDevices (2m15.2s)
  ✅ TestAccResourceVSphereVirtualMachine_removeMiddleDevicesChangeDiskUnit (2m12.27s)
  ✅ TestAccResourceVSphereVirtualMachine_scsiBusSharing (2m4.75s)
  ✅ TestAccResourceVSphereVirtualMachine_scsiBusSharingUpdate (2m56.06s)
  ✅ TestAccResourceVSphereVirtualMachine_shutdownOK (1m34.88s)
  ✅ TestAccResourceVSphereVmfsDatastore_basic (1m34.03s)
  ✅ TestAccResourceVsphereRole_addPrivileges (25.24s)
  ✅ TestAccResourceVsphereRole_createRole (17.66s)
  ✅ TestAccResourceVsphereRole_removePrivileges (22.06s)
  ✅ TestAccResourcevsphereEntityPermissions_basic (19.44s)
</details>


### Documentation

- [ ] Documentation has been added or updated.

### Issue References

https://github.com/vmware/terraform-provider-vsphere/issues/2508

### Release Note


### Additional Information

