### PR TITLE
feat: expose virtual machine folder in vsphere_virtual_machine data s…

### DIFF
--- a/docs/data-sources/virtual_machine.md
+++ b/docs/data-sources/virtual_machine.md
@@ -97,7 +97,7 @@ The following attributes are exported:
 * `id` - The UUID of the virtual machine or template.
 * `folder` - The inventory folder path of the virtual machine. This is the
   parent folder containing the virtual machine, relative to the vSphere
-  inventory. For example: `/DC1/vm/Production/Linux`.
+  inventory. For example, given a default datacenter of `default-dc`, a folder of type `vm` (denoting a virtual machine folder), and a supplied folder of `example-vm-folder`, the resulting path would be `/default-dc/vm/example-vm-folder`.
 * `guest_id` - The guest ID of the virtual machine or template.
 * `alternate_guest_name` - The alternate guest name of the virtual machine when
   `guest_id` is a non-specific operating system, like `otherGuest` or

--- a/docs/data-sources/virtual_machine.md
+++ b/docs/data-sources/virtual_machine.md
@@ -95,6 +95,9 @@ section.
 The following attributes are exported:
 
 * `id` - The UUID of the virtual machine or template.
+* `folder` - The inventory folder path of the virtual machine. This is the
+  parent folder containing the virtual machine, relative to the vSphere
+  inventory. For example: `/DC1/vm/Production/Linux`.
 * `guest_id` - The guest ID of the virtual machine or template.
 * `alternate_guest_name` - The alternate guest name of the virtual machine when
   `guest_id` is a non-specific operating system, like `otherGuest` or

--- a/vsphere/data_source_vsphere_virtual_machine.go
+++ b/vsphere/data_source_vsphere_virtual_machine.go
@@ -34,6 +34,7 @@ func dataSourceVSphereVirtualMachine() *schema.Resource {
 		"folder": {
 			Type:          schema.TypeString,
 			Optional:      true,
+			Computed:      true,
 			Description:   "The name of the folder the virtual machine is in. Allows distinguishing virtual machines with the same name in different folder paths",
 			StateFunc:     folder.NormalizePath,
 			ConflictsWith: []string{"uuid", "moid"},
@@ -309,6 +310,11 @@ func dataSourceVSphereVirtualMachineRead(d *schema.ResourceData, meta interface{
 	if err != nil {
 		return fmt.Errorf("error fetching virtual machine properties: %s", err)
 	}
+
+	// Expose the VM inventory folder path as a computed attribute.
+	// InventoryPath contains the full inventory object path including the VM name,
+	// so use path.Dir() to extract only the parent folder path.
+	_ = d.Set("folder", path.Dir(vm.InventoryPath))
 
 	if props.Config == nil {
 		return fmt.Errorf("no configuration returned for virtual machine %q", vm.InventoryPath)

--- a/vsphere/data_source_vsphere_virtual_machine_test.go
+++ b/vsphere/data_source_vsphere_virtual_machine_test.go
@@ -235,7 +235,8 @@ func TestAccDataSourceVSphereVirtualMachine_nameAndFolder(t *testing.T) {
 				resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.vm", "network_interfaces.0.bandwidth_share_count"),
 				resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.vm", "network_interfaces.0.mac_address"),
 				resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.vm", "network_interfaces.0.network_id"),
-				resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.vm", "instance_uuid")),
+				resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.vm", "instance_uuid"),
+				resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.vm", "folder")),
 		}},
 	})
 }


### PR DESCRIPTION
### Summary

Expose the virtual machine inventory folder path through the
`vsphere_virtual_machine` data source.

This change adds support for returning the VM parent folder as a computed
attribute (`folder`). The folder value is derived from the virtual machine
inventory path and allows consumers to retrieve the VM location within the
vSphere inventory directly from the data source output.

The documentation has also been updated to include the new exported
`folder` attribute in the Attribute Reference section.

### Type

- [ ] `fix`: Bug Fix
- [x] `feat`: Feature or Enhancement
- [x] `docs`: Documentation
- [ ] `refactor`: Refactoring
- [ ] `chore`: Build, Dependencies, Workflows, etc.
- [ ] `other`: Other (Please describe.)

### Breaking Changes?

- [ ] Yes, there are breaking changes.
- [x] No, there are no breaking changes.

### Tests

- [x] Tests have been added or updated.
- [x] Tests have been completed.

Output:

`terraform plan`

+ folder = "/DC1/vm/Production/Linux"


### Additional Information

Prior to this change, the `folder` argument was only used as an input to help
identify a virtual machine during lookup. The data source did not expose the
actual VM folder path in its output.

This enhancement preserves the existing behavior: the `folder` argument can
still be specified as an input when locating a virtual machine, while also
being exposed as a computed attribute containing the VM inventory folder path.

This enhancement preserves the existing lookup behavior while making the VM
inventory folder available as a computed attribute for downstream use in
Terraform configurations.
