### PR TITLE
fix: server fault when cloning VM on DRS-enabled cluster

### DIFF
--- a/vsphere/internal/helper/storagepod/storage_pod_helper.go
+++ b/vsphere/internal/helper/storagepod/storage_pod_helper.go
@@ -388,9 +388,6 @@ func recommendSDRS(client *govmomi.Client, sps types.StoragePlacementSpec, timeo
 		return nil, err
 	}
 
-	dummyAction := types.StorageMigrationAction{}
-	placement.Recommendations[0].Action[0] = &dummyAction
-
 	if len(placement.Recommendations) < 1 {
 		return nil, fmt.Errorf("no storage DRS recommendations were found for the requested action (type: %q)", sps.Type)
 	}

--- a/vsphere/resource_vsphere_virtual_machine.go
+++ b/vsphere/resource_vsphere_virtual_machine.go
@@ -1684,7 +1684,8 @@ func resourceVSphereVirtualMachinePostDeployChanges(d *schema.ResourceData, meta
 	}
 	cfgSpec.DeviceChange = virtualdevice.AppendDeviceChangeSpec(cfgSpec.DeviceChange, delta...)
 
-	if d.Get("datastore_cluster_id").(string) != "" {
+	// Apply SDRS if new disks are being added
+	if d.Get("datastore_cluster_id").(string) != "" && len(delta) > 0 {
 		log.Printf("[DEBUG] %s: Reconfiguring virtual machine through Storage DRS API", resourceVSphereVirtualMachineIDString(d))
 		pod, err := storagepod.FromID(client, d.Get("datastore_cluster_id").(string))
 		if err != nil {


### PR DESCRIPTION
### Summary

#### Problem

Starting with `v2.14.0` it is not possible to clone a virtual machine on a cluster which has storage DRS turned on if the configuration for the new machine does not include at least one additional hard disk.

This problem was introduced by me with https://github.com/vmware/terraform-provider-vsphere/pull/2550

#### Solution

The fix is to not attempt to apply SDRS recommendations if no new disks are being added.

#### Additional changes

Deleted unused code in `storage_pod_helper.go`

### Type

- [X] `fix`: Bug Fix
- [ ] `feat`: Feature or Enhancement
- [ ] `docs`: Documentation
- [ ] `refactor`: Refactoring
- [ ] `chore`: Build, Dependencies, Workflows, etc.
- [ ] `other`: Other (Please describe.)

### Breaking Changes?

- [ ] Yes, there are breaking changes.
- [X] No, there are no breaking changes.

### Tests

Verified that I can clone a virtual machine on a storage DRS-enabled cluster
1. Without adding any new disks
2. With multiple additional disks

<details>

<summary>Automated test run results</summary>

```
📦 github.com/vmware/terraform-provider-vsphere/vsphere
  ✅ TestAccResourceVSphereVirtualMachine_addDevices (21.29s)
  ✅ TestAccResourceVSphereVirtualMachine_basic (58.19s)
  ✅ TestAccResourceVSphereVirtualMachine_hardwareVersionBare (15.25s)
  ✅ TestAccResourceVSphereVirtualMachine_hardwareVersionClone (23.46s)
  ✅ TestAccResourceVSphereVirtualMachine_hardwareVersionUpgrade (25.75s)
  ✅ TestAccResourceVSphereVirtualMachine_highDiskUnitNumbers (15.01s)
  ✅ TestAccResourceVSphereVirtualMachine_highDiskUnitsToRegularSingleController (31s)
  ✅ TestAccResourceVSphereVirtualMachine_ignoreValidationOnComputedValue (1.88s)
  ✅ TestAccResourceVSphereVirtualMachine_moveToFolder (12.87s)
  ✅ TestAccResourceVSphereVirtualMachine_multiDevice (14.01s)
  ✅ TestAccResourceVSphereVirtualMachine_reCreateOnDeletion (22.95s)
  ✅ TestAccResourceVSphereVirtualMachine_removeMiddleDevices (32.17s)
  ✅ TestAccResourceVSphereVirtualMachine_removeMiddleDevicesChangeDiskUnit (31.45s)
  ✅ TestAccResourceVSphereVirtualMachine_scsiBusSharing (48.92s)
  ✅ TestAccResourceVSphereVirtualMachine_scsiBusSharingUpdate (1m4.08s)
  ✅ TestAccResourceVSphereVirtualMachine_shutdownOK (11.04s)
```

</details>

- [ ] Tests have been added or updated.
- [X] Tests have been completed.

### Documentation

- [ ] Documentation has been added or updated.

### Issue References

Fixes https://github.com/vmware/terraform-provider-vsphere/issues/2556

### Release Note

```
- `r/virtual_machine` - Fixed VM cloning on clusters with storage DRS turned on. (#2556)
```