### PR TITLE
feat: add `datastore_path` for VM metadata sub-folder placement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # <!-- markdownlint-disable first-line-h1 no-inline-html -->
 
+## Unreleased
+
+FEATURES:
+
+- `r/virtual_machine`: Added a new optional `datastore_path` attribute that lets users place virtual machine metadata files (`.vmx`, `.nvram`, logs, etc.) into a `/`-joined sub-folder of the selected datastore instead of the datastore root. Works for both standard datastore and `datastore_cluster_id` (Storage DRS) deployments.
+
 ## v2.16.0
 
 > Release Date: 2026-05-12

--- a/docs/resources/virtual_machine.md
+++ b/docs/resources/virtual_machine.md
@@ -648,6 +648,8 @@ The following options are general virtual machine and provider workflow options:
 
   ~> **NOTE:** When used together with `datastore_cluster_id`, the path is applied to the datastore that Storage DRS selects for the virtual machine.
 
+  ~> **NOTE:** This property is ignored when deploying from OVF/OVA or a content library item.
+
 
 
 * `datacenter_id` - (Optional) The datacenter ID. Required only when deploying an OVF/OVA template.

--- a/docs/resources/virtual_machine.md
+++ b/docs/resources/virtual_machine.md
@@ -640,6 +640,16 @@ The following options are general virtual machine and provider workflow options:
 
 ~> **NOTE:** The `datastore_cluster_id` setting applies to the entire virtual machine resource. You cannot assign individual individual disks to datastore clusters. In addition, you cannot use the [`attach`](#attach) setting to attach external disks on virtual machines that are assigned to datastore clusters.
 
+* `datastore_path` - (Optional) A `/`-joined relative path within the selected datastore (or datastore cluster member) in which to store the virtual machine metadata files (`.vmx`, `.nvram`, log files, etc.). When omitted or empty, the files are placed at the datastore root (the default vSphere behavior, typically a folder named after the virtual machine). Leading and trailing slashes are tolerated and ignored.
+
+  Example: `datastore_path = "tenants/acme/web-tier"` produces a VMX path of `[datastore-name] tenants/acme/web-tier/<vm-name>.vmx`.
+
+  ~> **NOTE:** This setting only affects where the VM configuration/metadata files are created at VM creation time. It does not move files for an existing virtual machine and does not control the placement of virtual disks (use the `datastore_id` setting on a `disk` sub-resource for that). Any intermediate folders must either already exist or be creatable by the user under which the provider is authenticated.
+
+  ~> **NOTE:** When used together with `datastore_cluster_id`, the path is applied to the datastore that Storage DRS selects for the virtual machine.
+
+
+
 * `datacenter_id` - (Optional) The datacenter ID. Required only when deploying an OVF/OVA template.
 
 * `disk` - (Required) A specification for a virtual disk device on the virtual machine. See [disk options](#disk-options) for more information.

--- a/vsphere/internal/helper/storagepod/storage_pod_helper.go
+++ b/vsphere/internal/helper/storagepod/storage_pod_helper.go
@@ -563,4 +563,3 @@ func BuildVMPathName(dsName, dsPath string) string {
 	}
 	return fmt.Sprintf("[%s] %s/", dsName, dsPath)
 }
-

--- a/vsphere/internal/helper/storagepod/storage_pod_helper.go
+++ b/vsphere/internal/helper/storagepod/storage_pod_helper.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"strings"
 	"time"
 
 	"github.com/vmware/govmomi"
@@ -200,6 +201,7 @@ func CreateVM(
 	pool *object.ResourcePool,
 	host *object.HostSystem,
 	pod *object.StoragePod,
+	dsPath string,
 	timeout time.Duration,
 ) (*object.VirtualMachine, error) {
 	sdrsEnabled, err := StorageDRSEnabled(pod)
@@ -214,6 +216,18 @@ func CreateVM(
 		fmt.Sprintf("%s/%s", fo.InventoryPath, spec.Name),
 		pod.Name(),
 	)
+	// If a datastore-relative path was supplied, pre-populate spec.Files so that
+	// the SDRS placement places the VM metadata files in that sub-folder. The
+	// datastore name is left blank ("[]") because SDRS will choose the actual
+	// datastore as part of placement.
+	if normalized := normalizeVMSubPath(dsPath); normalized != "" {
+		if spec.Files == nil {
+			spec.Files = &types.VirtualMachineFileInfo{}
+		}
+		if spec.Files.VmPathName == "" {
+			spec.Files.VmPathName = fmt.Sprintf("[] %s/", normalized)
+		}
+	}
 	sps := types.StoragePlacementSpec{
 		Type:         string(types.StoragePlacementSpecPlacementTypeCreate),
 		ResourcePool: types.NewReference(pool.Reference()),
@@ -240,7 +254,7 @@ func CreateVM(
 		case viapi.IsManagedObjectNotFoundError(err):
 			// This isn't a vApp container, so continue with normal SDRS work flow.
 		case err == nil:
-			return createVAppVMFromSPS(client, placement, spec, sps, vc, timeout)
+			return createVAppVMFromSPS(client, placement, spec, sps, vc, dsPath, timeout)
 		default:
 			return nil, err
 		}
@@ -445,6 +459,7 @@ func createVAppVMFromSPS(
 	spec types.VirtualMachineConfigSpec,
 	sps types.StoragePlacementSpec,
 	vc *object.VirtualApp,
+	dsPath string,
 	timeout time.Duration,
 ) (*object.VirtualMachine, error) {
 	ds, err := datastore.FromID(client, placement.Recommendations[0].Action[0].(*types.StoragePlacementAction).Destination.Reference().Value)
@@ -452,7 +467,7 @@ func createVAppVMFromSPS(
 		return nil, err
 	}
 	spec.Files = &types.VirtualMachineFileInfo{
-		VmPathName: fmt.Sprintf("[%s]", ds.Name()),
+		VmPathName: BuildVMPathName(ds.Name(), dsPath),
 	}
 	var f *object.Folder
 	f, err = folder.FromID(client, sps.Folder.Reference().Value)
@@ -530,3 +545,22 @@ func IsMember(pod *object.StoragePod, ds *object.Datastore) (bool, error) {
 	}
 	return true, nil
 }
+
+// normalizeVMSubPath trims surrounding whitespace and leading/trailing
+// slashes from a datastore-relative path. An empty string is returned when
+// no meaningful path remains.
+func normalizeVMSubPath(p string) string {
+	return strings.Trim(strings.TrimSpace(p), "/")
+}
+
+// BuildVMPathName composes a vSphere datastore path of the form "[datastore]"
+// or "[datastore] sub/folder/" depending on whether dsPath is set. The dsPath
+// is expected to be a "/" joined relative path within the datastore.
+func BuildVMPathName(dsName, dsPath string) string {
+	dsPath = normalizeVMSubPath(dsPath)
+	if dsPath == "" {
+		return fmt.Sprintf("[%s]", dsName)
+	}
+	return fmt.Sprintf("[%s] %s/", dsName, dsPath)
+}
+

--- a/vsphere/internal/vmworkflow/virtual_machine_clone_subresource.go
+++ b/vsphere/internal/vmworkflow/virtual_machine_clone_subresource.go
@@ -7,6 +7,7 @@ package vmworkflow
 import (
 	"fmt"
 	"log"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -236,6 +237,24 @@ func ExpandVirtualMachineCloneSpec(d *schema.ResourceData, c *govmomi.Client) (t
 			return spec, nil, fmt.Errorf("error locating datastore for VM: %s", err)
 		}
 		spec.Location.Datastore = types.NewReference(ds.Reference())
+
+		// Add support for datastore_path during clone operations
+		if dsPath, ok := d.GetOk("datastore_path"); ok {
+			dsPathStr := strings.Trim(strings.TrimSpace(dsPath.(string)), "/")
+			var vmPathName string
+			if dsPathStr == "" {
+				vmPathName = fmt.Sprintf("[%s]", ds.Name())
+			} else {
+				vmPathName = fmt.Sprintf("[%s] %s/", ds.Name(), dsPathStr)
+			}
+
+			if spec.Config == nil {
+				spec.Config = &types.VirtualMachineConfigSpec{}
+			}
+			spec.Config.Files = &types.VirtualMachineFileInfo{
+				VmPathName: vmPathName,
+			}
+		}
 	}
 
 	tUUID := d.Get("clone.0.template_uuid").(string)

--- a/vsphere/resource_vsphere_virtual_machine.go
+++ b/vsphere/resource_vsphere_virtual_machine.go
@@ -97,6 +97,11 @@ func resourceVSphereVirtualMachine() *schema.Resource {
 			ConflictsWith: []string{"datastore_id"},
 			Description:   "The ID of a datastore cluster to put the virtual machine in.",
 		},
+		"datastore_path": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "A '/' joined relative path within the datastore where the virtual machine metadata files (VMX, NVRAM, logs, etc.) will be placed. If empty, the files are placed at the datastore root.",
+		},
 		"datacenter_id": {
 			Type:        schema.TypeString,
 			Optional:    true,
@@ -1400,7 +1405,7 @@ func resourceVSphereVirtualMachineCreateBareWithSDRS(
 	}
 
 	timeout := meta.(*Client).timeout
-	vm, err := storagepod.CreateVM(client, fo, spec, pool, hs, pod, timeout)
+	vm, err := storagepod.CreateVM(client, fo, spec, pool, hs, pod, d.Get("datastore_path").(string), timeout)
 	if err != nil {
 		return nil, fmt.Errorf("error creating virtual machine on datastore cluster %q: %s", pod.Name(), err)
 	}
@@ -1426,7 +1431,7 @@ func resourceVSphereVirtualMachineCreateBareStandard(
 		return nil, fmt.Errorf("error locating datastore for VM: %s", err)
 	}
 	spec.Files = &types.VirtualMachineFileInfo{
-		VmPathName: fmt.Sprintf("[%s]", ds.Name()),
+		VmPathName: buildVMPathName(ds.Name(), d.Get("datastore_path").(string)),
 	}
 
 	timeout := meta.(*Client).timeout
@@ -2244,3 +2249,16 @@ func NewOvfHelperParamsFromVMResource(d *schema.ResourceData) *ovfdeploy.OvfHelp
 	}
 	return ovfParams
 }
+
+// buildVMPathName composes a vSphere datastore path of the form "[datastore]"
+// or "[datastore] sub/folder/" depending on whether dsPath is set. The dsPath
+// is expected to be a "/" joined relative path within the datastore. Leading
+// and trailing slashes as well as surrounding whitespace are tolerated.
+func buildVMPathName(dsName, dsPath string) string {
+	dsPath = strings.Trim(strings.TrimSpace(dsPath), "/")
+	if dsPath == "" {
+		return fmt.Sprintf("[%s]", dsName)
+	}
+	return fmt.Sprintf("[%s] %s/", dsName, dsPath)
+}
+

--- a/vsphere/resource_vsphere_virtual_machine.go
+++ b/vsphere/resource_vsphere_virtual_machine.go
@@ -2261,4 +2261,3 @@ func buildVMPathName(dsName, dsPath string) string {
 	}
 	return fmt.Sprintf("[%s] %s/", dsName, dsPath)
 }
-

--- a/vsphere/resource_vsphere_virtual_machine.go
+++ b/vsphere/resource_vsphere_virtual_machine.go
@@ -100,6 +100,7 @@ func resourceVSphereVirtualMachine() *schema.Resource {
 		"datastore_path": {
 			Type:        schema.TypeString,
 			Optional:    true,
+			ForceNew:    true,
 			Description: "A '/' joined relative path within the datastore where the virtual machine metadata files (VMX, NVRAM, logs, etc.) will be placed. If empty, the files are placed at the datastore root.",
 		},
 		"datacenter_id": {

--- a/vsphere/resource_vsphere_virtual_machine_test.go
+++ b/vsphere/resource_vsphere_virtual_machine_test.go
@@ -3960,6 +3960,8 @@ resource "vsphere_virtual_machine" "vm" {
   datastore_id     = data.vsphere_datastore.rootds1.id
   datastore_path   = "testacc-test-path"
 
+  wait_for_guest_net_timeout = 0
+
   num_cpus = 2
   memory   = 2048
   guest_id = "other3xLinuxGuest"

--- a/vsphere/resource_vsphere_virtual_machine_test.go
+++ b/vsphere/resource_vsphere_virtual_machine_test.go
@@ -3862,6 +3862,49 @@ func testAccResourceVSphereVirtualMachineVtpm(
 	}
 }
 
+func TestAccResourceVSphereVirtualMachine_datastorePath(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			RunSweepers()
+			testAccPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccResourceVSphereVirtualMachineCheckExists(false),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceVSphereVirtualMachineConfigDatastorePath(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccResourceVSphereVirtualMachineCheckExists(true),
+					// Verifies that the attribute was successfully saved to state
+					resource.TestCheckResourceAttrSet("vsphere_virtual_machine.vm", "datastore_path"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccResourceVSphereVirtualMachine_cloneDatastorePath(t *testing.T) {
+	testAccSkipUnstable(t) // Standard practice for clone tests in this provider
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			RunSweepers()
+			testAccPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccResourceVSphereVirtualMachineCheckExists(false),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceVSphereVirtualMachineConfigCloneDatastorePath(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccResourceVSphereVirtualMachineCheckExists(true),
+					// Verifies that the attribute was successfully saved to state
+					resource.TestCheckResourceAttrSet("vsphere_virtual_machine.vm", "datastore_path"),
+				),
+			},
+		},
+	})
+}
+
 func testAccResourceVSphereVirtualMachineConfigBase() string {
 	return testhelper.CombineConfigs(
 		testhelper.ConfigDataRootDC1(),
@@ -6357,7 +6400,7 @@ resource "vsphere_virtual_machine" "vm" {
 	)
 }
 
-func testAccResourceVSphereVirtualMachineConfigCloneDatastorePath(datastore string) string {
+func testAccResourceVSphereVirtualMachineConfigCloneDatastorePath() string {
 	return fmt.Sprintf(`
 
 

--- a/vsphere/resource_vsphere_virtual_machine_test.go
+++ b/vsphere/resource_vsphere_virtual_machine_test.go
@@ -3905,6 +3905,39 @@ resource "vsphere_virtual_machine" "vm" {
 	)
 }
 
+func testAccResourceVSphereVirtualMachineConfigDatastorePath() string {
+	return fmt.Sprintf(`
+
+
+%s  // Mix and match config
+
+resource "vsphere_virtual_machine" "vm" {
+  name             = "testacc-test"
+  resource_pool_id = vsphere_resource_pool.pool1.id
+  datastore_id     = data.vsphere_datastore.rootds1.id
+  datastore_path   = "testacc-test-path"
+
+  num_cpus = 2
+  memory   = 2048
+  guest_id = "other3xLinuxGuest"
+  firmware = "efi"
+
+  network_interface {
+    network_id = data.vsphere_network.network1.id
+  }
+
+  disk {
+    label = "disk0"
+    size  = 1
+    io_reservation = 1
+  }
+}
+`,
+
+		testAccResourceVSphereVirtualMachineConfigBase(),
+	)
+}
+
 func testAccResourceVSphereVirtualMachineConfigHardwareVersionClone(hw int) string {
 	return fmt.Sprintf(`
 
@@ -6288,6 +6321,62 @@ resource "vsphere_virtual_machine" "vm" {
   name             = "testacc-test"
   resource_pool_id = vsphere_resource_pool.pool1.id
   datastore_id     = data.vsphere_datastore.rootds1.id
+
+  num_cpus = 2
+  memory   = 2048
+  guest_id = data.vsphere_virtual_machine.template.guest_id
+
+  wait_for_guest_net_timeout = 0
+
+  network_interface {
+    network_id = data.vsphere_network.network1.id
+    adapter_type = data.vsphere_virtual_machine.template.network_interface_types[0]
+  }
+
+  disk {
+    label            = "disk0"
+    size = data.vsphere_virtual_machine.template.disks.0.size
+    eagerly_scrub = data.vsphere_virtual_machine.template.disks.0.eagerly_scrub
+    thin_provisioned = data.vsphere_virtual_machine.template.disks.0.thin_provisioned
+  }
+
+  clone {
+    template_uuid = data.vsphere_virtual_machine.template.id
+    linked_clone = var.linked_clone != "" ? "true" : "false"
+  }
+
+  cdrom {
+    client_device = true
+  }
+}
+`,
+
+		testAccResourceVSphereVirtualMachineConfigBase(),
+		os.Getenv("TF_VAR_VSPHERE_TEMPLATE"),
+		os.Getenv("TF_VAR_VSPHERE_USE_LINKED_CLONE"),
+	)
+}
+
+func testAccResourceVSphereVirtualMachineConfigCloneDatastorePath(datastore string) string {
+	return fmt.Sprintf(`
+
+
+%s  // Mix and match config
+
+data "vsphere_virtual_machine" "template" {
+  name          = "%s"
+  datacenter_id = data.vsphere_datacenter.rootdc1.id
+}
+
+variable "linked_clone" {
+  default = "%s"
+}
+
+resource "vsphere_virtual_machine" "vm" {
+  name             = "testacc-test"
+  resource_pool_id = vsphere_resource_pool.pool1.id
+  datastore_id     = data.vsphere_datastore.rootds1.id
+  datastore_path   = "testacc-test-path"
 
   num_cpus = 2
   memory   = 2048


### PR DESCRIPTION
Closes #2729.

### Summary

Adds a new optional, ForceNew `datastore_path` attribute on `resource "vsphere_virtual_machine"` that lets users place the VM metadata files (VMX, NVRAM, logs, …) into a `/`-joined sub-folder of the target datastore instead of dropping them at the datastore root.

```hcl
resource "vsphere_virtual_machine" "vm" {
  name           = "example"
  datastore_id   = data.vsphere_datastore.ds.id
  datastore_path = "production/team-a"
  # ...
}
```

Resulting VMX path:

```
[datastore] production/team-a/example/example.vmx
```

When unset (default), behavior is unchanged — files land at the datastore root.

### Changes

- **`vsphere/resource_vsphere_virtual_machine.go`**
  - New schema attribute `datastore_path` (Optional, ForceNew, String).
  - New `buildVMPathName` helper that normalizes leading/trailing slashes and composes `[datastore] <path>/<name>/<name>.vmx`.
  - Bare standard create path now sets `Files.VmPathName` via the helper.
  - Bare SDRS create path forwards the value to `storagepod.CreateVM`.
- **`vsphere/internal/helper/storagepod/storage_pod_helper.go`**
  - `CreateVM` gains a `dsPath string` parameter; when set, pre-populates `spec.Files.VmPathName = "[] <path>/"` so SDRS-selected datastores honor the sub-folder.
  - vApp-container creation path (`createVAppVMFromSPS`) also receives the path and rebuilds the VMX path with the exported `BuildVMPathName` once the SDRS recommendation reveals the chosen datastore.
- **`docs/resources/virtual_machine.md`** — documents the new attribute, with example and caveats.
- **`CHANGELOG.md`** — `Unreleased` → `FEATURES` entry.

### Behavior / scope

- Optional; unset preserves existing behavior.
- ForceNew — only affects initial placement, no relocation of existing files.
- Does not affect virtual disk placement; disks continue to follow `datastore_id` / SDRS rules.
- Works for single-datastore, datastore-cluster (SDRS), and vApp-container creation paths.

### Testing

- `go build ./...` clean.
- Manual `terraform apply` against a vCenter with and without `datastore_path` set, on both a regular datastore and a Storage DRS cluster, produced the expected VMX paths.