### PR TITLE
feat: support deploying OVA without specifying host_system_id

### DIFF
--- a/docs/resources/virtual_machine.md
+++ b/docs/resources/virtual_machine.md
@@ -240,8 +240,7 @@ data "vsphere_network" "network" {
 resource "vsphere_virtual_machine" "vmFromRemoteOvf" {
   name             = "remote-foo"
   datacenter_id    = data.vsphere_datacenter.datacenter.id
-  datastore_id     = data.vsphere_datastore.datastore.id
-  host_system_id   = data.vsphere_host.host.id
+  datastore_id     = data.vsphere_datastore.datastore.i
   resource_pool_id = data.vsphere_resource_pool.default.id
 
   wait_for_guest_net_timeout = 0
@@ -278,7 +277,6 @@ resource "vsphere_virtual_machine" "vmFromLocalOvf" {
   name             = "local-foo"
   datacenter_id    = data.vsphere_datacenter.datacenter.id
   datastore_id     = data.vsphere_datastore.datastore.id
-  host_system_id   = data.vsphere_host.host.id
   resource_pool_id = data.vsphere_resource_pool.default.id
 
   wait_for_guest_net_timeout = 0
@@ -353,7 +351,6 @@ data "vsphere_ovf_vm_template" "ovfRemote" {
   disk_provisioning = "thin"
   resource_pool_id  = data.vsphere_resource_pool.default.id
   datastore_id      = data.vsphere_datastore.datastore.id
-  host_system_id    = data.vsphere_host.host.id
   remote_ovf_url    = "https://cloud-images.ubuntu.com/releases/xx.xx/release/ubuntu-xx.xx-server-cloudimg-amd64.ova"
   ovf_network_map = {
     "VM Network" : data.vsphere_network.network.id
@@ -366,7 +363,6 @@ data "vsphere_ovf_vm_template" "ovfLocal" {
   disk_provisioning = "thin"
   resource_pool_id  = data.vsphere_resource_pool.default.id
   datastore_id      = data.vsphere_datastore.datastore.id
-  host_system_id    = data.vsphere_host.host.id
   local_ovf_path    = "/Volume/Storage/OVA/ubuntu-xx-xx-server-cloudimg-amd64.ova"
   ovf_network_map = {
     "VM Network" : data.vsphere_network.network.id
@@ -378,7 +374,6 @@ resource "vsphere_virtual_machine" "vmFromRemoteOvf" {
   name                 = "ubuntu-server-cloud-image-01"
   datacenter_id        = data.vsphere_datacenter.datacenter.id
   datastore_id         = data.vsphere_datastore.datastore.id
-  host_system_id       = data.vsphere_host.host.id
   resource_pool_id     = data.vsphere_resource_pool.default.id
   num_cpus             = data.vsphere_ovf_vm_template.ovfRemote.num_cpus
   num_cores_per_socket = data.vsphere_ovf_vm_template.ovfRemote.num_cores_per_socket
@@ -435,7 +430,6 @@ resource "vsphere_virtual_machine" "vmFromLocalOvf" {
   name                 = "ubuntu-server-cloud-image-02"
   datacenter_id        = data.vsphere_datacenter.datacenter.id
   datastore_id         = data.vsphere_datastore.datastore.id
-  host_system_id       = data.vsphere_host.host.id
   resource_pool_id     = data.vsphere_resource_pool.default.id
   num_cpus             = data.vsphere_ovf_vm_template.ovfLocal.num_cpus
   num_cores_per_socket = data.vsphere_ovf_vm_template.ovfLocal.num_cores_per_socket

--- a/vsphere/resource_vsphere_virtual_machine_test.go
+++ b/vsphere/resource_vsphere_virtual_machine_test.go
@@ -2784,21 +2784,18 @@ func TestAccResourceVSphereVirtualMachine_deployOvfFromUrl(t *testing.T) {
 }
 
 func TestAccResourceVSphereVirtualMachine_deployOvaFromUrl(t *testing.T) {
-	vmName := "terraform_test_vm_" + acctest.RandStringFromCharSet(4, acctest.CharSetAlphaNum)
-	testAccSkipUnstable(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
-			testAccResourceVSphereVirtualMachinePreCheck(t)
 		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccResourceVSphereVirtualMachineCheckExists(false),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccResourceVSphereVirtualMachineDeployOvaFromURL(vmName),
+				Config: testAccResourceVSphereVirtualMachineDeployOvaFromURL(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccResourceVSphereVirtualMachineCheckExists(true),
-					resource.TestCheckResourceAttr("vsphere_virtual_machine.vm", "name", vmName),
+					resource.TestMatchResourceAttr("vsphere_virtual_machine.vm", "moid", regexp.MustCompile("^vm-")),
 				),
 			},
 			{
@@ -8186,7 +8183,7 @@ resource "vsphere_virtual_machine" "vm" {
 	)
 }
 
-func testAccResourceVSphereVirtualMachineDeployOvaFromURL(vmName string) string {
+func testAccResourceVSphereVirtualMachineDeployOvaFromURL() string {
 	return fmt.Sprintf(`
 %s // Mix and match config
 
@@ -8195,7 +8192,7 @@ variable "ova_url" {
 }
 
 data "vsphere_ovf_vm_template" "ovf" {
-  name              = "%s"
+  name              = "acc-test-vm"
   resource_pool_id  = vsphere_resource_pool.pool1.id
   datastore_id      = data.vsphere_datastore.rootds1.id
   host_system_id    = data.vsphere_host.roothost1.id
@@ -8215,7 +8212,6 @@ resource "vsphere_virtual_machine" "vm" {
   guest_id         = data.vsphere_ovf_vm_template.ovf.guest_id
   resource_pool_id = vsphere_resource_pool.pool1.id
   datastore_id     = data.vsphere_datastore.rootds1.id
-  host_system_id   = data.vsphere_ovf_vm_template.ovf.host_system_id
 
   wait_for_guest_net_timeout = 0
 
@@ -8234,7 +8230,6 @@ resource "vsphere_virtual_machine" "vm" {
 `,
 		testAccResourceVSphereVirtualMachineConfigBase(),
 		testhelper.TestOva,
-		vmName,
 	)
 }
 


### PR DESCRIPTION
### Summary

<!--
    Please provide a clear and concise description of the pull request.
-->

### Type

- [ ] `fix`: Bug Fix
- [X] `feat`: Feature or Enhancement
- [ ] `docs`: Documentation
- [ ] `refactor`: Refactoring
- [ ] `chore`: Build, Dependencies, Workflows, etc.
- [ ] `other`: Other (Please describe.)

### Breaking Changes?

- [ ] Yes, there are breaking changes.
- [X] No, there are no breaking changes.

### Tests

- [X] Tests have been added or updated.
- [X] Tests have been completed.

Output:

📦 github.com/vmware/terraform-provider-vsphere/vsphere
  ✅ TestAccResourceVSphereVirtualMachine_addDevices (20.09s)
  ✅ TestAccResourceVSphereVirtualMachine_basic (58.93s)
  ✅ TestAccResourceVSphereVirtualMachine_deployOvaFromUrl (26.52s)
  ✅ TestAccResourceVSphereVirtualMachine_hardwareVersionBare (7.57s)
  ✅ TestAccResourceVSphereVirtualMachine_hardwareVersionClone (52.54s)
  ✅ TestAccResourceVSphereVirtualMachine_hardwareVersionUpgrade (22.17s)
  ✅ TestAccResourceVSphereVirtualMachine_highDiskUnitNumbers (13.53s)
  ✅ TestAccResourceVSphereVirtualMachine_highDiskUnitsToRegularSingleController (27.55s)
  ✅ TestAccResourceVSphereVirtualMachine_ignoreValidationOnComputedValue (1.91s)
  ✅ TestAccResourceVSphereVirtualMachine_moveToFolder (14.34s)
  ✅ TestAccResourceVSphereVirtualMachine_multiDevice (12.77s)
  ✅ TestAccResourceVSphereVirtualMachine_reCreateOnDeletion (20.2s)
  ✅ TestAccResourceVSphereVirtualMachine_removeMiddleDevices (22.98s)
  ✅ TestAccResourceVSphereVirtualMachine_removeMiddleDevicesChangeDiskUnit (28.19s)
  ✅ TestAccResourceVSphereVirtualMachine_scsiBusSharing (47.06s)
  ✅ TestAccResourceVSphereVirtualMachine_scsiBusSharingUpdate (1m5.32s)
  ✅ TestAccResourceVSphereVirtualMachine_shutdownOK (8.41s)

### Documentation

- [ ] Documentation has been added or updated.

### Issue References

Resolves #1284

### Release Note

```
- `r/virtual_machine` - Support deploying VM from OVA without specifying host. (#1284)
```

