### PR TITLE
fix: mark "services" on `r/vnic` as computed

### DIFF
--- a/vsphere/resource_vsphere_vnic.go
+++ b/vsphere/resource_vsphere_vnic.go
@@ -25,6 +25,8 @@ const (
 	vnicServiceTypeVsan       = "vsan"
 	vnicServiceTypeVmotion    = "vmotion"
 	vnicServiceTypeManagement = "management"
+
+	vnicNetStackDefault = "defaultTcpipStack"
 )
 
 var vnicServiceTypeAllowedValues = []string{
@@ -312,12 +314,13 @@ func BaseVMKernelSchema() map[string]*schema.Schema {
 			Type:        schema.TypeString,
 			Optional:    true,
 			Description: "TCP/IP stack setting for this interface. Possible values are 'defaultTcpipStack', 'vmotion', 'provisioning'",
-			Default:     "defaultTcpipStack",
+			Default:     vnicNetStackDefault,
 			ForceNew:    true,
 		},
 		"services": {
 			Type:        schema.TypeSet,
 			Optional:    true,
+			Computed:    true,
 			Description: "Enabled services setting for this interface. Current possible values are 'vmotion', 'management' and 'vsan'",
 			Elem: &schema.Schema{
 				Type:         schema.TypeString,
@@ -395,7 +398,7 @@ func updateVnicService(d *schema.ResourceData, hostID string, nicID string, meta
 }
 
 func precheckEnableServices(d *schema.ResourceData) error {
-	if d.Get("netstack").(string) != "defaultTcpipStack" && len(d.Get("services").(*schema.Set).List()) != 0 {
+	if d.Get("netstack").(string) != vnicNetStackDefault && len(d.Get("services").(*schema.Set).List()) != 0 {
 		return fmt.Errorf("services can only be configured when netstack is set to defaultTcpipStack")
 	}
 	return nil

--- a/vsphere/resource_vsphere_vnic_test.go
+++ b/vsphere/resource_vsphere_vnic_test.go
@@ -47,6 +47,51 @@ func generateSteps(cfgFunc genTfConfig, netstack string) []resource.TestStep {
 	return out
 }
 
+func TestAccResourceVSphereVNic_netstackVmotion(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccVSphereVNicDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVSphereVNicConfigNetstack("vmotion"),
+			},
+		},
+	})
+}
+
+func TestAccResourceVSphereVNic_netstackProvisioning(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccVSphereVNicDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVSphereVNicConfigNetstack("vSphereProvisioning"),
+			},
+		},
+	})
+}
+
+func TestAccResourceVSphereVNic_netstackDefault(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccVSphereVNicDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVSphereVNicConfigServices([]string{"management", "vsan"}),
+			},
+		},
+	})
+}
+
 func TestAccResourceVSphereVNic_dvs_default(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
@@ -382,6 +427,62 @@ func nicExists(client *govmomi.Client, nicID string) (bool, error) {
 	}
 
 	return true, nil
+}
+
+func testAccVSphereVNicConfigNetstack(netstack string) string {
+	return fmt.Sprintf(`
+%s
+
+	resource "vsphere_host_port_group" "p1" {
+	  name                     = "acc-test-pg"
+	  virtual_switch_name      = "vSwitch0"
+	  host_system_id           = data.vsphere_host.roothost3.id
+	}
+
+	resource "vsphere_vnic" "vmotion_vnic" {
+	  host      = data.vsphere_host.roothost3.id
+	  portgroup = vsphere_host_port_group.p1.name
+
+  	  ipv4 {
+        dhcp = true
+  	  }
+
+  	  netstack = %q
+	}
+	`, testhelper.CombineConfigs(
+		testhelper.ConfigDataRootDC1(),
+		testhelper.ConfigDataRootPortGroup1(),
+		testhelper.ConfigDataRootHost3()),
+		netstack)
+}
+
+func testAccVSphereVNicConfigServices(services []string) string {
+	servicesStr := strings.Join(services, "\", \"")
+	return fmt.Sprintf(`
+%s
+
+	resource "vsphere_host_port_group" "p1" {
+	  name                     = "acc-test-pg"
+	  virtual_switch_name      = "vSwitch0"
+	  host_system_id           = data.vsphere_host.roothost3.id
+	}
+
+	resource "vsphere_vnic" "vmotion_vnic" {
+	  host      = data.vsphere_host.roothost3.id
+	  portgroup = vsphere_host_port_group.p1.name
+
+	  ipv4 {
+        dhcp = true
+	  }
+
+	  netstack = "defaultTcpipStack"
+	  services = ["%s"]
+	}
+	`, testhelper.CombineConfigs(
+		testhelper.ConfigDataRootDC1(),
+		testhelper.ConfigDataRootPortGroup1(),
+		testhelper.ConfigDataRootHost3()),
+		servicesStr)
 }
 
 func testaccvspherevnicconfigHvs(netConfig string) string {


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 no-inline-html -->

<!--
    NOTE: Do NOT enter content between the comment markers <!- and ->.

    In order to have the best experience with our community, we recommend that you read the code of
    conduct and contributing guidelines before submitting a pull request.

    By submitting this pull request, you confirm that you have read, understood, and agreed to the
    project's code of conduct and contributing guidelines.

    Please use conventional commits to format the title of the pull request and the commit messages.

    For more information, please refer to https://www.conventionalcommits.org and the contributing
    guidelines for this project.
-->

### Summary

<!--
    Please provide a clear and concise description of the pull request.
-->

The `services` attribute on `r/vnic` is only allowed and applicable when using the default TCP/IP stack.
All other stacks, including the ones not yet supported by the provider, serve as presets and enable a specific service while simultaneously disallowing further server configration.

The problem with this design is that the read handler for `r/vnic` sets the `services` attribute regardless of the stack. This results in unwanted detection of non existent changes to the resource state.

To solve this I am marking `services` as both optional and computed effectively allowing Terraform to set a value to this attribute without triggering unwanted change detection.

### Type

<!--
    Please check the one(s) that applies to this pull request using "x".
-->

- [X] `fix`: Bug Fix
- [ ] `feat`: Feature or Enhancement
- [ ] `docs`: Documentation
- [ ] `refactor`: Refactoring
- [ ] `chore`: Build, Dependencies, Workflows, etc.
- [ ] `other`: Other (Please describe.)

### Breaking Changes?

<!--
    Please check the one that applies to this pull request using "x".
    If this pull request contains a breaking change, please describe the impact and mitigation path.
-->

- [ ] Yes, there are breaking changes.
- [X] No, there are no breaking changes.

### Tests

<!--
    Please check the one(s) that applies to this pull request using "x".
    For bug fixes and enhancements/features, please ensure that tests and documentation have been completed and provide details.
-->

- [X] Tests have been added or updated.
- [X] Tests have been completed.

Output:

<!--
    Please provide the output of the acceptance tests as applicable.
-->

[gotest.log](https://github.com/user-attachments/files/29885487/gotest.log)


### Documentation

<!--
    Please check the one(s) that applies to this pull request using "x".
    For enhancements/features, please ensure that documentation has been updated.
-->

- [ ] Documentation has been added or updated.

### Issue References

<!--
    Is this related to any GitHub issue(s)? If so, please provide the issue number(s) that are closed or resolved by this pull request.

    For bug fixes and enhancements/features, please ensure that a GitHub issue has been created and provide the issue number(s) here.

    Please use the 'Closes', 'Resolves', or 'Fixes' keywords followed by the a hash and issue number.
    This will link the pull request to the issue(s) and automatically close them when the pull request is merged.

    Example:

    Closes #000
    Resolves #001
    Fixes #002
-->

Fixes #2044

### Release Note

<!--
    Please provide context for the release notes.

    For example:

    ```
    - `r/foo` - Added support for foo. (#xxx)
    ```
-->

### Additional Information

<!--
    Please provide any additional information that may be helpful.
-->
