### PR TITLE
docs: fix stale import documentation link

### DIFF
--- a/docs/resources/datacenter.md
+++ b/docs/resources/datacenter.md
@@ -66,7 +66,7 @@ and require vCenter.
 An existing datacenter can be [imported][docs-import] into this resource
 via supplying the full path to the datacenter. An example is below:
 
-[docs-import]: /docs/import/index.html
+[docs-import]: https://developer.hashicorp.com/terraform/cli/import
 
 ```shell
 terraform import vsphere_datacenter.dc /dc1

--- a/docs/resources/host.md
+++ b/docs/resources/host.md
@@ -133,7 +133,7 @@ connections and require vCenter Server.
 An existing host can be [imported][docs-import] into this resource by supplying
 the host's ID.
 
-[docs-import]: /docs/import/index.html
+[docs-import]: https://developer.hashicorp.com/terraform/cli/import
 
 Obtain the host's ID using the data source. For example:
 

--- a/docs/resources/host_port_group.md
+++ b/docs/resources/host_port_group.md
@@ -138,7 +138,7 @@ The following attributes are exported:
 An existing host port group can be [imported][docs-import] into this resource
 using the host port group's ID. An example is below:
 
-[docs-import]: /docs/import/index.html
+[docs-import]: https://developer.hashicorp.com/terraform/cli/import
 
 ```shell
 terraform import vsphere_host_port_group.management tf-HostPortGroup:host-123:management

--- a/docs/resources/virtual_machine.md
+++ b/docs/resources/virtual_machine.md
@@ -1793,7 +1793,7 @@ The following attributes are exported on the base level of this resource:
 
 An existing virtual machine can be [imported][docs-import] into the Terraform state by providing the full path to the virtual machine.
 
-[docs-import]: /docs/import/index.html
+[docs-import]: https://developer.hashicorp.com/terraform/cli/import
 
 **Examples**:
 

--- a/docs/resources/vnic.md
+++ b/docs/resources/vnic.md
@@ -125,7 +125,7 @@ Configures the IPv6 settings of the network interface. Either DHCP or Autoconfig
 An existing vNic can be [imported][docs-import] into this resource
 via supplying the vNic's ID. An example is below:
 
-[docs-import]: /docs/import/index.html
+[docs-import]: https://developer.hashicorp.com/terraform/cli/import
 
 ```shell
 terraform import vsphere_vnic.vnic host-123_vmk2


### PR DESCRIPTION
##### Motivation
Fixes #2759. The `[imported]` link in the `vsphere_virtual_machine` resource docs pointed at `/docs/import/index.html`, a relative path from the old terraform.io docs site that no longer resolves correctly.

While fixing it I found the same stale link in four other resource docs (`vnic`, `host_port_group`, `host`, `datacenter`) that hadn't been updated when the rest of the docs moved to `https://developer.hashicorp.com/terraform/cli/import` -- fixed those too so the whole repo is consistent.

Documentation-only change, no code touched.