### PR TITLE
chore: Ignore thumprint changes on esx4 during acceptance testing

### DIFF
--- a/vsphere/resource_vsphere_compute_cluster_test.go
+++ b/vsphere/resource_vsphere_compute_cluster_test.go
@@ -1169,7 +1169,7 @@ resource "vsphere_host" "host4" {
   datacenter = data.vsphere_datacenter.rootdc1.id
 
   lifecycle {
-    ignore_changes = ["services", "cluster"]
+    ignore_changes = ["services", "cluster", "thumbprint"]
   }
 }
 


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 no-inline-html -->

<!--
    NOTE: Do NOT enter content between the comment markers <!- and ->.

    In order to have the best experience with our community, we recommend that you read the code of
    conduct and contributing guidelines before submitting a pull request.

    By submitting this pull request, you confirm that you have read, understood, and agreed to the
    project's code of conduct and contributing guidelines.

    Please use conventional commits to format the title of the pull request and the commit messages.

    For more information, please refer to https://www.conventionalcommits.org and the contributing
    guidelines for this project.
-->

### Summary

<!--
    Please provide a clear and concise description of the pull request.
-->

This PR resolves an intermittent failure of `testAccResourceVSphereComputeClusterConfigFaultDomains` that only happens on its first run on a fresh testing environment.
This is not a problem with the test itself but rather an artifact of the vSAN configuration it relies on.

The test environment is comprised of 4 hosts, where 3 are always connected to vCenter and the 4th is used only for specific tests. This test in particular connects the 4th host to a cluster and enables vSAN fault domains.
This results in a one-time certificate rotation and causes a state drift.
Subsequent re-runs of the test perform fine and pass.

The simplest solution is to just ignore the thumbprint changes for this test case.

### Type

<!--
    Please check the one(s) that applies to this pull request using "x".
-->

- [ ] `fix`: Bug Fix
- [ ] `feat`: Feature or Enhancement
- [ ] `docs`: Documentation
- [ ] `refactor`: Refactoring
- [X] `chore`: Build, Dependencies, Workflows, etc.
- [ ] `other`: Other (Please describe.)

### Breaking Changes?

<!--
    Please check the one that applies to this pull request using "x".
    If this pull request contains a breaking change, please describe the impact and mitigation path.
-->

- [ ] Yes, there are breaking changes.
- [X] No, there are no breaking changes.

### Tests

<!--
    Please check the one(s) that applies to this pull request using "x".
    For bug fixes and enhancements/features, please ensure that tests and documentation have been completed and provide details.
-->

- [X] Tests have been added or updated.
- [X] Tests have been completed.

Output:

<!--
    Please provide the output of the acceptance tests as applicable.
-->

### Documentation

<!--
    Please check the one(s) that applies to this pull request using "x".
    For enhancements/features, please ensure that documentation has been updated.
-->

- [ ] Documentation has been added or updated.

### Issue References

<!--
    Is this related to any GitHub issue(s)? If so, please provide the issue number(s) that are closed or resolved by this pull request.

    For bug fixes and enhancements/features, please ensure that a GitHub issue has been created and provide the issue number(s) here.

    Please use the 'Closes', 'Resolves', or 'Fixes' keywords followed by the a hash and issue number.
    This will link the pull request to the issue(s) and automatically close them when the pull request is merged.

    Example:

    Closes #000
    Resolves #001
    Fixes #002
-->

### Release Note

<!--
    Please provide context for the release notes.

    For example:

    ```
    - `r/foo` - Added support for foo. (#xxx)
    ```
-->

### Additional Information

<!--
    Please provide any additional information that may be helpful.
-->
