### PR TITLE
Add support for project VPCs in network data source

### DIFF
--- a/docs/data-sources/network.md
+++ b/docs/data-sources/network.md
@@ -62,6 +62,7 @@ The following arguments are supported:
   * `network_type`: This is required if you have multiple port groups with the same name. This will be one of `DistributedVirtualPortgroup` for distributed port groups, `Network` for standard (host-based) port groups, or `OpaqueNetwork` for networks managed externally, such as those managed by NSX.
 * `retry_timeout` - (Optional) The timeout duration in seconds for the data source to retry read operations.
 * `retry_interval` - (Optional) The interval in milliseconds to retry the read operation if `retry_timeout` is set. Default: 500.
+* `vpc_project_id` - (Optional) Select a project scope for retrieval of VPC subnets.
 * `vpc_id` - (Optional) Select a VPC scope for retrieval of VPC subnets.
   [docs-about-morefs]: /docs/providers/vsphere/index.html#use-of-managed-object-references-by-the-vsphere-provider
 

--- a/vsphere/data_source_vsphere_network.go
+++ b/vsphere/data_source_vsphere_network.go
@@ -47,6 +47,11 @@ func dataSourceVSphereNetwork() *schema.Resource {
 				Description: "Id of the distributed virtual switch of which the port group is a part of",
 				Optional:    true,
 			},
+			"vpc_project_id": {
+				Type:        schema.TypeString,
+				Description: "Id of the project object, which the VPC and network belongs to",
+				Optional:    true,
+			},
 			"vpc_id": {
 				Type:        schema.TypeString,
 				Description: "Id of the VPC which the network belongs to",
@@ -89,6 +94,7 @@ func dataSourceVSphereNetworkRead(d *schema.ResourceData, meta interface{}) erro
 	name := d.Get("name").(string)
 	dvSwitchUUID := d.Get("distributed_virtual_switch_uuid").(string)
 	vpcID := d.Get("vpc_id").(string)
+	vpcProjectID := d.Get("vpc_project_id").(string)
 	var dc *object.Datacenter
 	if dcID, ok := d.GetOk("datacenter_id"); ok {
 		var err error
@@ -128,7 +134,7 @@ func dataSourceVSphereNetworkRead(d *schema.ResourceData, meta interface{}) erro
 			return net, waitForNetworkCompleted, nil
 		} else if vpcID != "" {
 			// Handle VPC network
-			net, err = network.FromNameAndVPCId(client, name, dc, vpcID)
+			net, err = network.FromNameAndVPCId(client, name, dc, vpcProjectID, vpcID)
 			if err != nil {
 				var notFoundError *network.NotFoundError
 				if errors.As(err, &notFoundError) {

--- a/vsphere/data_source_vsphere_network_test.go
+++ b/vsphere/data_source_vsphere_network_test.go
@@ -184,3 +184,32 @@ func TestAccDataSourceVSphereNetwork_vpcNetwork(t *testing.T) {
 		},
 	})
 }
+
+func testAccDataSourceVSphereNetworkConfigProjectVPCNetwork() string {
+	return fmt.Sprintf(`
+%s
+`,
+		testhelper.CombineConfigs(testhelper.ConfigDataRootDC1(), testhelper.ConfigDataProjectVPCNetwork(), testhelper.ConfigDataRootVMNet()),
+	)
+}
+
+func TestAccDataSourceVSphereNetwork_vpcNetworkAndProject(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			RunSweepers()
+			testAccPreCheck(t)
+			if os.Getenv("TF_VAR_VSPHERE_PROJECT_VPC_SUBNET") == "" || os.Getenv("TF_VAR_VSPHERE_PROJECT_VPC_ID") == "" || os.Getenv("TF_VAR_VSPHERE_PROJECT_ID") == "" {
+				t.Skipf("This test requires project and VPC settings, please set TF_VAR_VSPHERE_PROJECT_VPC_SUBNET, TF_VAR_VSPHERE_PROJECT_VPC_ID and TF_VAR_VSPHERE_PROJECT_ID environment variables")
+			}
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceVSphereNetworkConfigProjectVPCNetwork(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.vsphere_network.vmnet", "type", "Network"),
+				),
+			},
+		},
+	})
+}

--- a/vsphere/internal/helper/testhelper/testing.go
+++ b/vsphere/internal/helper/testhelper/testing.go
@@ -207,6 +207,17 @@ data "vsphere_network" "network1" {
 `, os.Getenv("TF_VAR_VSPHERE_VPC_SUBNET"), os.Getenv("TF_VAR_VSPHERE_VPC_ID"))
 }
 
+func ConfigDataProjectVPCNetwork() string {
+	return fmt.Sprintf(`
+data "vsphere_network" "network1" {
+  name           = "%s"
+  vpc_project_id = "%s"
+  vpc_id         = "%s"
+  datacenter_id  = data.vsphere_datacenter.rootdc1.id
+}
+`, os.Getenv("TF_VAR_VSPHERE_PROJECT_VPC_SUBNET"), os.Getenv("TF_VAR_VSPHERE_PROJECT_ID"), os.Getenv("TF_VAR_VSPHERE_PROJECT_VPC_ID"))
+}
+
 func ConfigDataRootVMNet() string {
 	return `
 data "vsphere_network" "vmnet" {


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 no-inline-html -->

<!--
    NOTE: Do NOT enter content between the comment markers <!- and ->.

    In order to have the best experience with our community, we recommend that you read the code of
    conduct and contributing guidelines before submitting a pull request.

    By submitting this pull request, you confirm that you have read, understood, and agreed to the
    project's code of conduct and contributing guidelines.

    Please use conventional commits to format the title of the pull request and the commit messages.

    For more information, please refer to https://www.conventionalcommits.org and the contributing
    guidelines for this project.
-->

### Summary

Network datasource has a capability to find a network which belongs to NSX default project.

But VPC subnets can be nested under different project, and as network names are not unique, it is required to use the project id as part of the network identification.

<!--
    Please provide a clear and concise description of the pull request.
-->

### Type

<!--
    Please check the one(s) that applies to this pull request using "x".
-->

- [ ] `fix`: Bug Fix
- [x] `feat`: Feature or Enhancement
- [ ] `docs`: Documentation
- [ ] `refactor`: Refactoring
- [ ] `chore`: Build, Dependencies, Workflows, etc.
- [ ] `other`: Other (Please describe.)

### Breaking Changes?

<!--
    Please check the one that applies to this pull request using "x".
    If this pull request contains a breaking change, please describe the impact and mitigation path.
-->

- [ ] Yes, there are breaking changes.
- [x] No, there are no breaking changes.

### Tests

<!--
    Please check the one(s) that applies to this pull request using "x".
    For bug fixes and enhancements/features, please ensure that tests and documentation have been completed and provide details.
-->

- [x] Tests have been added or updated.
- [x] Tests have been completed.

Output:

<!--
    Please provide the output of the acceptance tests as applicable.
-->

```
=== RUN   TestAccDataSourceVSphereNetwork_dvsPortgroup
--- PASS: TestAccDataSourceVSphereNetwork_dvsPortgroup (147.31s)
=== RUN   TestAccDataSourceVSphereNetwork_withTimeout
--- PASS: TestAccDataSourceVSphereNetwork_withTimeout (147.16s)
=== RUN   TestAccDataSourceVSphereNetwork_absolutePathNoDatacenter
--- PASS: TestAccDataSourceVSphereNetwork_absolutePathNoDatacenter (138.68s)
=== RUN   TestAccDataSourceVSphereNetwork_hostPortgroups
--- PASS: TestAccDataSourceVSphereNetwork_hostPortgroups (129.20s)
=== RUN   TestAccDataSourceVSphereNetwork_vpcNetwork
--- PASS: TestAccDataSourceVSphereNetwork_vpcNetwork (129.07s)
=== RUN   TestAccDataSourceVSphereNetwork_vpcNetworkAndProject
--- PASS: TestAccDataSourceVSphereNetwork_vpcNetworkAndProject (129.07s)
PASS
```

### Documentation

<!--
    Please check the one(s) that applies to this pull request using "x".
    For enhancements/features, please ensure that documentation has been updated.
-->

- [x] Documentation has been added or updated.

### Issue References

<!--
    Is this related to any GitHub issue(s)? If so, please provide the issue number(s) that are closed or resolved by this pull request.

    For bug fixes and enhancements/features, please ensure that a GitHub issue has been created and provide the issue number(s) here.

    Please use the 'Closes', 'Resolves', or 'Fixes' keywords followed by the a hash and issue number.
    This will link the pull request to the issue(s) and automatically close them when the pull request is merged.

    Example:

    Closes #000
    Resolves #001
    Fixes #002
-->

### Release Note

<!--
    Please provide context for the release notes.

    For example:

    ```
    - `r/foo` - Added support for foo. (#xxx)
    ```
-->
Add support for project VPCs in network data source

### Additional Information

<!--
    Please provide any additional information that may be helpful.
-->
