### PR TITLE
fix: update static mac when reconfiguring vm

### DIFF
--- a/vsphere/internal/virtualdevice/virtual_machine_network_interface_subresource.go
+++ b/vsphere/internal/virtualdevice/virtual_machine_network_interface_subresource.go
@@ -1053,22 +1053,20 @@ func (r *NetworkInterfaceSubresource) Update(l object.VirtualDeviceList) ([]type
 		card.Backing = backing
 	}
 
-	if r.HasChange("use_static_mac") {
-		if r.Get("use_static_mac").(bool) {
-			card.AddressType = string(types.VirtualEthernetCardMacTypeManual)
-			card.MacAddress = r.Get("mac_address").(string)
+	if r.Get("use_static_mac").(bool) {
+		card.AddressType = string(types.VirtualEthernetCardMacTypeManual)
+		card.MacAddress = r.Get("mac_address").(string)
+	} else {
+		// If we've gone from a static MAC address to a auto-generated one, we need
+		// to check what address type we need to set things to.
+		if r.client.ServiceContent.About.ApiType != "VirtualCenter" {
+			// ESXi - type is "generated"
+			card.AddressType = string(types.VirtualEthernetCardMacTypeGenerated)
 		} else {
-			// If we've gone from a static MAC address to a auto-generated one, we need
-			// to check what address type we need to set things to.
-			if r.client.ServiceContent.About.ApiType != "VirtualCenter" {
-				// ESXi - type is "generated"
-				card.AddressType = string(types.VirtualEthernetCardMacTypeGenerated)
-			} else {
-				// vCenter - type is "assigned"
-				card.AddressType = string(types.VirtualEthernetCardMacTypeAssigned)
-			}
-			card.MacAddress = ""
+			// vCenter - type is "assigned"
+			card.AddressType = string(types.VirtualEthernetCardMacTypeAssigned)
 		}
+		card.MacAddress = ""
 	}
 
 	if r.Get("adapter_type") != networkInterfaceSubresourceTypeSriov {


### PR DESCRIPTION
### Summary

Changes to static MAC addresses should be applied as long as `use_static_mac` is set to true, instead of only when its value changes

### Type

- [X] `fix`: Bug Fix
- [ ] `feat`: Feature or Enhancement
- [ ] `docs`: Documentation
- [ ] `refactor`: Refactoring
- [ ] `chore`: Build, Dependencies, Workflows, etc.
- [ ] `other`: Other (Please describe.)

### Breaking Changes?

- [ ] Yes, there are breaking changes.
- [X] No, there are no breaking changes.

### Tests

<details>

<summary>Automated test run results</summary>

```
Pending
```

</details>

- [ ] Tests have been added or updated.
- [X] Tests have been completed.

### Documentation

- [ ] Documentation has been added or updated.

### Issue References

Fixes https://github.com/vmware/terraform-provider-vsphere/issues/2549

### Release Note

```
- `r/virtual_machine` - Fix MAC address reconfiguration . (#2549)
```