### PR TITLE
fix: clone VM by specifying storage policy

### DIFF
--- a/vsphere/internal/virtualdevice/virtual_machine_disk_subresource.go
+++ b/vsphere/internal/virtualdevice/virtual_machine_disk_subresource.go
@@ -953,6 +953,14 @@ func DiskCloneRelocateOperation(resourceData *schema.ResourceData, client *govmo
 		}
 		r := NewDiskSubresource(client, resourceData, diskDataMap, nil, i)
 
+		// A disk locator is only useful if a target datastore is available. If we
+		// don't have a datastore specified (ie: when Storage DRS is in use), then
+		// we just need to skip this disk. The disk will be migrated properly
+		// through the SDRS API.
+		if dsID := r.Get("datastore_id"); dsID == "" || dsID == diskDatastoreComputedName {
+			continue
+		}
+
 		shouldRelocate := shouldAddRelocateSpec(resourceData, device.(*types.VirtualDisk), i)
 		if !shouldRelocate {
 			continue


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 no-inline-html -->

<!--
    NOTE: Do NOT enter content between the comment markers <!- and ->.

    In order to have the best experience with our community, we recommend that you read the code of
    conduct and contributing guidelines before submitting a pull request.

    By submitting this pull request, you confirm that you have read, understood, and agreed to the
    project's code of conduct and contributing guidelines.

    Please use conventional commits to format the title of the pull request and the commit messages.

    For more information, please refer to https://www.conventionalcommits.org and the contributing
    guidelines for this project.
-->

### Summary

Restoring the loging that forces the clone operation to use the SDRS API when a storage policy is specified.
This bit was removed by mistake in https://github.com/vmware/terraform-provider-vsphere/pull/2028/files#diff-d4995f37a0dcbcba7edfeb06e8baa89abd0f12976fc696dd12fa9f692d70283eL933

### Type

<!--
    Please check the one(s) that applies to this pull request using "x".
-->

- [X] `fix`: Bug Fix
- [ ] `feat`: Feature or Enhancement
- [ ] `docs`: Documentation
- [ ] `refactor`: Refactoring
- [ ] `chore`: Build, Dependencies, Workflows, etc.
- [ ] `other`: Other (Please describe.)

### Breaking Changes?

<!--
    Please check the one that applies to this pull request using "x".
    If this pull request contains a breaking change, please describe the impact and mitigation path.
-->

- [ ] Yes, there are breaking changes.
- [X] No, there are no breaking changes.

### Tests

<!--
    Please check the one(s) that applies to this pull request using "x".
    For bug fixes and enhancements/features, please ensure that tests and documentation have been completed and provide details.
-->

- [ ] Tests have been added or updated.
- [X] Tests have been completed.

Output:

Verified that I can clone a virtual machine by specifying a storage policy identifier
Verified that I can clone a virtual machine by specifying a datastore

<!--
    Please provide the output of the acceptance tests as applicable.
-->

### Documentation

<!--
    Please check the one(s) that applies to this pull request using "x".
    For enhancements/features, please ensure that documentation has been updated.
-->

- [ ] Documentation has been added or updated.

### Issue References

<!--
    Is this related to any GitHub issue(s)? If so, please provide the issue number(s) that are closed or resolved by this pull request.

    For bug fixes and enhancements/features, please ensure that a GitHub issue has been created and provide the issue number(s) here.

    Please use the 'Closes', 'Resolves', or 'Fixes' keywords followed by the a hash and issue number.
    This will link the pull request to the issue(s) and automatically close them when the pull request is merged.

    Example:

    Closes #000
    Resolves #001
    Fixes #002
-->

https://github.com/vmware/terraform-provider-vsphere/issues/2117

### Release Note

<!--
    Please provide context for the release notes.

    For example:

    ```
    - `r/foo` - Added support for foo. (#xxx)
    ```
-->

```
- `r/virtual_machine` - Fixed cloning with storage policy
```

### Additional Information

<!--
    Please provide any additional information that may be helpful.
-->
