### PR TITLE
chore: replace `mitchellh/copystructure` with internal helper functions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,8 +7,8 @@ require (
 	github.com/hashicorp/terraform-plugin-log v0.10.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.40.1
 	github.com/hashicorp/terraform-plugin-testing v1.16.0
-	github.com/mitchellh/copystructure v1.2.0
 	github.com/vmware/govmomi v0.54.1
+	github.com/huandu/go-clone v1.7.3
 )
 
 require (
@@ -41,6 +41,7 @@ require (
 	github.com/hashicorp/yamux v0.1.2 // indirect
 	github.com/mattn/go-colorable v0.1.14 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
+	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/go-testing-interface v1.14.1 // indirect
 	github.com/mitchellh/go-wordwrap v1.0.1 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.40.1
 	github.com/hashicorp/terraform-plugin-testing v1.16.0
 	github.com/vmware/govmomi v0.54.1
-	github.com/huandu/go-clone v1.7.3
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -100,10 +100,6 @@ github.com/hashicorp/terraform-svchost v0.2.1 h1:ubvrTFw3Q7CsoEaX7V06PtCTKG3wu7G
 github.com/hashicorp/terraform-svchost v0.2.1/go.mod h1:zDMheBLvNzu7Q6o9TBvPqiZToJcSuCLXjAXxBslSky4=
 github.com/hashicorp/yamux v0.1.2 h1:XtB8kyFOyHXYVFnwT5C3+Bdo8gArse7j2AQ0DA0Uey8=
 github.com/hashicorp/yamux v0.1.2/go.mod h1:C+zze2n6e/7wshOZep2A70/aQU6QBRWJO/G6FT1wIns=
-github.com/huandu/go-assert v1.1.5 h1:fjemmA7sSfYHJD7CUqs9qTwwfdNAx7/j2/ZlHXzNB3c=
-github.com/huandu/go-assert v1.1.5/go.mod h1:yOLvuqZwmcHIC5rIzrBhT7D3Q9c3GFnd0JrPVhn/06U=
-github.com/huandu/go-clone v1.7.3 h1:rtQODA+ABThEn6J5LBTppJfKmZy/FwfpMUWa8d01TTQ=
-github.com/huandu/go-clone v1.7.3/go.mod h1:ReGivhG6op3GYr+UY3lS6mxjKp7MIGTknuU5TbTVaXE=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
 github.com/jhump/protoreflect v1.17.0 h1:qOEr613fac2lOuTgWN4tPAtLL7fUSbuJL5X5XumQh94=
@@ -149,7 +145,6 @@ github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3/go.mod h1:A0bzQcvG
 github.com/skeema/knownhosts v1.3.1 h1:X2osQ+RAjK76shCbvhHHHVl3ZlgDm8apHEHFqRjnBY8=
 github.com/skeema/knownhosts v1.3.1/go.mod h1:r7KTdC8l4uxWRyK2TpQZ/1o5HaSzh06ePQNxPwTcfiY=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
-github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
@@ -248,6 +243,5 @@ gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntN
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/warnings.v0 v0.1.2 h1:wFXVbFY8DY5/xOe1ECiWdKCzZlxgshcYVNkBHstARME=
 gopkg.in/warnings.v0 v0.1.2/go.mod h1:jksf8JmL6Qr/oQM2OXTHunEvvTAsrWBLb6OOjuVWRNI=
-gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/go.sum
+++ b/go.sum
@@ -100,6 +100,10 @@ github.com/hashicorp/terraform-svchost v0.2.1 h1:ubvrTFw3Q7CsoEaX7V06PtCTKG3wu7G
 github.com/hashicorp/terraform-svchost v0.2.1/go.mod h1:zDMheBLvNzu7Q6o9TBvPqiZToJcSuCLXjAXxBslSky4=
 github.com/hashicorp/yamux v0.1.2 h1:XtB8kyFOyHXYVFnwT5C3+Bdo8gArse7j2AQ0DA0Uey8=
 github.com/hashicorp/yamux v0.1.2/go.mod h1:C+zze2n6e/7wshOZep2A70/aQU6QBRWJO/G6FT1wIns=
+github.com/huandu/go-assert v1.1.5 h1:fjemmA7sSfYHJD7CUqs9qTwwfdNAx7/j2/ZlHXzNB3c=
+github.com/huandu/go-assert v1.1.5/go.mod h1:yOLvuqZwmcHIC5rIzrBhT7D3Q9c3GFnd0JrPVhn/06U=
+github.com/huandu/go-clone v1.7.3 h1:rtQODA+ABThEn6J5LBTppJfKmZy/FwfpMUWa8d01TTQ=
+github.com/huandu/go-clone v1.7.3/go.mod h1:ReGivhG6op3GYr+UY3lS6mxjKp7MIGTknuU5TbTVaXE=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
 github.com/jhump/protoreflect v1.17.0 h1:qOEr613fac2lOuTgWN4tPAtLL7fUSbuJL5X5XumQh94=
@@ -145,6 +149,7 @@ github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3/go.mod h1:A0bzQcvG
 github.com/skeema/knownhosts v1.3.1 h1:X2osQ+RAjK76shCbvhHHHVl3ZlgDm8apHEHFqRjnBY8=
 github.com/skeema/knownhosts v1.3.1/go.mod h1:r7KTdC8l4uxWRyK2TpQZ/1o5HaSzh06ePQNxPwTcfiY=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
@@ -243,5 +248,6 @@ gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntN
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/warnings.v0 v0.1.2 h1:wFXVbFY8DY5/xOe1ECiWdKCzZlxgshcYVNkBHstARME=
 gopkg.in/warnings.v0 v0.1.2/go.mod h1:jksf8JmL6Qr/oQM2OXTHunEvvTAsrWBLb6OOjuVWRNI=
+gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/vsphere/internal/helper/structure/copy.go
+++ b/vsphere/internal/helper/structure/copy.go
@@ -1,0 +1,31 @@
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MPL-2.0
+
+package structure
+
+import (
+	"fmt"
+
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+// CopyMap returns a shallow copy of a map[string]interface{}.
+func CopyMap(src map[string]interface{}) map[string]interface{} {
+	dst := make(map[string]interface{}, len(src))
+	for k, v := range src {
+		dst[k] = v
+	}
+	return dst
+}
+
+// CopyDeviceConfigSpec returns a shallow copy of a types.BaseVirtualDeviceConfigSpec.
+func CopyDeviceConfigSpec(op types.BaseVirtualDeviceConfigSpec) types.BaseVirtualDeviceConfigSpec {
+	switch v := op.(type) {
+	case *types.VirtualDeviceConfigSpec:
+		c := *v
+		return &c
+	default:
+		panic(fmt.Sprintf("unsupported virtual device config spec type %T", op))
+	}
+}

--- a/vsphere/internal/virtualdevice/virtual_machine_cdrom_subresource.go
+++ b/vsphere/internal/virtualdevice/virtual_machine_cdrom_subresource.go
@@ -11,7 +11,7 @@ import (
 	"regexp"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mitchellh/copystructure"
+	"github.com/huandu/go-clone"
 	"github.com/vmware/govmomi"
 	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/vim25/types"
@@ -350,10 +350,7 @@ func CdromPostCloneOperation(d *schema.ResourceData, c *govmomi.Client, l object
 			continue
 		}
 		sm := srcSet[i].(map[string]interface{})
-		nm, err := copystructure.Copy(sm)
-		if err != nil {
-			return nil, nil, fmt.Errorf("error copying source CDROM device state data at index %d: %s", i, err)
-		}
+		nm := clone.Clone(sm)
 		for k, v := range cm {
 			// Skip key and device_address here
 			switch k {

--- a/vsphere/internal/virtualdevice/virtual_machine_cdrom_subresource.go
+++ b/vsphere/internal/virtualdevice/virtual_machine_cdrom_subresource.go
@@ -11,7 +11,6 @@ import (
 	"regexp"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/huandu/go-clone"
 	"github.com/vmware/govmomi"
 	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/vim25/types"
@@ -350,16 +349,16 @@ func CdromPostCloneOperation(d *schema.ResourceData, c *govmomi.Client, l object
 			continue
 		}
 		sm := srcSet[i].(map[string]interface{})
-		nm := clone.Clone(sm)
+		nm := structure.CopyMap(sm)
 		for k, v := range cm {
 			// Skip key and device_address here
 			switch k {
 			case "key", "device_address":
 				continue
 			}
-			nm.(map[string]interface{})[k] = v
+			nm[k] = v
 		}
-		r := NewCdromSubresource(c, d, nm.(map[string]interface{}), sm, i)
+		r := NewCdromSubresource(c, d, nm, sm, i)
 		if !reflect.DeepEqual(sm, nm) {
 			// Update
 			cspec, err := r.Update(l)

--- a/vsphere/internal/virtualdevice/virtual_machine_device_subresource.go
+++ b/vsphere/internal/virtualdevice/virtual_machine_device_subresource.go
@@ -14,7 +14,6 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/huandu/go-clone"
 	"github.com/vmware/govmomi"
 	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/vim25/types"
@@ -981,7 +980,7 @@ func AppendDeviceChangeSpec(
 	ops ...types.BaseVirtualDeviceConfigSpec,
 ) []types.BaseVirtualDeviceConfigSpec {
 	for _, op := range ops {
-		c := clone.Clone(op).(types.BaseVirtualDeviceConfigSpec)
+		c := structure.CopyDeviceConfigSpec(op)
 		spec = append(spec, c)
 	}
 	return spec

--- a/vsphere/internal/virtualdevice/virtual_machine_device_subresource.go
+++ b/vsphere/internal/virtualdevice/virtual_machine_device_subresource.go
@@ -14,7 +14,7 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mitchellh/copystructure"
+	"github.com/huandu/go-clone"
 	"github.com/vmware/govmomi"
 	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/vim25/types"
@@ -981,7 +981,7 @@ func AppendDeviceChangeSpec(
 	ops ...types.BaseVirtualDeviceConfigSpec,
 ) []types.BaseVirtualDeviceConfigSpec {
 	for _, op := range ops {
-		c := copystructure.Must(copystructure.Copy(op)).(types.BaseVirtualDeviceConfigSpec)
+		c := clone.Clone(op).(types.BaseVirtualDeviceConfigSpec)
 		spec = append(spec, c)
 	}
 	return spec

--- a/vsphere/internal/virtualdevice/virtual_machine_disk_subresource.go
+++ b/vsphere/internal/virtualdevice/virtual_machine_disk_subresource.go
@@ -16,7 +16,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/mitchellh/copystructure"
+	"github.com/huandu/go-clone"
 	"github.com/vmware/govmomi"
 	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/vim25/types"
@@ -355,10 +355,7 @@ func diskApplyOperationCreateUpdate(
 			// changes are handled during storage vMotion later on during the
 			// update phase. keep_on_remove is a Terraform-only attribute and only
 			// needs to be committed to state.
-			omc, err := copystructure.Copy(oldData)
-			if err != nil {
-				return fmt.Errorf("%s: error generating copy of old disk data: %s", r.Addr(), err)
-			}
+			omc := clone.Clone(oldData)
 			oldCopy := omc.(map[string]interface{})
 			oldCopy["datastore_id"] = newData["datastore_id"]
 			oldCopy["keep_on_remove"] = newData["keep_on_remove"]
@@ -696,10 +693,7 @@ nextNew:
 		if ne != nil {
 			continue
 		}
-		nv, err := copystructure.Copy(ods[ni])
-		if err != nil {
-			return fmt.Errorf("disk.%d: error making updated diff of deleted entry: %s", ni, err)
-		}
+		nv := clone.Clone(ods[ni])
 		nm := nv.(map[string]interface{})
 		switch {
 		case nm["keep_on_remove"].(bool):
@@ -1151,18 +1145,12 @@ func DiskPostCloneOperation(d *schema.ResourceData, c *govmomi.Client, l object.
 		}
 		// Copy the source set into old. This allows us to patch a copy of the
 		// product of this set with the source, creating a diff.
-		old, err := copystructure.Copy(src)
-		if err != nil {
-			return nil, nil, fmt.Errorf("error copying source set for disk at unit_number %d: %s", src["unit_number"].(int), err)
-		}
+		old := clone.Clone(src)
 		rOld := NewDiskSubresource(c, d, old.(map[string]interface{}), nil, i)
 		if err := rOld.Read(l); err != nil {
 			return nil, nil, fmt.Errorf("%s: %s", rOld.Addr(), err)
 		}
-		newValue, err := copystructure.Copy(rOld.Data())
-		if err != nil {
-			return nil, nil, fmt.Errorf("error copying current device state for disk at unit_number %d: %s", src["unit_number"].(int), err)
-		}
+		newValue := clone.Clone(rOld.Data())
 		for k, v := range src {
 			// Skip label, path (path will always be computed here as cloned disks
 			// are not being attached externally), name, datastore_id, and uuid. Also

--- a/vsphere/internal/virtualdevice/virtual_machine_disk_subresource.go
+++ b/vsphere/internal/virtualdevice/virtual_machine_disk_subresource.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/huandu/go-clone"
 	"github.com/vmware/govmomi"
 	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/vim25/types"
@@ -355,8 +354,7 @@ func diskApplyOperationCreateUpdate(
 			// changes are handled during storage vMotion later on during the
 			// update phase. keep_on_remove is a Terraform-only attribute and only
 			// needs to be committed to state.
-			omc := clone.Clone(oldData)
-			oldCopy := omc.(map[string]interface{})
+			oldCopy := structure.CopyMap(oldData)
 			oldCopy["datastore_id"] = newData["datastore_id"]
 			oldCopy["keep_on_remove"] = newData["keep_on_remove"]
 			if reflect.DeepEqual(oldCopy, newData) {
@@ -693,8 +691,7 @@ nextNew:
 		if ne != nil {
 			continue
 		}
-		nv := clone.Clone(ods[ni])
-		nm := nv.(map[string]interface{})
+		nm := structure.CopyMap(ods[ni].(map[string]interface{}))
 		switch {
 		case nm["keep_on_remove"].(bool):
 			fallthrough
@@ -1145,12 +1142,12 @@ func DiskPostCloneOperation(d *schema.ResourceData, c *govmomi.Client, l object.
 		}
 		// Copy the source set into old. This allows us to patch a copy of the
 		// product of this set with the source, creating a diff.
-		old := clone.Clone(src)
-		rOld := NewDiskSubresource(c, d, old.(map[string]interface{}), nil, i)
+		old := structure.CopyMap(src)
+		rOld := NewDiskSubresource(c, d, old, nil, i)
 		if err := rOld.Read(l); err != nil {
 			return nil, nil, fmt.Errorf("%s: %s", rOld.Addr(), err)
 		}
-		newValue := clone.Clone(rOld.Data())
+		newValue := structure.CopyMap(rOld.Data())
 		for k, v := range src {
 			// Skip label, path (path will always be computed here as cloned disks
 			// are not being attached externally), name, datastore_id, and uuid. Also
@@ -1167,9 +1164,9 @@ func DiskPostCloneOperation(d *schema.ResourceData, c *govmomi.Client, l object.
 					continue
 				}
 			}
-			newValue.(map[string]interface{})[k] = v
+			newValue[k] = v
 		}
-		rNew := NewDiskSubresource(c, d, newValue.(map[string]interface{}), rOld.Data(), i)
+		rNew := NewDiskSubresource(c, d, newValue, rOld.Data(), i)
 		if !reflect.DeepEqual(rNew.Data(), rOld.Data()) {
 			uspec, err := rNew.Update(l)
 			if err != nil {

--- a/vsphere/internal/virtualdevice/virtual_machine_network_interface_subresource.go
+++ b/vsphere/internal/virtualdevice/virtual_machine_network_interface_subresource.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/huandu/go-clone"
 	"github.com/vmware/govmomi"
 	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/vim25/types"
@@ -576,8 +575,7 @@ func NetworkInterfacePostCloneOperation(d *schema.ResourceData, c *govmomi.Clien
 			continue
 		}
 		sm := srcSet[i].(map[string]interface{})
-		nc := clone.Clone(sm)
-		nm := nc.(map[string]interface{})
+		nm := structure.CopyMap(sm)
 		for k, v := range cm {
 			// Skip key and device_address here
 			switch k {

--- a/vsphere/internal/virtualdevice/virtual_machine_network_interface_subresource.go
+++ b/vsphere/internal/virtualdevice/virtual_machine_network_interface_subresource.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/mitchellh/copystructure"
+	"github.com/huandu/go-clone"
 	"github.com/vmware/govmomi"
 	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/vim25/types"
@@ -576,10 +576,7 @@ func NetworkInterfacePostCloneOperation(d *schema.ResourceData, c *govmomi.Clien
 			continue
 		}
 		sm := srcSet[i].(map[string]interface{})
-		nc, err := copystructure.Copy(sm)
-		if err != nil {
-			return nil, nil, fmt.Errorf("error copying source network interface state data at index %d: %s", i, err)
-		}
+		nc := clone.Clone(sm)
 		nm := nc.(map[string]interface{})
 		for k, v := range cm {
 			// Skip key and device_address here

--- a/vsphere/virtual_machine_config_structure.go
+++ b/vsphere/virtual_machine_config_structure.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/mitchellh/copystructure"
+	"github.com/huandu/go-clone"
 	"github.com/vmware/govmomi"
 	"github.com/vmware/govmomi/vim25/types"
 	"github.com/vmware/terraform-provider-vsphere/vsphere/internal/helper/spbm"
@@ -799,10 +799,7 @@ func expandVAppConfig(d *schema.ResourceData, client *govmomi.Client) (*types.Vm
 	if len(newVApps) > 0 && newVApps[0] != nil {
 		newVApp := newVApps[0].(map[string]interface{})
 		if props, ok := newVApp["properties"].(map[string]interface{}); ok {
-			propsCopy, err := copystructure.Copy(props)
-			if err != nil {
-				return nil, fmt.Errorf("while extracting vapp properties into a new map: %s", err)
-			}
+			propsCopy := clone.Clone(props)
 			newMap = propsCopy.(map[string]interface{})
 		}
 	}

--- a/vsphere/virtual_machine_config_structure.go
+++ b/vsphere/virtual_machine_config_structure.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/huandu/go-clone"
 	"github.com/vmware/govmomi"
 	"github.com/vmware/govmomi/vim25/types"
 	"github.com/vmware/terraform-provider-vsphere/vsphere/internal/helper/spbm"
@@ -799,8 +798,7 @@ func expandVAppConfig(d *schema.ResourceData, client *govmomi.Client) (*types.Vm
 	if len(newVApps) > 0 && newVApps[0] != nil {
 		newVApp := newVApps[0].(map[string]interface{})
 		if props, ok := newVApp["properties"].(map[string]interface{}); ok {
-			propsCopy := clone.Clone(props)
-			newMap = propsCopy.(map[string]interface{})
+			newMap = structure.CopyMap(props)
 		}
 	}
 


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 no-inline-html -->

<!--
    NOTE: Do NOT enter content between the comment markers <!- and ->.

    In order to have the best experience with our community, we recommend that you read the code of
    conduct and contributing guidelines before submitting a pull request.

    By submitting this pull request, you confirm that you have read, understood, and agreed to the
    project's code of conduct and contributing guidelines.

    Please use conventional commits to format the title of the pull request and the commit messages.

    For more information, please refer to https://www.conventionalcommits.org and the contributing
    guidelines for this project.
-->

### Summary

<!--
    Please provide a clear and concise description of the pull request.
-->

This pull request replaces usage of the external `copystructure` library with new internal helper functions for copying maps and device config specs. This change removes an external dependency, simplifies error handling, and provides more targeted copy implementations for the provider's needs.

Projects developed by Broadcom are not allowed to depend on open-source libraries with no maintainers and/or older than 5 years.
`mitchellh/copystructure` is abandoned and archived and although its interface its stable we can and should move to a supported alternative.

Dependency Management:

* Removed direct import of `github.com/mitchellh/copystructure` from the codebase and moved it to an indirect dependency in `go.mod`, reducing reliance on the external library in main code paths. [[1]](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L10) [[2]](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6R43)

Internal Helper implementation:

* Added `structure.CopyMap` and `structure.CopyDeviceConfigSpec` in `vsphere/internal/helper/structure/copy.go` to provide shallow copy utilities for `map[string]interface{}` and `types.BaseVirtualDeviceConfigSpec`, respectively.

Refactoring across Subresources:

* Updated CDROM, disk, and network interface subresource files to use `structure.CopyMap` instead of `copystructure.Copy`, removing error handling related to deep copy and simplifying code. [[1]](diffhunk://#diff-66ede34cec587015ef97677fc68f4b4e257169462685a40a030286135e828fb1L14) [[2]](diffhunk://#diff-66ede34cec587015ef97677fc68f4b4e257169462685a40a030286135e828fb1L353-R361) [[3]](diffhunk://#diff-a4335bcf3e823f5c90faa8359c8d7cc983376c37736d2a56b40aad3b9aeef2a2L17) [[4]](diffhunk://#diff-a4335bcf3e823f5c90faa8359c8d7cc983376c37736d2a56b40aad3b9aeef2a2L984-R983) [[5]](diffhunk://#diff-d4995f37a0dcbcba7edfeb06e8baa89abd0f12976fc696dd12fa9f692d70283eL19) [[6]](diffhunk://#diff-d4995f37a0dcbcba7edfeb06e8baa89abd0f12976fc696dd12fa9f692d70283eL358-R357) [[7]](diffhunk://#diff-d4995f37a0dcbcba7edfeb06e8baa89abd0f12976fc696dd12fa9f692d70283eL699-R694) [[8]](diffhunk://#diff-d4995f37a0dcbcba7edfeb06e8baa89abd0f12976fc696dd12fa9f692d70283eL1154-R1150) [[9]](diffhunk://#diff-d4995f37a0dcbcba7edfeb06e8baa89abd0f12976fc696dd12fa9f692d70283eL1182-R1169) [[10]](diffhunk://#diff-e8de2d20cbf49f2db545eafc50b5230673e69274016a107bc7c75f6adcb1d635L17) [[11]](diffhunk://#diff-e8de2d20cbf49f2db545eafc50b5230673e69274016a107bc7c75f6adcb1d635L579-R578)

Other Updates:

* Updated `vsphere/virtual_machine_config_structure.go` to use the new `structure.CopyMap` for copying vApp property maps, further eliminating dependency on `copystructure`. [[1]](diffhunk://#diff-0f666e3e0a18ec30c8b0ce30625fbaaa649f031053f41843159c3470d6baf51eL15) [[2]](diffhunk://#diff-0f666e3e0a18ec30c8b0ce30625fbaaa649f031053f41843159c3470d6baf51eL802-R801)

Testing:

- Ran all acceptance tests (link to output in the testing section).
- Generated some one-off unit tests that compare clones of the same object created by both libraries.

<details>
<summary>Equality validation tests</summary>

```

func TestCopyParity_BaseVirtualDeviceConfigSpec(t *testing.T) {
	src := types.BaseVirtualDeviceConfigSpec(&types.VirtualDeviceConfigSpec{
		Operation: types.VirtualDeviceConfigSpecOperationAdd,
		Device: &types.VirtualDisk{
			VirtualDevice: types.VirtualDevice{
				Key: 2000,
				Backing: &types.VirtualDiskFlatVer2BackingInfo{
					VirtualDeviceFileBackingInfo: types.VirtualDeviceFileBackingInfo{
						FileName: "[ds1] vm/vm.vmdk",
					},
					DiskMode:        string(types.VirtualDiskModePersistent),
					ThinProvisioned: types.NewBool(true),
				},
			},
			CapacityInKB: 4194304,
		},
	})

	old := copystructure.Must(copystructure.Copy(src)).(types.BaseVirtualDeviceConfigSpec)
	new := clone.Clone(src).(types.BaseVirtualDeviceConfigSpec)

	if !reflect.DeepEqual(old, new) {
		t.Fatalf("parity mismatch for BaseVirtualDeviceConfigSpec:\n old=%#v\n new=%#v", old, new)
	}

	assertNoSharedPointers(t, src, new)
}

func TestCopyParity_VirtualCdrom(t *testing.T) {
	src := types.BaseVirtualDeviceConfigSpec(&types.VirtualDeviceConfigSpec{
		Operation: types.VirtualDeviceConfigSpecOperationAdd,
		Device: &types.VirtualCdrom{
			VirtualDevice: types.VirtualDevice{
				Key: 3000,
				Backing: &types.VirtualCdromIsoBackingInfo{
					VirtualDeviceFileBackingInfo: types.VirtualDeviceFileBackingInfo{
						FileName: "[ds1] iso/test.iso",
					},
				},
			},
		},
	})

	old := copystructure.Must(copystructure.Copy(src)).(types.BaseVirtualDeviceConfigSpec)
	new := clone.Clone(src).(types.BaseVirtualDeviceConfigSpec)

	if !reflect.DeepEqual(old, new) {
		t.Fatalf("parity mismatch for VirtualCdrom:\n old=%#v\n new=%#v", old, new)
	}

	assertNoSharedPointers(t, src, new)
}

func TestCopyParity_VirtualVmxnet3(t *testing.T) {
	src := types.BaseVirtualDeviceConfigSpec(&types.VirtualDeviceConfigSpec{
		Operation: types.VirtualDeviceConfigSpecOperationAdd,
		Device: &types.VirtualVmxnet3{
			VirtualVmxnet: types.VirtualVmxnet{
				VirtualEthernetCard: types.VirtualEthernetCard{
					VirtualDevice: types.VirtualDevice{
						Key: 4000,
						Backing: &types.VirtualEthernetCardNetworkBackingInfo{
							VirtualDeviceDeviceBackingInfo: types.VirtualDeviceDeviceBackingInfo{
								DeviceName: "VM Network",
							},
						},
					},
					AddressType: string(types.VirtualEthernetCardMacTypeGenerated),
				},
			},
		},
	})

	old := copystructure.Must(copystructure.Copy(src)).(types.BaseVirtualDeviceConfigSpec)
	new := clone.Clone(src).(types.BaseVirtualDeviceConfigSpec)

	if !reflect.DeepEqual(old, new) {
		t.Fatalf("parity mismatch for VirtualVmxnet3:\n old=%#v\n new=%#v", old, new)
	}

	assertNoSharedPointers(t, src, new)
}

func TestCopyParity_TerraformMap(t *testing.T) {
	testCases := []struct {
		name string
		data map[string]interface{}
	}{
		{
			name: "disk_subresource_map",
			data: map[string]interface{}{
				"label":          "disk1",
				"size":           40,
				"unit_number":    0,
				"thin_provision": true,
				"eagerly_scrub":  false,
				"datastore_id":   "datastore-123",
				"uuid":           "6000C294-b2c5-4ef7-9b6c-1234567890ab",
				"attach":         false,
				"keep_on_remove": true,
				"disk_sharing":   "sharingNone",
				"write_through":  false,
				"nested_array": []interface{}{
					"item1", "item2", 123,
				},
				"nested_map": map[string]interface{}{
					"key1": "value1",
					"key2": 456,
				},
			},
		},
		{
			name: "cdrom_subresource_map",
			data: map[string]interface{}{
				"client_device": false,
				"datastore_id":  "datastore-456",
				"path":          "[datastore1] vm/test.iso",
			},
		},
		{
			name: "network_interface_map",
			data: map[string]interface{}{
				"device_address":        "pci:0000:0b:00.0",
				"network_id":            "network-789",
				"adapter_type":          "vmxnet3",
				"use_static_mac":        false,
				"mac_address":           "00:50:56:12:34:56",
				"bandwidth_limit":       -1,
				"bandwidth_reservation": 0,
				"bandwidth_share_level": "normal",
				"bandwidth_share_count": 50,
			},
		},
	}

	for _, tc := range testCases {
		t.Run(tc.name, func(t *testing.T) {
			oldCopy, err := copystructure.Copy(tc.data)
			if err != nil {
				t.Fatalf("copystructure.Copy failed: %v", err)
			}
			old := oldCopy.(map[string]interface{})

			newCopy := clone.Clone(tc.data)
			new := newCopy.(map[string]interface{})

			if !reflect.DeepEqual(old, new) {
				t.Fatalf("parity mismatch for %s:\n old=%#v\n new=%#v", tc.name, old, new)
			}

			assertNoSharedPointers(t, tc.data, new)
		})
	}
}

func assertNoSharedPointers(t *testing.T, src, dst interface{}) {
	srcPtrs := collectPointers(reflect.ValueOf(src))
	dstPtrs := collectPointers(reflect.ValueOf(dst))

	for ptr := range srcPtrs {
		if dstPtrs[ptr] {
			t.Errorf("shared pointer detected: %v", ptr)
		}
	}
}

func collectPointers(v reflect.Value) map[uintptr]bool {
	ptrs := make(map[uintptr]bool)
	collectPointersRecursive(v, ptrs, make(map[uintptr]bool))
	return ptrs
}

func collectPointersRecursive(v reflect.Value, ptrs map[uintptr]bool, visited map[uintptr]bool) {
	if !v.IsValid() {
		return
	}

	switch v.Kind() {
	case reflect.Ptr:
		if !v.IsNil() {
			ptr := v.Pointer()
			if visited[ptr] {
				return
			}
			visited[ptr] = true
			ptrs[ptr] = true
			collectPointersRecursive(v.Elem(), ptrs, visited)
		}
	case reflect.Interface:
		if !v.IsNil() {
			collectPointersRecursive(v.Elem(), ptrs, visited)
		}
	case reflect.Struct:
		for i := 0; i < v.NumField(); i++ {
			collectPointersRecursive(v.Field(i), ptrs, visited)
		}
	case reflect.Slice, reflect.Array:
		for i := 0; i < v.Len(); i++ {
			collectPointersRecursive(v.Index(i), ptrs, visited)
		}
		if v.Kind() == reflect.Slice && !v.IsNil() && v.CanAddr() {
			ptrs[(*reflect.SliceHeader)(unsafe.Pointer(v.UnsafeAddr())).Data] = true
		}
	case reflect.Map:
		if !v.IsNil() {
			for _, key := range v.MapKeys() {
				collectPointersRecursive(key, ptrs, visited)
				collectPointersRecursive(v.MapIndex(key), ptrs, visited)
			}
		}
	}
}

```

</details>

### Type

<!--
    Please check the one(s) that applies to this pull request using "x".
-->

- [ ] `fix`: Bug Fix
- [ ] `feat`: Feature or Enhancement
- [ ] `docs`: Documentation
- [ ] `refactor`: Refactoring
- [X] `chore`: Build, Dependencies, Workflows, etc.
- [ ] `other`: Other (Please describe.)

### Breaking Changes?

<!--
    Please check the one that applies to this pull request using "x".
    If this pull request contains a breaking change, please describe the impact and mitigation path.
-->

- [ ] Yes, there are breaking changes.
- [X] No, there are no breaking changes.

### Tests

<!--
    Please check the one(s) that applies to this pull request using "x".
    For bug fixes and enhancements/features, please ensure that tests and documentation have been completed and provide details.
-->

- [ ] Tests have been added or updated.
- [X] Tests have been completed.

Output:

Ran acceptance tests against vCenter 9

[gotest.log](https://github.com/user-attachments/files/28542120/gotest.log)

### Documentation

<!--
    Please check the one(s) that applies to this pull request using "x".
    For enhancements/features, please ensure that documentation has been updated.
-->

- [ ] Documentation has been added or updated.

### Issue References

<!--
    Is this related to any GitHub issue(s)? If so, please provide the issue number(s) that are closed or resolved by this pull request.

    For bug fixes and enhancements/features, please ensure that a GitHub issue has been created and provide the issue number(s) here.

    Please use the 'Closes', 'Resolves', or 'Fixes' keywords followed by the a hash and issue number.
    This will link the pull request to the issue(s) and automatically close them when the pull request is merged.

    Example:

    Closes #000
    Resolves #001
    Fixes #002
-->

### Release Note

<!--
    Please provide context for the release notes.

    For example:

    ```
    - `r/foo` - Added support for foo. (#xxx)
    ```
-->

### Additional Information

<!--
    Please provide any additional information that may be helpful.
-->
