### PR TITLE
fix: Do not reset `num_cores_per_socket` to 0 when no change is being made to the configuration

### DIFF
--- a/vsphere/virtual_machine_config_structure.go
+++ b/vsphere/virtual_machine_config_structure.go
@@ -1125,12 +1125,24 @@ func expandVirtualMachineConfigSpecChanged(d *schema.ResourceData, client *govmo
 	}
 
 	isVMConfigSpecChanged := !reflect.DeepEqual(oldSpec, newSpec)
-	// Don't include the hardware version in the UpdateSpec. It is only needed
-	// when creating new VMs.
-	newSpec.Version = ""
+	sanitizeConfigSpec(&newSpec, info)
 
 	// Return the new spec and compare
 	return newSpec, isVMConfigSpecChanged, nil
+}
+
+func sanitizeConfigSpec(spec *types.VirtualMachineConfigSpec, info *types.VirtualMachineConfigInfo) {
+	// Don't include the hardware version in the UpdateSpec. It is only needed
+	// when creating new VMs.
+	spec.Version = ""
+
+	// Don't set NumCoresPerSocket to 0 if auto assignment is already enabled because
+	// this would cause vCenter to require a VM reboot
+	cpuAutoAssignCurrent := info.Hardware.AutoCoresPerSocket != nil && *info.Hardware.AutoCoresPerSocket
+	cpuAutoAssignRequested := spec.NumCoresPerSocket != nil && *spec.NumCoresPerSocket == 0
+	if cpuAutoAssignCurrent && cpuAutoAssignRequested {
+		spec.NumCoresPerSocket = nil
+	}
 }
 
 // getMemoryReservationLockedToMax determines if the memory_reservation is not


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 no-inline-html -->

<!--
    NOTE: Do NOT enter content between the comment markers <!- and ->.

    In order to have the best experience with our community, we recommend that you read the code of
    conduct and contributing guidelines before submitting a pull request.

    By submitting this pull request, you confirm that you have read, understood, and agreed to the
    project's code of conduct and contributing guidelines.

    Please use conventional commits to format the title of the pull request and the commit messages.

    For more information, please refer to https://www.conventionalcommits.org and the contributing
    guidelines for this project.
-->

### Summary

<!--
    Please provide a clear and concise description of the pull request.
-->

If you create a VM and set `num_cores_per_socket` and then attempt to reconfigure the virtual machine by changing attributes which normally do not enforce a reboot you will encounter a server-side error that the configuration cannot be applied.
The cause for this is that a value for `num_cores_per_socket` is always sent to the server by the TF provider.
However, the actual CPU topology is controlled by 2 properties "under the hood". The number of cores per socket should be left unset on the configuration payload unless actual changes have to be made.

In the specific case described in https://github.com/vmware/terraform-provider-vsphere/issues/2731 `num_cores_per_socket` is explicitly set to 0 on VM creation. This means that the CPU topology is set to "auto assign at power on" mode. Simply renaming the virtual machine sends `num_cores_per_socket` as a 0 again which forces VPX to attempt a hardware reconfiguration. This operation requires a reboot and fails.

This bug does not occur when `NumCoresPerSocket` gets set to a positive integer while topology mode is already "auto".

To fix this I reset `NumCoresPerSocket` on the VM config spec to nil when it is being set to 0 while the VM is already configured with auto topology mode.

### Type

<!--
    Please check the one(s) that applies to this pull request using "x".
-->

- [X] `fix`: Bug Fix
- [ ] `feat`: Feature or Enhancement
- [ ] `docs`: Documentation
- [ ] `refactor`: Refactoring
- [ ] `chore`: Build, Dependencies, Workflows, etc.
- [ ] `other`: Other (Please describe.)

### Breaking Changes?

<!--
    Please check the one that applies to this pull request using "x".
    If this pull request contains a breaking change, please describe the impact and mitigation path.
-->

- [ ] Yes, there are breaking changes.
- [X] No, there are no breaking changes.

### Tests

<!--
    Please check the one(s) that applies to this pull request using "x".
    For bug fixes and enhancements/features, please ensure that tests and documentation have been completed and provide details.
-->

- [ ] Tests have been added or updated.
- [X] Tests have been completed.

Output:

[gotest.log](https://github.com/user-attachments/files/29006233/gotest.log)

<!--
    Please provide the output of the acceptance tests as applicable.
-->

Manual Testing Done:

| Previous State | New State | Effect |
| :--- | :--- | :--- |
| N/A (New VM) | 0 | CPU Topology set to auto |
| N/A (New VM) | 2 | CPU Topology set to manual, 2 cores per socket |
| N/A (New VM) | N/A (Not set) Default is 1 | CPU Topology set to manual, 1 core per socket |
| 0 | 0 | No reconfig, CPU Topology already set to auto |
| N/A (Not set) Default is 1  | 1 | No reconfig, CPU Topology already set to manual |
| 2 | 2 | No reconfig, CPU Topology already set to manual |
| 0 | 1 | Reconfig, CPU Topology set to manual |
| 1 | 0 | Reconfig, CPU Topology set to auto |
| 0 | Unset (deleted attribute) | Reconfig, CPU Topology set to manual (Default is 1) |
| 1 | Unset (deleted attribute) | No reconfig, CPU Topology set to manual (Default is 1) |

### Documentation

<!--
    Please check the one(s) that applies to this pull request using "x".
    For enhancements/features, please ensure that documentation has been updated.
-->

- [ ] Documentation has been added or updated.

### Issue References

<!--
    Is this related to any GitHub issue(s)? If so, please provide the issue number(s) that are closed or resolved by this pull request.

    For bug fixes and enhancements/features, please ensure that a GitHub issue has been created and provide the issue number(s) here.

    Please use the 'Closes', 'Resolves', or 'Fixes' keywords followed by the a hash and issue number.
    This will link the pull request to the issue(s) and automatically close them when the pull request is merged.

    Example:

    Closes #000
    Resolves #001
    Fixes #002
-->

Fixes #2731

### Release Note

<!--
    Please provide context for the release notes.

    For example:

    ```
    - `r/foo` - Added support for foo. (#xxx)
    ```
-->

### Additional Information

<!--
    Please provide any additional information that may be helpful.
-->
