### PR TITLE
[wip] fix: BaseFromReference support for ClusterComputeResource

### DIFF
--- a/vsphere/internal/helper/computeresource/compute_resource_helper.go
+++ b/vsphere/internal/helper/computeresource/compute_resource_helper.go
@@ -40,6 +40,24 @@ type BaseComputeResource interface {
 	String() string
 }
 
+// ClusterFromID locates a ClusterComputeResource by its managed object reference ID.
+func ClusterFromID(client *govmomi.Client, id string) (*object.ClusterComputeResource, error) {
+	finder := find.NewFinder(client.Client, false)
+
+	ref := types.ManagedObjectReference{
+		Type:  "ClusterComputeResource",
+		Value: id,
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), provider.DefaultAPITimeout)
+	defer cancel()
+	obj, err := finder.ObjectReference(ctx, ref)
+	if err != nil {
+		return nil, err
+	}
+	return obj.(*object.ClusterComputeResource), nil
+}
+
 // StandaloneFromID locates a ComputeResource by its managed object reference ID.
 //
 // Note this is for base level ComputeResource objects only, and should only be
@@ -123,7 +141,7 @@ func BaseFromReference(client *govmomi.Client, ref types.ManagedObjectReference)
 	case "ComputeResource":
 		return StandaloneFromID(client, ref.Value)
 	case "ClusterComputeResource":
-		return StandaloneFromID(client, ref.Value)
+		return ClusterFromID(client, ref.Value)
 	}
 	return nil, fmt.Errorf("unknown object type %s", ref.Type)
 }


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 no-inline-html -->

### Summary

When trying to create a VM on a ResourcePool in a Cluster on vcsim I ran into the error "error loading default device list:".
When investigating I found an issue that looked like the handling of Clusters was incomplete, therefore I added the missing part and my tests where successfull.

### Type

- [x] `fix`: Bug Fix
- [ ] `feat`: Feature or Enhancement
- [ ] `docs`: Documentation
- [ ] `refactor`: Refactoring
- [ ] `chore`: Build, Dependencies, Workflows, etc.
- [ ] `other`: Other (Please describe.)

### Breaking Changes?

- [ ] Yes, there are breaking changes.
- [x] No, there are no breaking changes.

### Tests

- [ ] Tests have been added or updated.
- [x] Tests have been completed.

Output:

<!--
    Please provide the output of the acceptance tests as applicable.
-->

### Documentation

<!--
    Please check the one(s) that applies to this pull request using "x".
    For enhancements/features, please ensure that documentation has been updated.
-->

- [ ] Documentation has been added or updated.

### Issue References

<!--
    Is this related to any GitHub issue(s)? If so, please provide the issue number(s) that are closed or resolved by this pull request.

    For bug fixes and enhancements/features, please ensure that a GitHub issue has been created and provide the issue number(s) here.

    Please use the 'Closes', 'Resolves', or 'Fixes' keywords followed by the a hash and issue number.
    This will link the pull request to the issue(s) and automatically close them when the pull request is merged.

    Example:

    Closes #000
    Resolves #001
    Fixes #002
-->

### Release Note

- fix: BaseFromReference support for ClusterComputeResource

### Additional Information
