### PR TITLE
chore: set golangci-lint version to v2.1.6

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -43,4 +43,4 @@ jobs:
       - name: Run Linters
         uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
         with:
-          version: latest
+          version: v2.1.6

--- a/vsphere/internal/helper/storagepod/storage_pod_helper.go
+++ b/vsphere/internal/helper/storagepod/storage_pod_helper.go
@@ -399,6 +399,7 @@ func applySDRS(client *govmomi.Client, placement *types.StoragePlacementResult, 
 	srm := object.NewStorageResourceManager(client.Client)
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
+	// Apply the first recommendation
 	task, err := srm.ApplyStorageDrsRecommendation(ctx, []string{placement.Recommendations[0].Key})
 	if err != nil {
 		return nil, err

--- a/vsphere/internal/helper/storagepod/storage_pod_helper.go
+++ b/vsphere/internal/helper/storagepod/storage_pod_helper.go
@@ -399,7 +399,6 @@ func applySDRS(client *govmomi.Client, placement *types.StoragePlacementResult, 
 	srm := object.NewStorageResourceManager(client.Client)
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
-	// Apply the first recommendation
 	task, err := srm.ApplyStorageDrsRecommendation(ctx, []string{placement.Recommendations[0].Key})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
### Summary

Using a fixed version of `golangci-lint` instead of `latest`.
The last version that the lint status was verified with was 2.1.6 and I'm using that as the new setting.

This should prevent new issues from appearing as the linter evolves and we can update its version along with any affected code manually.

### Type

- [ ] `fix`: Bug Fix
- [ ] `feat`: Feature or Enhancement
- [ ] `docs`: Documentation
- [ ] `refactor`: Refactoring
- [X] `chore`: Build, Dependencies, Workflows, etc.
- [ ] `other`: Other (Please describe.)

### Breaking Changes?

- [ ] Yes, there are breaking changes.
- [X] No, there are no breaking changes.

### Tests

- [ ] Tests have been added or updated.
- [ ] Tests have been completed.

Output:

### Documentation

- [ ] Documentation has been added or updated.

### Issue References

### Release Note

### Additional Information